### PR TITLE
editorconfig: Update styles for pyi and c files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 indent_style = tab
+indent_size = 8
 
-[*.py]
+[*.{py,pyi}]
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
A tiny change to update style a bit: 

- The new `pyi` file should be treated like python
- While I don't like hard-coding tab-sizes, AFAIK the linux style guide says tabs must be at width 8.