### PR TITLE
helpers: fix for_each_cpu to use new attributes

### DIFF
--- a/drgn/helpers/linux/cpumask.py
+++ b/drgn/helpers/linux/cpumask.py
@@ -26,8 +26,8 @@ def for_each_cpu(mask):
     :rtype: Iterator[int]
     """
     bits = mask.bits
-    word_bits = 8 * bits.type_.type.sizeof()
-    for i in range(bits.type_.size):
+    word_bits = 8 * bits.type_.type.size
+    for i in range(bits.type_.length):
         word = bits[i].value_()
         for j in range(word_bits):
             if word & (1 << j):


### PR DESCRIPTION
for_each_cpu is using old attributes "sizeof" and "size". Fix them to
use new ones.

Before patch:
>>> for x in for_each_online_cpu(prog): print(x)
...
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/naota/drgn/drgn/helpers/linux/cpumask.py", line 29, in for_each_cpu
    word_bits = 8 * bits.type_.type.sizeof()
AttributeError: '_drgn.Type' object has no attribute 'sizeof'

After patch:
>>> for x in for_each_online_cpu(prog): print(x)
...
0
1
2
3
4
5
6
7