### PR TITLE
cli: Assume --kernel if no target is specified

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -206,30 +206,19 @@ along with any arguments:
     pid = int(sys.argv[1])
     uid = find_task(prog, pid).cred.uid.val.value_()
     print(f'PID {pid} is being run by UID {uid}')
-    $ sudo drgn -k script.py 601
+    $ sudo drgn script.py 601
     PID 601 is being run by UID 1000
 
 It's even possible to run drgn scripts directly with the proper `shebang
 <https://en.wikipedia.org/wiki/Shebang_(Unix)>`_::
 
     $ cat script2.py
-    #!/usr/bin/drgn -k
+    #!/usr/bin/env drgn
 
     mounts = prog['init_task'].nsproxy.mnt_ns.mounts.value_()
     print(f'You have {mounts} filesystems mounted')
     $ sudo ./script2.py
     You have 36 filesystems mounted
-
-You usually shouldn't depend on an executable being installed at a specific
-absolute path. With newer versions of GNU coreutils (since v8.30), you can
-use |env -S|_:
-
-.. |env -S| replace:: ``env --split-string``
-.. _env -S: https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html#g_t_002dS_002f_002d_002dsplit_002dstring-usage-in-scripts
-
-.. code-block:: sh
-
-    #!/usr/bin/env -S drgn -k
 
 Interactive Mode
 ^^^^^^^^^^^^^^^^
@@ -268,7 +257,7 @@ In interactive mode, the drgn CLI automatically uses ``str()`` instead of
 ``repr()`` for objects and types, so you don't need to call ``print()``
 explicitly::
 
-    $ sudo drgn -k
+    $ sudo drgn
     >>> prog['jiffies']
     (volatile unsigned long)4395387628
     >>> prog.type('atomic_t')

--- a/drgn/internal/cli.py
+++ b/drgn/internal/cli.py
@@ -49,8 +49,8 @@ def main() -> None:
 
     program_group = parser.add_argument_group(
         title='program selection',
-        description='one of the following is required',
-    ).add_mutually_exclusive_group(required=True)
+        description='if unspecified --kernel is assumed',
+    ).add_mutually_exclusive_group()
     program_group.add_argument(
         '-c', '--core', metavar='PATH', type=str,
         help='debug the given core dump')
@@ -81,10 +81,10 @@ def main() -> None:
     prog = drgn.Program()
     if args.core is not None:
         prog.set_core_dump(args.core)
-    elif args.kernel:
-        prog.set_kernel()
-    else:
+    elif args.pid is not None:
         prog.set_pid(args.pid or os.getpid())
+    else:
+        prog.set_kernel()
     if args.default_symbols:
         try:
             prog.load_default_debug_info()


### PR DESCRIPTION
cli currently requires one of --kernel, --core or --pid to be
specified.  Let's assume --kernel so that we can get away with older
env(1) which doesn't understand -S option when writing debug scripts
which uses drgn as the interpreter.  While this is a bit of a kludge,
other options aren't useful on the shebang lines anyway given that
they need an extra dynamic argument.