### PR TITLE
libdrgn: Add support for looking up reading kernel parameters

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -128,11 +128,13 @@ Programs
         :raises LookupError: if no objects with the given name are found in
             the given file
 
-    .. method:: symbol(address)
+    .. method:: symbol(address_or_name, /)
 
-        Get the symbol containing the given address.
+        Get the symbol containing the given address, or the global symbol with
+        the given name.
 
-        :param int address: The address.
+        :param address_or_name: The address or name.
+        :type address_or_name: str or int
         :rtype: Symbol
         :raises LookupError: if no symbol contains the given address
 

--- a/drgn/helpers/linux/kconfig.py
+++ b/drgn/helpers/linux/kconfig.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: GPL-3.0+
+
+"""
+Kconfig
+-------
+
+The ``drgn.helpers.linux.kconfig`` module provides helpers for reading the
+Linux kernel build configuration.
+"""
+
+import gzip
+import types
+from typing import Mapping
+
+__all__ = ("get_kconfig",)
+
+
+def get_kconfig(prog) -> Mapping[str, str]:
+    """
+    Get the kernel build configuration as a mapping from the option name to the
+    value.
+
+    >>> get_kconfig(prog)['CONFIG_SMP']
+    'y'
+    >>> get_kconfig(prog)['CONFIG_HZ']
+    '300'
+
+    This is only supported if the kernel was compiled with ``CONFIG_IKCONFIG``.
+    Note that most Linux distributions do not enable this option.
+    """
+    try:
+        return prog.cache["kconfig_map"]
+    except KeyError:
+        pass
+
+    try:
+        start = prog.symbol("kernel_config_data").address
+        size = prog.symbol("kernel_config_data_end").address - start
+    except LookupError:
+        # Before Linux kernel commit 13610aa908dc ("kernel/configs: use .incbin
+        # directive to embed config_data.gz") (in v5.1), the data is a variable
+        # rather than two symbols.
+        try:
+            kernel_config_data = prog["kernel_config_data"]
+        except KeyError:
+            raise LookupError(
+                "kernel configuration data not found; kernel must be compiled with CONFIG_IKCONFIG"
+            )
+        # The data is delimited by the magic strings "IKCFG_ST" and "IKCFG_ED"
+        # plus a NUL byte.
+        start = kernel_config_data.address_ + 8
+        size = len(kernel_config_data) - 17
+
+    data = prog.read(start, size)
+    result = {}
+    for line in gzip.decompress(data).decode().splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name, _, value = line.partition("=")
+        if value:
+            result[name] = value
+
+    # Make result mapping 'immutable', so changes cannot propagate to the cache
+    result = types.MappingProxyType(result)
+    prog.cache["kconfig_map"] = result
+    return result

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -1321,9 +1321,9 @@ struct drgn_symbol;
  * drgn_symbol_destroy().
  * @return @c NULL on success, non-@c NULL on error.
  */
-struct drgn_error *drgn_program_find_symbol(struct drgn_program *prog,
-					    uint64_t address,
-					    struct drgn_symbol **ret);
+struct drgn_error *
+drgn_program_find_symbol_by_address(struct drgn_program *prog, uint64_t address,
+				    struct drgn_symbol **ret);
 
 /** Element type and size. */
 struct drgn_element_info {
@@ -2330,7 +2330,7 @@ struct drgn_error *drgn_object_sizeof(const struct drgn_object *obj,
  *
  * Symbol table entries.
  *
- * @sa drgn_program_find_symbol()
+ * @sa drgn_program_find_symbol_by_address()
  *
  * @{
  */

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -1325,6 +1325,17 @@ struct drgn_error *
 drgn_program_find_symbol_by_address(struct drgn_program *prog, uint64_t address,
 				    struct drgn_symbol **ret);
 
+/**
+ * Get the symbol corresponding to the given name.
+ *
+ * @param[out] ret The returned symbol. It should be freed with @ref
+ * drgn_symbol_destroy().
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_find_symbol_by_name(struct drgn_program *prog,
+						    const char *name,
+						    struct drgn_symbol **ret);
+
 /** Element type and size. */
 struct drgn_element_info {
 	/** Type of the element. */

--- a/libdrgn/language_c.c
+++ b/libdrgn/language_c.c
@@ -1290,8 +1290,10 @@ c_format_pointer_object(const struct drgn_object *obj,
 		return err;
 
 	have_symbol = ((flags & DRGN_FORMAT_OBJECT_SYMBOLIZE) &&
-		       drgn_program_find_symbol_internal(obj->prog, uvalue,
-							 NULL, &sym));
+		       drgn_program_find_symbol_by_address_internal(obj->prog,
+								    uvalue,
+								    NULL,
+								    &sym));
 	if (have_symbol && dereference && !c_string &&
 	    !string_builder_appendc(sb, '('))
 		return &drgn_enomem;

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -906,9 +906,10 @@ drgn_program_find_object(struct drgn_program *prog, const char *name,
 				      ret);
 }
 
-bool drgn_program_find_symbol_internal(struct drgn_program *prog,
-				       uint64_t address, Dwfl_Module *module,
-				       struct drgn_symbol *ret)
+bool drgn_program_find_symbol_by_address_internal(struct drgn_program *prog,
+						  uint64_t address,
+						  Dwfl_Module *module,
+						  struct drgn_symbol *ret)
 {
 	const char *name;
 	GElf_Off offset;
@@ -943,15 +944,16 @@ struct drgn_error *drgn_error_symbol_not_found(uint64_t address)
 }
 
 LIBDRGN_PUBLIC struct drgn_error *
-drgn_program_find_symbol(struct drgn_program *prog, uint64_t address,
-			 struct drgn_symbol **ret)
+drgn_program_find_symbol_by_address(struct drgn_program *prog, uint64_t address,
+				    struct drgn_symbol **ret)
 {
 	struct drgn_symbol *sym;
 
 	sym = malloc(sizeof(*sym));
 	if (!sym)
 		return &drgn_enomem;
-	if (!drgn_program_find_symbol_internal(prog, address, NULL, sym)) {
+	if (!drgn_program_find_symbol_by_address_internal(prog, address, NULL,
+							  sym)) {
 		free(sym);
 		return drgn_error_symbol_not_found(address);
 	}

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -157,16 +157,18 @@ struct drgn_error *drgn_program_find_prstatus(struct drgn_program *prog,
 					      uint32_t tid, struct string *ret);
 
 /*
- * Like @ref drgn_program_find_symbol(), but @p ret is already allocated, we may
- * already know the module, and doesn't return a @ref drgn_error.
+ * Like @ref drgn_program_find_symbol_by_address(), but @p ret is already
+ * allocated, we may already know the module, and doesn't return a @ref
+ * drgn_error.
  *
  * @param[in] module Module containing the address. May be @c NULL, in which
  * case this will look it up.
  * @return Whether the symbol was found.
  */
-bool drgn_program_find_symbol_internal(struct drgn_program *prog,
-				       uint64_t address, Dwfl_Module *module,
-				       struct drgn_symbol *ret);
+bool drgn_program_find_symbol_by_address_internal(struct drgn_program *prog,
+						  uint64_t address,
+						  Dwfl_Module *module,
+						  struct drgn_symbol *ret);
 
 /** @} */
 

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -730,7 +730,8 @@ static PyObject *Program_symbol(Program *self, PyObject *args, PyObject *kwds)
 					 index_converter, &address))
 		return NULL;
 
-	err = drgn_program_find_symbol(&self->prog, address.uvalue, &sym);
+	err = drgn_program_find_symbol_by_address(&self->prog, address.uvalue,
+						  &sym);
 	if (err)
 		return set_drgn_error(err);
 	ret = Symbol_wrap(sym, self);

--- a/libdrgn/stack_trace.c
+++ b/libdrgn/stack_trace.c
@@ -57,8 +57,9 @@ drgn_format_stack_trace(struct drgn_stack_trace *trace, char **ret)
 		pc = drgn_stack_frame_pc(frame);
 		module = dwfl_frame_module(trace->frames[frame.i]);
 		if (module &&
-		    drgn_program_find_symbol_internal(trace->prog, pc, module,
-						      &sym)) {
+		    drgn_program_find_symbol_by_address_internal(trace->prog,
+								 pc, module,
+								 &sym)) {
 			if (!string_builder_appendf(&str,
 						    "%s+0x%" PRIx64 "/0x%" PRIx64,
 						    sym.name, pc - sym.address,
@@ -112,8 +113,8 @@ drgn_stack_frame_symbol(struct drgn_stack_frame frame, struct drgn_symbol **ret)
 	sym = malloc(sizeof(*sym));
 	if (!sym)
 		return &drgn_enomem;
-	if (!drgn_program_find_symbol_internal(frame.trace->prog, pc, module,
-					       sym)) {
+	if (!drgn_program_find_symbol_by_address_internal(frame.trace->prog, pc,
+							  module, sym)) {
 		free(sym);
 		return drgn_error_symbol_not_found(pc);
 	}

--- a/tests/helpers/linux/test_kconfig.py
+++ b/tests/helpers/linux/test_kconfig.py
@@ -1,0 +1,13 @@
+import os.path
+
+from drgn.helpers.linux.kconfig import get_kconfig
+
+from tests.helpers.linux import LinuxHelperTestCase
+
+
+class TestKconfig(LinuxHelperTestCase):
+    def test_get_kconfig(self):
+        if not os.path.isfile("/proc/config.gz"):
+            self.skipTest("kernel not built with CONFIG_IKCONFIG_PROC")
+        m = get_kconfig(self.prog)
+        self.assertIn(m["CONFIG_IKCONFIG"], {"y", "m"})


### PR DESCRIPTION
Since this is my first diff, I would appreciate it if you took a closer look than you normally do, to make sure I'm not overlooking anything.

This should be following the methodology set in #36 pretty exactly. Let me know if anything can be improved though!

I'm not sure if these tests will be fine, if CONFIG_IKCONFIG is not set (as is the case on most systems) I think the test will fail as is. Do you have a way to skip the test in this case, without preventing it from failing if the functionality is actually broken?

Closes #36