### PR TITLE
libdrgn: fix regression in kernel module loading

### DIFF
--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -883,7 +883,7 @@ get_kernel_module_name_from_modinfo(Elf_Scn *modinfo_scn, const char **ret)
 			nul = memchr(p, 0, end - p);
 			if (!nul)
 				break;
-			if (strstartswith(p, "name=") == 0) {
+			if (strstartswith(p, "name=")) {
 				*ret = p + 5;
 				return NULL;
 			}


### PR DESCRIPTION
Commit f327552229658d85b791c6b0613efb96b8a9da24 introduced a
regression resulting in kernel modules not loaded at the right
offset. This patch fixes the regression.