### PR TITLE
Added path_lookup function

### DIFF
--- a/drgn/helpers/linux/fs.py
+++ b/drgn/helpers/linux/fs.py
@@ -256,7 +256,7 @@ def path_lookup(prog_or_ns, path):
     """
     fd = os.open(path,os.O_PATH)
     pid = os.getpid()
-    struct_path = fget(find_task(prog_or_ns, pid),fd).f_path
+    struct_path = fget(find_task(prog_or_ns, pid),fd).f_path.read_()
     os.close(fd)
     return struct_path
 


### PR DESCRIPTION
The function returns a struct path object of a given path name.
I was wondering whether to call it kern_path, the name is debatable.

For example, d_path(path_lookup(prog, '/etc/shadow') == '/etc/shadow' :)