### PR TITLE
Add cpp language stub

### DIFF
--- a/libdrgn/language.c
+++ b/libdrgn/language.c
@@ -39,6 +39,40 @@ const struct drgn_language drgn_languages[] = {
 		.op_neg = c_op_neg,
 		.op_not = c_op_not,
 	},
+	[DRGN_LANGUAGE_CPP] = {
+		.name = "C++",
+		.void_type = {
+			{
+				.kind = DRGN_TYPE_VOID,
+				.primitive = DRGN_C_TYPE_VOID,
+				.language = &drgn_language_cpp,
+			},
+		},
+		.format_type_name = c_format_type_name,
+		.format_type = c_format_type,
+		.format_object = c_format_object,
+		.find_type = c_find_type,
+		.bit_offset = c_bit_offset,
+		.integer_literal = c_integer_literal,
+		.bool_literal = c_bool_literal,
+		.float_literal = c_float_literal,
+		.op_cast = c_op_cast,
+		.op_bool = c_op_bool,
+		.op_cmp = c_op_cmp,
+		.op_add = c_op_add,
+		.op_sub = c_op_sub,
+		.op_mul = c_op_mul,
+		.op_div = c_op_div,
+		.op_mod = c_op_mod,
+		.op_lshift = c_op_lshift,
+		.op_rshift = c_op_rshift,
+		.op_and = c_op_and,
+		.op_or = c_op_or,
+		.op_xor = c_op_xor,
+		.op_pos = c_op_pos,
+		.op_neg = c_op_neg,
+		.op_not = c_op_not,
+	},
 };
 
 struct drgn_error *drgn_language_from_die(Dwarf_Die *die,
@@ -54,6 +88,12 @@ struct drgn_error *drgn_language_from_die(Dwarf_Die *die,
 	case DW_LANG_C99:
 	case DW_LANG_C11:
 		*ret = &drgn_language_c;
+		break;
+	case DW_LANG_C_plus_plus:
+	case DW_LANG_C_plus_plus_03:
+	case DW_LANG_C_plus_plus_11:
+	case DW_LANG_C_plus_plus_14:
+		*ret = &drgn_language_cpp;
 		break;
 	default:
 		*ret = NULL;

--- a/libdrgn/language.c
+++ b/libdrgn/language.c
@@ -40,3 +40,24 @@ const struct drgn_language drgn_languages[] = {
 		.op_not = c_op_not,
 	},
 };
+
+struct drgn_error *drgn_language_from_die(Dwarf_Die *die,
+					  const struct drgn_language **ret)
+{
+	Dwarf_Die cudie;
+
+	if (dwarf_cu_info(die->cu, NULL, NULL, &cudie, NULL, NULL, NULL, NULL))
+		return drgn_error_libdw();
+	switch (dwarf_srclang(&cudie)) {
+	case DW_LANG_C:
+	case DW_LANG_C89:
+	case DW_LANG_C99:
+	case DW_LANG_C11:
+		*ret = &drgn_language_c;
+		break;
+	default:
+		*ret = NULL;
+		break;
+	}
+	return NULL;
+}

--- a/libdrgn/language.h
+++ b/libdrgn/language.h
@@ -158,11 +158,13 @@ drgn_unary_op c_op_not;
 
 enum {
 	DRGN_LANGUAGE_C,
+	DRGN_LANGUAGE_CPP,
 	DRGN_NUM_LANGUAGES,
 };
 
 extern const struct drgn_language drgn_languages[DRGN_NUM_LANGUAGES];
 
+#define drgn_language_cpp drgn_languages[DRGN_LANGUAGE_CPP]
 #define drgn_language_c drgn_languages[DRGN_LANGUAGE_C]
 
 /**

--- a/libdrgn/language.h
+++ b/libdrgn/language.h
@@ -164,7 +164,6 @@ enum {
 extern const struct drgn_language drgn_languages[DRGN_NUM_LANGUAGES];
 
 #define drgn_language_c drgn_languages[DRGN_LANGUAGE_C]
-#define drgn_default_language drgn_language_c
 
 /**
  * Return flags that should be passed through when formatting an object
@@ -202,26 +201,25 @@ drgn_element_format_object_flags(enum drgn_format_object_flags flags)
 		(flags & DRGN_FORMAT_OBJECT_ELEMENT_TYPE_NAMES) >> 2);
 }
 
-/** Return the @ref drgn_language corresponding to the given DW_LANG */
-static inline const struct drgn_language *
-drgn_language_from_dw_lang(int dw_lang)
-{
-	switch (dw_lang) {
-	case DW_LANG_C:
-	case DW_LANG_C89:
-	case DW_LANG_C99:
-	case DW_LANG_C11:
-		return &drgn_language_c;
-	default:
-		return &drgn_default_language;
-	}
-}
-
+/**
+ * Return the given @ref drgn_language if it is non-@c NULL or the default if it
+ * is @c NULL.
+ */
 static inline const struct drgn_language *
 drgn_language_or_default(const struct drgn_language *lang)
 {
-	return lang ? lang : &drgn_default_language;
+	return lang ? lang : &drgn_language_c;
 }
+
+/**
+ * Return the @ref drgn_language of the CU of the given DIE.
+ *
+ * @param[out] ret Returned language. May be returned as @c NULL if the language
+ * is unknown.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_language_from_die(Dwarf_Die *die,
+					  const struct drgn_language **ret);
 
 /** @} */
 

--- a/libdrgn/python/language.c
+++ b/libdrgn/python/language.c
@@ -60,6 +60,7 @@ int add_languages(void)
 {
 	static const char *attr_names[] = {
 		[DRGN_LANGUAGE_C] = "C",
+		[DRGN_LANGUAGE_CPP] = "CPP",
 	};
 	size_t i;
 

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -2060,6 +2060,14 @@ class TestProgram(unittest.TestCase):
         self.assertEqual(
             dwarf_program(dies, lang=DW_LANG.BLISS).language, DEFAULT_LANGUAGE
         )
+        self.assertEqual(
+            dwarf_program(dies, lang=DW_LANG.C_plus_plus_14).language, Language.CPP
+        )
+
+        self.assertEqual(
+            dwarf_program(dies, lang=DW_LANG.C_plus_plus).object("main").type_.language,
+            Language.CPP,
+        )
 
     def test_reference_counting(self):
         # Test that we keep the appropriate objects alive even if we don't have

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -1165,6 +1165,10 @@ class TestType(unittest.TestCase):
         self.assertEqual(void_type(language=None).language, DEFAULT_LANGUAGE)
         self.assertEqual(void_type(language=Language.C).language, Language.C)
 
+        self.assertEqual(
+            int_type("int", 4, True, language=Language.CPP).language, Language.CPP
+        )
+
     def test_cmp(self):
         self.assertEqual(void_type(), void_type())
         self.assertEqual(void_type(Qualifiers.CONST), void_type(Qualifiers.CONST))


### PR DESCRIPTION
This is a pretty small and mostly independent change, but I wanted to make sure this is ironed out before moving forward, as there are a couple rough edges I wanted to discuss.

After this, I want to start by tackling the problem of storing template types in `struct drgn_type`, and working on the template support itself (which will probably be another relatively large change).