### PR TITLE
Fix leak in kdump code

### DIFF
--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -126,6 +126,7 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 
 	prog->flags |= DRGN_PROGRAM_IS_LINUX_KERNEL;
 	drgn_program_set_platform(prog, &platform);
+	prog->kdump_ctx = ctx;
 	return NULL;
 
 err:


### PR DESCRIPTION
prog->kdump_ctx is never really initialized, and the kdump_ctx struct
allocated in drgn_program_set_kdump() is leaked.

WARNING:
I found this bug while working towards https://github.com/osandov/drgn/issues/24 . Once I applied the changes on this PR and tested my bits, `drgn` would hang on exit. That was due to a bug in libkdumpfile as I found later. I submitted a PR for the latter bug here -> https://github.com/ptesarik/libkdumpfile/pull/26
Please do not merge this until https://github.com/ptesarik/libkdumpfile/pull/26 is merged.
