### PR TITLE
Support stack traces for running threads on kdumps

### DIFF
--- a/libdrgn/linux_kernel.h
+++ b/libdrgn/linux_kernel.h
@@ -34,13 +34,14 @@ linux_kernel_report_debug_info(struct drgn_program *prog,
 #define KDUMP_SIG_LEN (sizeof(KDUMP_SIGNATURE) - 1)
 
 #ifdef WITH_LIBKDUMPFILE
+struct drgn_error *drgn_program_cache_prstatus_kdump(struct drgn_program *prog);
 struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog);
 #else
 static inline struct drgn_error *
 drgn_program_set_kdump(struct drgn_program *prog)
 {
         return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
-	                         "drgn was built without libkdumpfile support");
+				 "drgn was built without libkdumpfile support");
 }
 #endif
 

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -157,6 +157,15 @@ struct drgn_error *drgn_program_get_dwfl(struct drgn_program *prog, Dwfl **ret);
 struct drgn_error *drgn_program_find_prstatus(struct drgn_program *prog,
 					      uint32_t tid, struct string *ret);
 
+/**
+ * Cache the @c NT_PRSTATUS note provided by @p data in @p prog.
+ *
+ * @param[in] data The pointer to the note data.
+ * @param[in] size Size of data in note.
+ */
+struct drgn_error *drgn_program_cache_prstatus_entry(struct drgn_program *prog,
+                                                     char *data, size_t size);
+
 /*
  * Like @ref drgn_program_find_symbol_by_address(), but @p ret is already
  * allocated, we may already know the module, and doesn't return a @ref

--- a/libdrgn/stack_trace.c
+++ b/libdrgn/stack_trace.c
@@ -398,8 +398,12 @@ static bool drgn_thread_set_initial_registers(Dwfl_Thread *thread,
 		}
 	}
 
-	/* Then, try the core dump. */
+	/* Then, try the core dump (and/or kdump if supported). */
+#ifdef WITH_LIBKDUMPFILE
+	if (prog->core || prog->kdump_ctx) {
+#else
 	if (prog->core) {
+#endif
 		uint32_t tid;
 		struct string prstatus;
 


### PR DESCRIPTION
 ### Testing

Dump setup (dump + PRSTATUS notes):
```
$ file dump.201912060006
dump.201912060006: Kdump compressed dump v6, system Linux, node exist2crash.vm, release 5.0.0-36-generic, version #39~18.04.1-Ubuntu SMP Tue Nov 12 11:09:50 UTC 2019, machine x86_64, domain (none)

$ ~/libkdumpfile/examples/dumpattr dump.201912060006 cpu
cpu:
  1:
    pid: 5983
    reg:
      gs: 0
      fs: 0
      ...
      r15: 18446639110723060864
    PRSTATUS: [ 00000000000000000000000000000000000000000000000000000000000000005F1700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080C4796689A0FFFF002ED6CF87A0FFFF80583FC29FF0FFFF002ED6CF87A0FFFFE0B8E9048FB3FFFF0700000000000000000000000000000002000000000000000000000000000000E080020000000000A1DB0FC067C4A4D8000E00000000000005000000000000000036D6CF87A0FFFF002ED6CF87A0FFFFFFFFFFFFFFFFFFFF8024488BFFFFFFFF1000000000000000820201000000000078B8E9048FB3FFFF18000000000000004065AE60157F0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ]
  0:
    pid: 6029
    reg:
      gs: 0
      fs: 0
      ...
      r15: 18446639102305643520
    PRSTATUS: [ 00000000000000000000000000000000000000000000000000000000000000008D17000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002CC27087A0FFFF0200000000000000203E05058FB3FFFFF98D568CFFFFFFFF883D05058FB3FFFF0000000000000000FFFFFFFF000000007754F3C3669041549200000000000000820000000000000001000000000000000017838488A0FFFF00000000000000000017838488A0FFFF00F38B8CFFFFFFFF8B16C28BFFFFFFFFCD5B348BFFFFFFFF10000000000000004600000000000000C83C05058FB3FFFF18000000000000004067334FAA7F0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ]
  number: 2
```

Run drgn to ensure that you can now get stack traces of the running threads in the above setup
```
$ sudo drgn -c dump.201912060006 -s vmlinux-5.0.0-36-generic -s mods/zfs/zfs.ko
could not get debugging information for:
kernel modules (could not read depmod: open: /lib/modules/5.0.0-36-generic/modules.dep.bin: No such file or directory)
drgn 0.0.3+17.g5139616.dirty (using Python 3.6.9, with libkdumpfile)
For help, type help(drgn).
>>> import drgn
>>> from drgn import NULL, Object, cast, container_of, execscript, reinterpret, sizeof
>>> from drgn.helpers.linux import *

>>> a = Object(prog, 'struct task_struct *', value=0xffffa08884831700)
>>> task_state_to_char(a)
'R'
>>> a.pid
(pid_t)6029
>>> prog.stack_trace(a)
#0  __crash_kexec+0x9d/0x11e
#1  panic+0x10e/0x2a4
#2  0xffffffff8b849f25
#3  __handle_sysrq+0x9f/0x162
#4  write_sysrq_trigger+0x34/0x3a
#5  proc_reg_write+0x3e/0x60
#6  __vfs_write+0x1b/0x34
#7  vfs_write+0xb1/0x19c
#8  ksys_write+0x5c/0xd3
#9  __x64_sys_write+0x1a/0x1c
#10 do_syscall_64+0x5a/0x116
#11 entry_SYSCALL_64+0x7c/0x156

>>> a = Object(prog, 'struct task_struct *', value=0xffffa0888cc62e00)
>>> task_state_to_char(a)
'R'
>>> a.pid
(pid_t)5983
>>> prog.stack_trace(a)
#0  new_slab+0x240/0x722
#1  ___slab_alloc+0x393/0x54a
#2  __slab_alloc+0x20/0x33
#3  kmem_cache_alloc+0x182/0x1b6
#4  0xffffffffc03f8866
#5  zio_data_buf_alloc+0x55/0x58
#6  zil_itx_create+0x29/0x58
#7  zfs_log_write+0x124/0x37c
#8  zfs_write+0x68c/0xd6f
#9  zpl_write_common_iovec+0xa5/0x124
#10 zpl_iter_write_common+0x81/0x9e
#11 zpl_iter_write+0x4f/0x70
#12 new_sync_write+0x10c/0x16d
#13 __vfs_write+0x29/0x34
#14 vfs_write+0xb1/0x19c
#15 ksys_write+0x5c/0xd3
#16 __x64_sys_write+0x1a/0x1c
#17 do_syscall_64+0x5a/0x116
#18 entry_SYSCALL_64+0x7c/0x156
```