### PR TITLE
.editorconfig: Add editorconfig for configuring style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = tab
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.rst]
+indent_style = space
+indent_size = 4
+
+[{makefile, Makefile}*]
+indent_style = tab


### PR DESCRIPTION
Editorconfig is a simple standard for configuring editors based on project specific style settings. I added a basic editorconfig that seems to follow the style of this project (to my knowledge).

- tabs in c code
- 4 spaces in rst and python
- tab override for makefiles (in case the global default changes)