### PR TITLE
examples/tcp_sock: Fix missed import

### DIFF
--- a/examples/linux/tcp_sock.py
+++ b/examples/linux/tcp_sock.py
@@ -4,6 +4,7 @@ import ipaddress
 import socket
 import struct
 
+from drgn import cast, container_of
 from drgn.helpers import enum_type_to_class
 from drgn.helpers.linux import (
     cgroup_path,


### PR DESCRIPTION
In the previous commit used import was removed by mistake. Restore them.

Fixes: 7dd1853 ("examples: Switch tcp_sock to cgroup helpers")