### PR TITLE
libdrgn: read kdumps (new dependecy: libkdumpfile)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Install the following dependencies:
 * Python 3.6 or newer
 * elfutils development libraries (libelf and libdw)
 * GNU autotools (autoconf, automake, and libtool) and pkgconf
+* `libkdumpfile <https://github.com/ptesarik/libkdumpfile>`_
 
 Then, run:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,8 @@
 Installation
 ============
 
+XXX: Something about libkdumpfile
+
 .. highlight:: console
 
 drgn depends on `Python <https://www.python.org/>`_ 3.6 or newer as well as

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -52,9 +52,14 @@ libdrgnimpl_la_SOURCES = binary_search_tree.h \
 			 vector.h
 
 libdrgnimpl_la_CFLAGS = -fvisibility=hidden -fopenmp $(libelf_CFLAGS) \
-			$(libdw_CFLAGS) $(libkdumpfile_CFLAGS)
+			$(libdw_CFLAGS)
 libdrgnimpl_la_CPPFLAGS = -D_GNU_SOURCE
-libdrgnimpl_la_LIBADD = $(libelf_LIBS) $(libdw_LIBS) $(libkdumpfile_LIBS)
+libdrgnimpl_la_LIBADD = $(libelf_LIBS) $(libdw_LIBS)
+
+if WITH_LIBKDUMPFILE
+libdrgnimpl_la_CFLAGS += $(libkdumpfile_CFLAGS)
+libdrgnimpl_la_LIBADD += $(libkdumpfile_LIBS)
+endif
 
 lib_LTLIBRARIES = libdrgn.la
 

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -18,7 +18,6 @@ libdrgnimpl_la_SOURCES = binary_search_tree.h \
 			 hash_table.h \
 			 internal.c \
 			 internal.h \
-			 kdump_reader.c \
 			 kdump_reader.h \
 			 language.h \
 			 language_c.c \
@@ -57,6 +56,7 @@ libdrgnimpl_la_CPPFLAGS = -D_GNU_SOURCE
 libdrgnimpl_la_LIBADD = $(libelf_LIBS) $(libdw_LIBS)
 
 if WITH_LIBKDUMPFILE
+libdrgnimpl_la_SOURCES += kdump_reader.c
 libdrgnimpl_la_CFLAGS += $(libkdumpfile_CFLAGS)
 libdrgnimpl_la_LIBADD += $(libkdumpfile_LIBS)
 endif

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -18,6 +18,8 @@ libdrgnimpl_la_SOURCES = binary_search_tree.h \
 			 hash_table.h \
 			 internal.c \
 			 internal.h \
+			 kdump_reader.c \
+			 kdump_reader.h \
 			 language.h \
 			 language_c.c \
 			 lexer.c \
@@ -50,9 +52,9 @@ libdrgnimpl_la_SOURCES = binary_search_tree.h \
 			 vector.h
 
 libdrgnimpl_la_CFLAGS = -fvisibility=hidden -fopenmp $(libelf_CFLAGS) \
-			$(libdw_CFLAGS)
+			$(libdw_CFLAGS) $(libkdumpfile_CFLAGS)
 libdrgnimpl_la_CPPFLAGS = -D_GNU_SOURCE
-libdrgnimpl_la_LIBADD = $(libelf_LIBS) $(libdw_LIBS)
+libdrgnimpl_la_LIBADD = $(libelf_LIBS) $(libdw_LIBS) $(libkdumpfile_LIBS)
 
 lib_LTLIBRARIES = libdrgn.la
 

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -48,6 +48,22 @@ python3-devel or python3-dev) or specify the location of the Python development
 headers by setting the PYTHON_CPPFLAGS environment variable.])])
 	    CPPFLAGS="$save_CPPFLAGS"])
 
+AC_ARG_WITH([libkdumpfile],
+	    [AS_HELP_STRING([--with-libkdumpfile@<:@=ARG@:>@],
+			    [leverage libkdumpfile to read crash dumps using
+			     the makedumpfile format. ARG may be yes or no
+			     @<:default=no:>@])],
+           [], [with_libkdumpfile=no])
+AS_IF([test "x$with_libkdumpfile" != xno],
+      [
+       PKG_CHECK_MODULES(libkdumpfile, [libkdumpfile])
+       AM_CONDITIONAL([WITH_LIBKDUMPFILE], true)
+       AC_DEFINE(LIBKDUMPFILE, true)
+      ],
+      [
+       AM_CONDITIONAL([WITH_LIBKDUMPFILE], false)
+      ])
+
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(libelf, [libelf])
 AC_SUBST([libelf_CFLAGS])
@@ -56,9 +72,6 @@ dnl We need dwarf_cu_getdwarf() which was added in elfutils 0.160.
 PKG_CHECK_MODULES(libdw, [libdw >= 0.160])
 AC_SUBST([libdw_CFLAGS])
 AC_SUBST([libdw_LIBS])
-PKG_CHECK_MODULES(libkdumpfile, [libkdumpfile])
-AC_SUBST([libkdumpfile_CFLAGS])
-AC_SUBST([libkdumpfile_LIBS])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -56,6 +56,9 @@ dnl We need dwarf_cu_getdwarf() which was added in elfutils 0.160.
 PKG_CHECK_MODULES(libdw, [libdw >= 0.160])
 AC_SUBST([libdw_CFLAGS])
 AC_SUBST([libdw_LIBS])
+PKG_CHECK_MODULES(libkdumpfile, [libkdumpfile])
+AC_SUBST([libkdumpfile_CFLAGS])
+AC_SUBST([libkdumpfile_LIBS])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -49,20 +49,18 @@ headers by setting the PYTHON_CPPFLAGS environment variable.])])
 	    CPPFLAGS="$save_CPPFLAGS"])
 
 AC_ARG_WITH([libkdumpfile],
-	    [AS_HELP_STRING([--with-libkdumpfile@<:@=ARG@:>@],
-			    [leverage libkdumpfile to read crash dumps using
-			     the makedumpfile format. ARG may be yes or no
-			     @<:default=no:>@])],
-           [], [with_libkdumpfile=no])
-AS_IF([test "x$with_libkdumpfile" != xno],
-      [
-       PKG_CHECK_MODULES(libkdumpfile, [libkdumpfile])
-       AM_CONDITIONAL([WITH_LIBKDUMPFILE], true)
-       AC_DEFINE(LIBKDUMPFILE, true)
-      ],
-      [
-       AM_CONDITIONAL([WITH_LIBKDUMPFILE], false)
-      ])
+	    [AS_HELP_STRING([--with-libkdumpfile],
+			    [build with support for the makedumpfile kernel
+			     core dump format using libkdumpfile
+			     @<:@default=auto@:>@])],
+			     [], [with_libkdumpfile=auto])
+AS_CASE(["x$with_libkdumpfile"],
+	[xyes], [PKG_CHECK_MODULES(libkdumpfile, [libkdumpfile])],
+	[xauto], [PKG_CHECK_MODULES(libkdumpfile, [libkdumpfile],
+				    [with_libkdumpfile=yes],
+				    [with_libkdumpfile=no])])
+AM_CONDITIONAL([WITH_LIBKDUMPFILE], [test "x$with_libkdumpfile" != xno])
+AM_COND_IF([WITH_LIBKDUMPFILE], [AC_DEFINE(WITH_LIBKDUMPFILE)])
 
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(libelf, [libelf])

--- a/libdrgn/kdump_reader.c
+++ b/libdrgn/kdump_reader.c
@@ -1,0 +1,286 @@
+// Copyright 2019 - Serapheim Dimitropoulos
+// SPDX-License-Identifier: GPL-3.0+
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "kdump_reader.h"
+#include "program.h"
+
+bool has_kdump_signature(int fd, struct drgn_error **err)
+{
+	char signature[SIG_LEN];
+
+	int n = read(fd, signature, sizeof (signature));
+	if (n != sizeof (signature)) {
+		*err = drgn_error_format(DRGN_ERROR_FAULT,
+		                         "short read from file");
+		return false;
+	}
+
+	int cmp = memcmp(signature, KDUMP_SIGNATURE, sizeof (signature));
+	if (cmp)
+		return false;
+
+	return true;
+}
+
+struct drgn_error *drgn_kdump_init(kdump_ctx_t **ctx, int fd)
+{
+	kdump_ctx_t *context = kdump_new();
+	if (!ctx) {
+		close(fd);
+		return drgn_error_create(DRGN_ERROR_OTHER,
+		                         "kdump_new() failed\n");
+	}
+
+	kdump_status ks = kdump_set_number_attr(context,
+	                                        KDUMP_ATTR_FILE_FD, fd);
+	if (ks != KDUMP_OK) {
+		kdump_free(context);
+		close(fd);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "setting kdump fd attribute: %s\n",
+					 kdump_get_err(context));
+	}
+
+	kdump_attr_t attr;
+	attr.type = KDUMP_STRING;
+	attr.val.string = "linux";
+	ks = kdump_set_attr(context, KDUMP_ATTR_OSTYPE, &attr);
+	if (ks != KDUMP_OK) {
+		kdump_free(context);
+		close(fd);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "setting kdump xlat attribute: %s\n",
+					 kdump_get_err(context));
+	}
+	*ctx = context;
+}
+
+void drgn_kdump_close(kdump_ctx_t *ctx)
+{
+	kdump_free(ctx);
+}
+
+
+struct drgn_error *drgn_kdump_get_kernel_offset(kdump_ctx_t *ctx,
+                                                uint64_t *offset)
+{
+	const char *key = "linux.vmcoreinfo.lines.KERNELOFFSET";
+
+	kdump_attr_ref_t root;
+	kdump_status ks = kdump_attr_ref(ctx, key, &root);
+	if (ks != KDUMP_OK) {
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	kdump_attr_t attr;
+	ks = kdump_attr_ref_get(ctx, &root, &attr);
+	if (ks != KDUMP_OK) {
+		kdump_attr_unref(ctx, &root);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref_get(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	switch (attr.type) {
+	case KDUMP_STRING:
+		*offset = strtoull(attr.val.string, NULL, 16);
+		break;
+	case KDUMP_NUMBER:
+		*offset = attr.val.number;
+		break;
+	default:
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "%s - unexpected attr type: %d\n",
+					 key, attr.type);
+	}
+
+	kdump_attr_unref(ctx, &root);
+	return NULL;
+}
+
+struct drgn_error *drgn_kdump_get_osrelease(kdump_ctx_t *ctx,
+                                            char *osrelease)
+{
+	const char *key = "linux.uts.release";
+
+	kdump_attr_ref_t root;
+	kdump_status ks = kdump_attr_ref(ctx, key, &root);
+	if (ks != KDUMP_OK) {
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	kdump_attr_t attr;
+	ks = kdump_attr_ref_get(ctx, &root, &attr);
+	if (ks != KDUMP_OK) {
+		kdump_attr_unref(ctx, &root);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref_get(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	switch (attr.type) {
+	case KDUMP_STRING:
+		strncpy(osrelease, attr.val.string, OSRELEASE_LEN);
+		break;
+	default:
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "%s - unexpected attr type: %d\n",
+					 key, attr.type);
+	}
+
+	kdump_attr_unref(ctx, &root);
+	return NULL;
+}
+
+struct drgn_error *drgn_kdump_get_page_size(kdump_ctx_t *ctx,
+                                            uint64_t *page_size)
+{
+	const char *key = KDUMP_ATTR_PAGE_SIZE;
+
+	kdump_attr_ref_t root;
+	kdump_status ks = kdump_attr_ref(ctx, key, &root);
+	if (ks != KDUMP_OK) {
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	kdump_attr_t attr;
+	ks = kdump_attr_ref_get(ctx, &root, &attr);
+	if (ks != KDUMP_OK) {
+		kdump_attr_unref(ctx, &root);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref_get(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	switch (attr.type) {
+	case KDUMP_NUMBER:
+		*page_size = attr.val.number;
+		break;
+	default:
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "%s - unexpected attr type: %d\n",
+					 key, attr.type);
+	}
+
+	kdump_attr_unref(ctx, &root);
+	return NULL;
+}
+
+static bool drgn_kdump_is_64bits(const char *kdump_arch_attr)
+{
+	return (!strcmp(kdump_arch_attr, KDUMP_ARCH_X86_64) ||
+	        !strcmp(kdump_arch_attr, KDUMP_ARCH_AARCH64) ||
+	        !strcmp(kdump_arch_attr, KDUMP_ARCH_ALPHA) ||
+	        !strcmp(kdump_arch_attr, KDUMP_ARCH_IA64) ||
+	        !strcmp(kdump_arch_attr, KDUMP_ARCH_PPC64) ||
+	        !strcmp(kdump_arch_attr, KDUMP_ARCH_S390X));
+}
+
+struct drgn_error *drgn_kdump_get_arch(kdump_ctx_t *ctx,
+                                       enum drgn_architecture_flags *arch)
+{
+	/*
+	 * We first look in the architecture name and from there we
+	 * we determine  whether the architecture is 32 or 64 bits.
+	 * We could also attempt to guess the endianess that way but
+	 * we once again query the kdump for the rare case of
+	 * bi-endian architectures.
+	 */
+	*arch = 0;
+
+	const char *key = KDUMP_ATTR_ARCH_NAME;
+	kdump_attr_ref_t root;
+	kdump_status ks = kdump_attr_ref(ctx, key, &root);
+	if (ks != KDUMP_OK) {
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	kdump_attr_t attr;
+	ks = kdump_attr_ref_get(ctx, &root, &attr);
+	if (ks != KDUMP_OK) {
+		kdump_attr_unref(ctx, &root);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref_get(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	switch (attr.type) {
+	case KDUMP_STRING:
+		if (drgn_kdump_is_64bits(attr.val.string))
+			*arch |= DRGN_ARCH_IS_64_BIT;
+		break;
+	default:
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "%s - unexpected attr type: %d\n",
+					 key, attr.type);
+	}
+	kdump_attr_unref(ctx, &root);
+
+	key = KDUMP_ATTR_BYTE_ORDER;
+	ks = kdump_attr_ref(ctx, key, &root);
+	if (ks != KDUMP_OK) {
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	ks = kdump_attr_ref_get(ctx, &root, &attr);
+	if (ks != KDUMP_OK) {
+		kdump_attr_unref(ctx, &root);
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_attr_ref_get(%s) failed: %s\n",
+					 key, kdump_get_err(ctx));
+	}
+
+	switch (attr.type) {
+	case KDUMP_NUMBER:
+		if (attr.val.number == KDUMP_LITTLE_ENDIAN)
+			*arch |= DRGN_ARCH_IS_LITTLE_ENDIAN;
+		break;
+	default:
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "%s - unexpected attr type: %d\n",
+					 key, attr.type);
+	}
+	kdump_attr_unref(ctx, &root);
+
+	return NULL;
+}
+
+struct drgn_error *drgn_read_kdump(void *buf, uint64_t address, size_t count,
+                                   uint64_t offset, void *arg, bool physical)
+{
+	kdump_ctx_t *ctx = arg;
+	size_t nread = count;
+
+	/* zero-out buffer before doing anything */
+	memset(buf, 0, count);
+
+	kdump_addrspace_t as = (physical) ? KDUMP_KPHYSADDR : KDUMP_KVADDR;
+	kdump_status ks = kdump_read(ctx, as, address, buf, &nread);
+	if (ks != KDUMP_OK) {
+		return drgn_error_format(DRGN_ERROR_OTHER,
+		                         "kdump_read failed: %s",
+					 kdump_get_err(ctx));
+	}
+
+	if (nread != count) {
+		return drgn_error_format(DRGN_ERROR_FAULT,
+		                         "short read at kdump_read: %s",
+					 kdump_get_err(ctx));
+	}
+	return NULL;
+}

--- a/libdrgn/kdump_reader.c
+++ b/libdrgn/kdump_reader.c
@@ -1,6 +1,7 @@
 // Copyright 2019 - Serapheim Dimitropoulos
 // SPDX-License-Identifier: GPL-3.0+
 
+#ifdef LIBKDUMPFILE
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,7 +23,7 @@ struct drgn_error *has_kdump_signature(int fd, bool *is_kdump)
 			if (errno == EINTR)
 				continue;
 			*is_kdump = false;
-			return drgn_error_create_os(errno, NULL, "read");
+			return drgn_error_create_os("read", errno, NULL);
 		} else if (ret == 0) {
 			*is_kdump = false;
 			return drgn_error_format(DRGN_ERROR_FAULT,
@@ -195,3 +196,4 @@ struct drgn_error *drgn_read_kdump(void *buf, uint64_t address, size_t count,
 	}
 	return NULL;
 }
+#endif /* LIBKDUMPFILE */

--- a/libdrgn/kdump_reader.h
+++ b/libdrgn/kdump_reader.h
@@ -19,10 +19,8 @@
 #ifndef DRGN_KDUMP_READER_H
 #define DRGN_KDUMP_READER_H
 
-#ifdef LIBKDUMPFILE
 #include <stdbool.h>
 #include <stdint.h>
-#include <libkdumpfile/kdumpfile.h>
 
 #include "internal.h"
 
@@ -31,48 +29,35 @@
  *
  * @defgroup KdumpReader kdump reader
  *
- * kdump reader implementation of the MemoryReader interface.
+ * Logic for setting up drgn for reading kdump crash dumps.
  *
  * @{
  */
 
 #define	KDUMP_SIGNATURE	"KDUMP   "
-#define	SIG_LEN	(sizeof (KDUMP_SIGNATURE) - 1)
+#define	KDUMP_SIG_LEN	(sizeof (KDUMP_SIGNATURE) - 1)
 
-/** Check contents from the file descriptor start with the KDUMP signature */
-struct drgn_error *has_kdump_signature(int fd, bool *ret);
+#ifndef LIBKDUMPFILE
 
-/** Create a kdump-context from the given file descriptor */
-struct drgn_error *drgn_kdump_init(kdump_ctx_t **ctx, int fd);
+static inline struct drgn_error *
+drgn_program_set_kdump(const struct drgn_program *prog)
+{
+        return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+	                         "drgn configured without libkdumpfile");
+}
 
-/** Clean up all kdump-related metadata. */
-void drgn_kdump_close(kdump_ctx_t *ctx);
-
-/**
- * Get all the vmcoreinfo from the kdump in a single string.
- *
- * @param[in] ctx Kdump context.
- * @param[out] ret vmcore info.
- * @return @c NULL on success, non-@c NULL on error.
- */
-struct drgn_error *drgn_kdump_get_raw_vmcoreinfo(kdump_ctx_t *ctx,
-                                                 const char **ret);
+#else /* LIBKDUMPFILE */
 
 /**
- * Get the expected architecture flags from the kdump file.
+ * Setup program-related context leveraging libkdumpfile so
+ * we are able to read from makedumpfile program dumps.
  *
- * @param[in] ctx Kdump context.
- * @param[out] arch architecture flags.
  * @return @c NULL on success, non-@c NULL on error.
  */
-struct drgn_error *drgn_kdump_get_arch(kdump_ctx_t *ctx,
-                                       enum drgn_architecture_flags *arch);
+struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog);
 
-/** @ref drgn_memory_read_fn which reads from a kdump file. */
-struct drgn_error *drgn_read_kdump(void *buf, uint64_t address, size_t count,
-                                   uint64_t offset, void *arg, bool physical);
+#endif /* LIBKDUMPFILE */
 
 /** @} */
-#endif /* LIBKDUMPFILE */
 
 #endif /* DRGN_KDUMP_READER_H */

--- a/libdrgn/kdump_reader.h
+++ b/libdrgn/kdump_reader.h
@@ -10,12 +10,16 @@
  * - sourceforge.net/p/makedumpfile/code/ci/master/tree/IMPLEMENTATION
  * - github.com/ptesarik/libkdumpfile
  *
+ * Note that this is only really used when --with-libkdumpfile=yes is
+ * configured.
+ *
  * See @ref KdumpReader.
  */
 
 #ifndef DRGN_KDUMP_READER_H
 #define DRGN_KDUMP_READER_H
 
+#ifdef LIBKDUMPFILE
 #include <stdbool.h>
 #include <stdint.h>
 #include <libkdumpfile/kdumpfile.h>
@@ -69,5 +73,6 @@ struct drgn_error *drgn_read_kdump(void *buf, uint64_t address, size_t count,
                                    uint64_t offset, void *arg, bool physical);
 
 /** @} */
+#endif /* LIBKDUMPFILE */
 
 #endif /* DRGN_KDUMP_READER_H */

--- a/libdrgn/kdump_reader.h
+++ b/libdrgn/kdump_reader.h
@@ -1,0 +1,93 @@
+// Copyright 2019 - Serapheim Dimitropoulos
+// SPDX-License-Identifier: GPL-3.0+
+
+/**
+ * @file
+ *
+ * Makedumpfile format reader that implements the MemoryReader interface.
+ *
+ * Other implementation references:
+ * - sourceforge.net/p/makedumpfile/code/ci/master/tree/IMPLEMENTATION
+ * - github.com/ptesarik/libkdumpfile
+ *
+ * See @ref KdumpReader.
+ */
+
+#ifndef DRGN_KDUMP_READER_H
+#define DRGN_KDUMP_READER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <libkdumpfile/kdumpfile.h>
+
+#include "internal.h"
+
+/**
+ * @ingroup Internals
+ *
+ * @defgroup KdumpReader kdump reader
+ *
+ * kdump reader implementation of the MemoryReader interface.
+ *
+ * @{
+ */
+
+#define	KDUMP_SIGNATURE	"KDUMP   "
+#define	SIG_LEN	(sizeof (KDUMP_SIGNATURE) - 1)
+
+/** Check contents from the file descriptor start with the KDUMP signature */
+bool has_kdump_signature(int fd, struct drgn_error **err);
+
+/** Create a kdump-context from the given file descriptor */
+struct drgn_error *drgn_kdump_init(kdump_ctx_t **ctx, int fd);
+
+/** Clean up all kdump-related metadata. */
+void drgn_kdump_close(kdump_ctx_t *ctx);
+
+/**
+ * Get the offset of the kernel binary from the kdump file.
+ *
+ * @param[in] ctx Kdump context.
+ * @param[out] offset kernel offset within the image.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_kdump_get_kernel_offset(kdump_ctx_t *ctx,
+                                                uint64_t *offset);
+
+/**
+ * Get the osrelease attribute (e.g. `uname -r`) from the kdump file.
+ *
+ * @param[in] ctx Kdump context.
+ * @param[out] osrelease (e.g. "4.15.0-50-generic").
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_kdump_get_osrelease(kdump_ctx_t *ctx,
+                                            char *osrelease);
+
+/**
+ * Get the page size for contents of the given kdump file.
+ *
+ * @param[in] ctx Kdump context.
+ * @param[out] page_size Page size.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_kdump_get_page_size(kdump_ctx_t *ctx,
+                                            uint64_t *page_size);
+
+/**
+ * Get the expected architecture flags from the kdump file.
+ *
+ * @param[in] ctx Kdump context.
+ * @param[out] arch architecture flags.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_kdump_get_arch(kdump_ctx_t *ctx,
+                                       enum drgn_architecture_flags *arch);
+
+/** @ref drgn_memory_read_fn which reads from a kdump file. */
+struct drgn_error *drgn_read_kdump(void *buf, uint64_t address, size_t count,
+                                   uint64_t offset, void *arg, bool physical);
+
+/** @} */
+
+#endif /* DRGN_KDUMP_READER_H */

--- a/libdrgn/kdump_reader.h
+++ b/libdrgn/kdump_reader.h
@@ -36,7 +36,7 @@
 #define	SIG_LEN	(sizeof (KDUMP_SIGNATURE) - 1)
 
 /** Check contents from the file descriptor start with the KDUMP signature */
-bool has_kdump_signature(int fd, struct drgn_error **err);
+struct drgn_error *has_kdump_signature(int fd, bool *ret);
 
 /** Create a kdump-context from the given file descriptor */
 struct drgn_error *drgn_kdump_init(kdump_ctx_t **ctx, int fd);
@@ -45,34 +45,14 @@ struct drgn_error *drgn_kdump_init(kdump_ctx_t **ctx, int fd);
 void drgn_kdump_close(kdump_ctx_t *ctx);
 
 /**
- * Get the offset of the kernel binary from the kdump file.
+ * Get all the vmcoreinfo from the kdump in a single string.
  *
  * @param[in] ctx Kdump context.
- * @param[out] offset kernel offset within the image.
+ * @param[out] ret vmcore info.
  * @return @c NULL on success, non-@c NULL on error.
  */
-struct drgn_error *drgn_kdump_get_kernel_offset(kdump_ctx_t *ctx,
-                                                uint64_t *offset);
-
-/**
- * Get the osrelease attribute (e.g. `uname -r`) from the kdump file.
- *
- * @param[in] ctx Kdump context.
- * @param[out] osrelease (e.g. "4.15.0-50-generic").
- * @return @c NULL on success, non-@c NULL on error.
- */
-struct drgn_error *drgn_kdump_get_osrelease(kdump_ctx_t *ctx,
-                                            char *osrelease);
-
-/**
- * Get the page size for contents of the given kdump file.
- *
- * @param[in] ctx Kdump context.
- * @param[out] page_size Page size.
- * @return @c NULL on success, non-@c NULL on error.
- */
-struct drgn_error *drgn_kdump_get_page_size(kdump_ctx_t *ctx,
-                                            uint64_t *page_size);
+struct drgn_error *drgn_kdump_get_raw_vmcoreinfo(kdump_ctx_t *ctx,
+                                                 const char **ret);
 
 /**
  * Get the expected architecture flags from the kdump file.

--- a/libdrgn/kdump_reader.h
+++ b/libdrgn/kdump_reader.h
@@ -19,9 +19,6 @@
 #ifndef DRGN_KDUMP_READER_H
 #define DRGN_KDUMP_READER_H
 
-#include <stdbool.h>
-#include <stdint.h>
-
 #include "internal.h"
 
 /**
@@ -37,26 +34,22 @@
 #define	KDUMP_SIGNATURE	"KDUMP   "
 #define	KDUMP_SIG_LEN	(sizeof (KDUMP_SIGNATURE) - 1)
 
-#ifndef LIBKDUMPFILE
-
-static inline struct drgn_error *
-drgn_program_set_kdump(const struct drgn_program *prog)
-{
-        return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
-	                         "drgn configured without libkdumpfile");
-}
-
-#else /* LIBKDUMPFILE */
-
 /**
  * Setup program-related context leveraging libkdumpfile so
  * we are able to read from makedumpfile program dumps.
  *
  * @return @c NULL on success, non-@c NULL on error.
  */
+#ifdef WITH_LIBKDUMPFILE
 struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog);
-
-#endif /* LIBKDUMPFILE */
+#else
+static inline struct drgn_error *
+drgn_program_set_kdump(struct drgn_program *prog)
+{
+        return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+	                         "drgn configured without libkdumpfile");
+}
+#endif
 
 /** @} */
 

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -166,6 +166,7 @@ drgn_program_check_initialized(struct drgn_program *prog)
 	return NULL;
 }
 
+#ifdef LIBKDUMPFILE
 static struct drgn_error *
 drgn_program_set_kdump(struct drgn_program *prog)
 {
@@ -210,6 +211,7 @@ out_fd:
 	prog->core_fd = -1;
         return err;
 }
+#endif /* LIBKDUMPFILE */
 
 LIBDRGN_PUBLIC struct drgn_error *
 drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
@@ -232,11 +234,13 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 	if (prog->core_fd == -1)
 		return drgn_error_create_os("open", errno, path);
 
+#ifdef LIBKDUMPFILE
 	err = has_kdump_signature(prog->core_fd, &is_kdump);
 	if (is_kdump)
 		return drgn_program_set_kdump(prog);
 	if (err)
 		goto out_fd;
+#endif /* LIBKDUMPFILE */
 
 	elf_version(EV_CURRENT);
 

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -28,12 +28,10 @@
  * @{
  */
 
-#define OSRELEASE_LEN 128
-
 /** The important parts of the VMCOREINFO note of a Linux kernel core. */
 struct vmcoreinfo {
 	/** <tt>uname -r</tt> */
-	char osrelease[OSRELEASE_LEN];
+	char osrelease[128];
 	/** PAGE_SIZE of the kernel. */
 	uint64_t page_size;
 	/**
@@ -80,6 +78,10 @@ void drgn_program_init(struct drgn_program *prog,
 
 /** Deinitialize a @ref drgn_program. */
 void drgn_program_deinit(struct drgn_program *prog);
+
+/** Update the @ref drgn_architecture_flags of a @ref drgn_program. */
+void drgn_program_update_arch(struct drgn_program *prog,
+                              enum drgn_architecture_flags arch);
 
 /**
  * Implement @ref drgn_program_from_core_dump() on an initialized @ref

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -28,10 +28,12 @@
  * @{
  */
 
+#define OSRELEASE_LEN 128
+
 /** The important parts of the VMCOREINFO note of a Linux kernel core. */
 struct vmcoreinfo {
 	/** <tt>uname -r</tt> */
-	char osrelease[128];
+	char osrelease[OSRELEASE_LEN];
 	/** PAGE_SIZE of the kernel. */
 	uint64_t page_size;
 	/**


### PR DESCRIPTION
## Intro

Note that this is a WIP to get feedback on the design/organization of the code.
After writing this in C, I realized that it could have been easily implemented in
Python too since libkdumpfile provides wrappers for Python. I'm not sure what
would be preferable at this point but it wouldn't be a problem for me rewriting
this in Python.

## Preliminary Feature Testing

Look at the `jiffies` of kdump in `crash`:
```
$ crash ../dump/vmlinux-4.15.0-47-generic ../dump/dump.201904221843

crash 7.2.1
Copyright (C) 2002-2017  Red Hat, Inc.
... < cropped output > ...
crash> p jiffies
jiffies = $2 = 4294918568
```

Using the same address to read the `jiffies` from drgn prototype we get the same value:
```
$ sudo drgn -c dump/dump.201904221843 -s dump/vmlinux-4.15.0-47-generic
could not get debugging information for:
kernel (could not find vmlinux)
kernel modules (could not find loaded kernel modules: could not find 'struct module')
drgn 0.0.1 (using Python 3.6.7)
For help, type help(drgn).
>>> import drgn
>>> from drgn import cast, container_of, execscript, NULL, Object, reinterpret
>>> from drgn.helpers.linux import *
>>> prog['jiffies']
(volatile unsigned long)4294918568
>>>
```

## Testing that feature is indeed an optional dependency

The above testing was done by enabling the feature through `setup.py` like this:
```
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ class my_build_ext(build_ext):
             args = [
                 os.path.relpath('libdrgn/configure', self.build_temp),
                 '--disable-static', '--with-python=' + sys.executable,
+                '--with-libkdumpfile=yes',
             ]
             try:
                 subprocess.check_call(args, cwd=self.build_temp)
```

Without the feature trying to open the same crash dump we get the following error:
```
$ sudo drgn -c dump/dump.201904221843 -s dump/vmlinux-4.15.0-47-generic
Traceback (most recent call last):
  File "/usr/local/bin/drgn", line 11, in <module>
    load_entry_point('drgn==0.0.1', 'console_scripts', 'drgn')()
  File "/usr/local/lib/python3.6/dist-packages/drgn-0.0.1-py3.6-linux-x86_64.egg/drgn/internal/cli.py", line 83, in main
    prog.set_core_dump(args.core)
ValueError: drgn configured without libkdumpfile
```

## Work left
* finalize ifdef structure for making this an optional dependency
* figure out if automated testing is possible?
* style fixes
* copy Petr Tesarik (maintainer of libkdumpfile) in the final rounds of code review to ensure proper use of the library (and also give a heads up that we exist as an official consumer)