### PR TITLE
examples: Add tcp_sock.py

### DIFF
--- a/drgn/helpers/linux/list_nulls.py
+++ b/drgn/helpers/linux/list_nulls.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+"""
+Nulls Lists
+-----------
+
+The ``drgn.helpers.linux.list_nulls`` module provides helpers for working with
+the special version of lists (``struct hlist_nulls_head`` and ``struct
+hlist_nulls_node``) in :linux:`include/linux/list_nulls.h` where the end of
+list is not a ``NULL`` pointer, but a "nulls" marker.
+"""
+
+from drgn import container_of
+
+
+__all__ = [
+    'is_a_nulls',
+    'hlist_nulls_empty',
+    'hlist_nulls_entry',
+    'hlist_nulls_for_each_entry',
+]
+
+
+def is_a_nulls(pos):
+    """
+    .. c:function:: bool is_a_nulls(struct hlist_nulls_node *pos)
+
+    Return whether a a pointer is a nulls marker.
+    """
+    return bool(pos.value_() & 1)
+
+
+def hlist_nulls_empty(head):
+    """
+    .. c:function:: bool hlist_nulls_empty(struct hlist_nulls_head *head)
+
+    Return whether a nulls hash list is empty.
+    """
+    return is_a_nulls(head.first)
+
+
+def hlist_nulls_entry(pos, type, member):
+    """
+    .. c:function:: type *hlist_nulls_entry(struct hlist_nulls_node *pos, type, member)
+
+    Return an entry in a nulls hash list.
+
+    The nulls hash list is assumed to be non-empty.
+    """
+    return container_of(pos, type, member)
+
+
+def hlist_nulls_for_each_entry(type, head, member):
+    """
+    .. c:function:: hlist_nulls_for_each_entry(type, struct hlist_nulls_head *head, member)
+
+    Iterate over all the entries in a nulls hash list specified by ``struct
+    hlist_nulls_head`` head, given the type of the entry and the ``struct
+    hlist_nulls_node`` member in that type.
+
+    :return: Iterator of ``type *`` objects.
+    """
+    pos = head.first
+    while not is_a_nulls(pos):
+        yield hlist_nulls_entry(pos, type, member)
+        pos = pos.next

--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+"""
+Networking
+----------
+
+The ``drgn.helpers.linux.net`` module provides helpers for working with the
+Linux kernel networking subsystem.
+"""
+
+from drgn.helpers.linux.list_nulls import hlist_nulls_for_each_entry
+from drgn.helpers.linux.tcp import get_tcp_states
+
+
+__all__ = [
+    'sk_fullsock',
+    'sk_nulls_for_each',
+]
+
+
+def sk_fullsock(sk):
+    """
+    .. c:function:: bool sk_fullsock(struct sock *sk)
+
+    Check whether a socket is a full socket, i.e., not a time-wait or request
+    socket.
+    """
+    TcpStates = get_tcp_states(sk.prog_)
+    return TcpStates(sk.__sk_common.skc_state) not in (TcpStates.SYN_RECV,
+                                                       TcpStates.TIME_WAIT)
+
+
+def sk_nulls_for_each(head):
+    """
+    .. c:function:: sk_nulls_for_each(struct hlist_nulls_head *head)
+
+    Iterate over all the entries in a nulls hash list of sockets specified by
+    ``struct hlist_nulls_head`` head.
+
+    :return: Iterator of ``struct sock`` objects.
+    """
+    for sk in hlist_nulls_for_each_entry( 'struct sock', head,
+                                         '__sk_common.skc_nulls_node'):
+        yield sk

--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -9,7 +9,7 @@ Linux kernel networking subsystem.
 """
 
 from drgn.helpers.linux.list_nulls import hlist_nulls_for_each_entry
-from drgn.helpers.linux.tcp import get_tcp_states
+from drgn.helpers.linux.tcp import get_tcp_states, sk_tcpstate
 
 
 __all__ = [
@@ -26,8 +26,7 @@ def sk_fullsock(sk):
     socket.
     """
     TcpStates = get_tcp_states(sk.prog_)
-    return TcpStates(sk.__sk_common.skc_state) not in (TcpStates.SYN_RECV,
-                                                       TcpStates.TIME_WAIT)
+    return sk_tcpstate(sk) not in (TcpStates.SYN_RECV, TcpStates.TIME_WAIT)
 
 
 def sk_nulls_for_each(head):

--- a/drgn/helpers/linux/tcp.py
+++ b/drgn/helpers/linux/tcp.py
@@ -13,6 +13,7 @@ import enum
 
 __all__ = [
     'get_tcp_states',
+    'sk_tcpstate',
 ]
 
 
@@ -42,3 +43,12 @@ def get_tcp_states(prog):
     except KeyError:
         prog.cache[enum_name] = _get_tcp_states(prog, enum_name)
         return prog.cache[enum_name]
+
+
+def sk_tcpstate(sk):
+    """
+    .. c:function:: enum TcpState sk_tcpstate(struct sock *sk)
+
+    Return the TCP protocol state of a socket.
+    """
+    return get_tcp_states(sk.prog_)(sk.__sk_common.skc_state)

--- a/drgn/helpers/linux/tcp.py
+++ b/drgn/helpers/linux/tcp.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+"""
+TCP
+---
+
+The ``drgn.helpers.linux.tcp`` module provides helpers for working with the TCP
+protocol in the Linux kernel.
+"""
+
+import enum
+
+
+__all__ = [
+    'get_tcp_states',
+]
+
+
+def _get_tcp_states(prog, enum_name):
+    # The enum type is anonymous, but it can be looked up from one of the
+    # enumerators.
+    raw_enumerators = prog['TCP_ESTABLISHED'].type_.enumerators
+    tcp_ = 'TCP_'
+    enumerators = [
+        (name[len(tcp_):], value) if name.startswith(tcp_) else (name, value)
+        for (name, value) in raw_enumerators
+        if name != 'TCP_MAX_STATES'
+    ]
+    return enum.IntEnum(enum_name, enumerators)
+
+
+def get_tcp_states(prog):
+    """
+    Get all definitions for the TCP protocol states
+    (:linux:`include/net/tcp_states.h`) as an :class:`enum.IntEnum` class.
+
+    :rtype: enum.IntEnum
+    """
+    enum_name = 'TcpStates'
+    try:
+        return prog.cache[enum_name]
+    except KeyError:
+        prog.cache[enum_name] = _get_tcp_states(prog, enum_name)
+        return prog.cache[enum_name]

--- a/examples/linux/tcp_sock.py
+++ b/examples/linux/tcp_sock.py
@@ -1,0 +1,113 @@
+"""List all TCP sockets and their cgroup v2 paths"""
+
+import ipaddress
+import os
+import socket
+import struct
+
+from drgn import Object, cast, container_of
+from drgn.helpers.linux import (
+    get_tcp_states,
+    hlist_for_each,
+    hlist_nulls_empty,
+    sk_fullsock,
+    sk_nulls_for_each,
+)
+
+
+TcpStates = get_tcp_states(prog)
+
+
+def inet_sk(sk):
+    return cast('struct inet_sock *', sk)
+
+
+def _ipv4(be32):
+    return ipaddress.IPv4Address(struct.pack('I', be32.value_()))
+
+
+def _ipv6(in6_addr):
+    return ipaddress.IPv6Address(struct.pack('IIII', *in6_addr.in6_u.u6_addr32))
+
+
+def _brackets(ip):
+    if ip.version == 4:
+        return '{}'.format(ip.compressed)
+    elif ip.version == 6:
+        return '[{}]'.format(ip.compressed)
+    return ''
+
+
+def _ip_port(ip, port):
+    return '{:>40}:{:<6}'.format(_brackets(ip), port)
+
+
+def _cgroup_path(cgroup):
+    cgroup_path = ''
+
+    while cgroup.level > 0:
+        cgroup_name = cgroup.kn.name.string_().decode()
+        if cgroup_path:
+            cgroup_path = os.path.join(cgroup_name, cgroup_path)
+        else:
+            cgroup_path = cgroup_name
+
+        parent_css = cgroup.self.parent
+        if not parent_css:
+            break
+
+        cgroup = container_of(parent_css, 'struct cgroup', 'self')
+
+    return cgroup_path
+
+
+def _print_sk(sk):
+    inet = inet_sk(sk)
+
+    tcp_state = TcpStates(sk.__sk_common.skc_state)
+
+    if sk.__sk_common.skc_family == socket.AF_INET:
+        src_ip = _ipv4(sk.__sk_common.skc_rcv_saddr)
+        dst_ip = _ipv4(sk.__sk_common.skc_daddr)
+    elif sk.__sk_common.skc_family == socket.AF_INET6:
+        src_ip = _ipv6(sk.__sk_common.skc_v6_rcv_saddr)
+        dst_ip = _ipv6(sk.__sk_common.skc_v6_daddr)
+    else:
+        return
+
+    src_port = socket.ntohs(inet.inet_sport)
+    dst_port = socket.ntohs(sk.__sk_common.skc_dport)
+
+    cgroup_path = ''
+    if sk_fullsock(sk):
+        cgroup = Object(prog, 'struct cgroup', address=sk.sk_cgrp_data.val)
+        cgroup_path = _cgroup_path(cgroup)
+
+    print('{:<12} {} {} {}'.format(
+        tcp_state.name,
+        _ip_port(src_ip, src_port),
+        _ip_port(dst_ip, dst_port),
+        cgroup_path
+    ))
+
+    # Uncomment to print whole struct:
+    #   print(sk)
+    #   print(inet)
+    #   print(cgroup)
+
+
+tcp_hashinfo = prog.object('tcp_hashinfo')
+
+# 1. Iterate over all TCP sockets in TCP_LISTEN state.
+for ilb in tcp_hashinfo.listening_hash:
+    for pos in hlist_for_each(ilb.head):
+        sk = container_of(pos, 'struct sock', '__sk_common.skc_node')
+        _print_sk(sk)
+
+# 2. And all other TCP sockets.
+for i in range(tcp_hashinfo.ehash_mask + 1):
+    head = tcp_hashinfo.ehash[i].chain
+    if hlist_nulls_empty(head):
+        continue
+    for sk in sk_nulls_for_each(head):
+        _print_sk(sk)

--- a/examples/linux/tcp_sock.py
+++ b/examples/linux/tcp_sock.py
@@ -12,10 +12,8 @@ from drgn.helpers.linux import (
     hlist_nulls_empty,
     sk_fullsock,
     sk_nulls_for_each,
+    sk_tcpstate,
 )
-
-
-TcpStates = get_tcp_states(prog)
 
 
 def inet_sk(sk):
@@ -64,7 +62,7 @@ def _cgroup_path(cgroup):
 def _print_sk(sk):
     inet = inet_sk(sk)
 
-    tcp_state = TcpStates(sk.__sk_common.skc_state)
+    tcp_state = sk_tcpstate(sk)
 
     if sk.__sk_common.skc_family == socket.AF_INET:
         src_ip = _ipv4(sk.__sk_common.skc_rcv_saddr)

--- a/tests/helpers/linux/__init__.py
+++ b/tests/helpers/linux/__init__.py
@@ -1,7 +1,9 @@
 import ctypes
+import errno
 import os
 import re
 import signal
+import socket
 import time
 import unittest
 
@@ -97,3 +99,14 @@ def umount(target, flags=0):
     if _umount2(os.fsencode(target), flags) == -1:
         errno = ctypes.get_errno()
         raise OSError(errno, os.strerror(errno), target)
+
+
+def create_socket(*args, **kwds):
+    try:
+        return socket.socket(*args, **kwds)
+    except OSError as e:
+        if e.errno in (errno.ENOSYS, errno.EAFNOSUPPORT,
+                       errno.ESOCKTNOSUPPORT):
+            raise unittest.SkipTest('kernel does not support TCP')
+        else:
+            raise

--- a/tests/helpers/linux/test_net.py
+++ b/tests/helpers/linux/test_net.py
@@ -1,0 +1,15 @@
+import os
+
+from drgn import cast
+from drgn.helpers.linux.fs import fget
+from drgn.helpers.linux.net import sk_fullsock
+from drgn.helpers.linux.pid import find_task
+from tests.helpers.linux import LinuxHelperTestCase, create_socket
+
+
+class TestNet(LinuxHelperTestCase):
+    def test_sk_fullsock(self):
+        with create_socket() as sock:
+            file = fget(find_task(self.prog, os.getpid()), sock.fileno())
+            sk = cast('struct socket *', file.private_data).sk.read_()
+            self.assertTrue(sk_fullsock(sk))

--- a/tests/helpers/linux/test_tcp.py
+++ b/tests/helpers/linux/test_tcp.py
@@ -1,0 +1,28 @@
+import os
+import socket
+
+from drgn import cast
+from drgn.helpers.linux.fs import fget
+from drgn.helpers.linux.pid import find_task
+from drgn.helpers.linux.tcp import get_tcp_states, sk_tcpstate
+from tests.helpers.linux import LinuxHelperTestCase, create_socket
+
+
+class TestTcp(LinuxHelperTestCase):
+    def test_tcp_states(self):
+        with create_socket() as sock:
+            task = find_task(self.prog, os.getpid())
+            file = fget(task, sock.fileno())
+            sk = cast('struct socket *', file.private_data).sk
+            TcpStates = get_tcp_states(self.prog)
+            self.assertEqual(sk_tcpstate(sk), TcpStates.CLOSE)
+
+            sock.bind(('localhost', 0))
+            sock.listen()
+            self.assertEqual(sk_tcpstate(sk), TcpStates.LISTEN)
+
+            with socket.create_connection(sock.getsockname()), \
+                    sock.accept()[0] as sock2:
+                file = fget(task, sock2.fileno())
+                sk = cast('struct socket *', file.private_data).sk
+                self.assertEqual(sk_tcpstate(sk), TcpStates.ESTABLISHED)


### PR DESCRIPTION
Add example script that goes over all TCP sockets and for every socket
prints:
- TCP state;
- IP:port pair;
- cgroup v2 path.

The script shows basic operations with sockets including getting `struct
sock`, `struct inet_sock`, socket fields and cgroup v2 of socket.

It provides output similar to `ss -nt` or `ss -lnt`:
```
% sudo python36 -m drgn examples/linux/tcp_sock.py | shuf -n 5
TIME_WAIT                                       [::1]:2560                                      [::1]:44041
ESTABLISHED                                     [::1]:54178                                     [::1]:11101  system.slice/async-distillery-server.service
LISTEN                                           [::]:3201                                       [::]:0      system.slice/fbflow.service
ESTABLISHED           [2401:db00:21:718a:face:0:31:0]:2406            [2401:db00:12:a106:face:0:1e:0]:46306  system.slice/configerator_proxy2.service
LISTEN                                        0.0.0.0:11150                                   0.0.0.0:0      system.slice/system-mcrouter.slice/mcrouter@tao.service
```

Since it requires iterating over sockets, necessary `hlist_nulls`
helpers are added as well.

Some functions from `tcp_sock.py` (`sk_fullsock`, `sk_nulls_for_each`,
`inet_sk`) are generally useful and can be moved to a library later.