### PR TITLE
Migrate inline allocation to variable length allocation in drgn_type

### DIFF
--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -446,15 +446,12 @@ struct drgn_type {
 			size_t num_members;
 			struct drgn_type *type;
 		};
+		union {
+			struct drgn_type_member *members;
+			struct drgn_type_enumerator *enumerators;
+			struct drgn_type_parameter *parameters;
+		};
 	} _private;
-	/*
-	 * An array of struct drgn_type_member, struct drgn_type_enumerator, or
-	 * struct drgn_type_parameter may follow. We can't use flexible array
-	 * members for these because they are not allowed in a union or nested
-	 * structure; we can't use GCC's zero length array extension because
-	 * that triggers false positives in Clang's AddressSanitizer. Instead,
-	 * these are accessed internally with drgn_type_payload().
-	 */
 };
 
 /**
@@ -606,11 +603,6 @@ static inline const char *drgn_type_tag(struct drgn_type *type)
 	return type->_private.tag;
 }
 
-static inline void *drgn_type_payload(struct drgn_type *type)
-{
-	return (char *)type + sizeof(*type);
-}
-
 /**
  * Get whether a kind of type has members. This is true for structure, union,
  * and class types.
@@ -633,7 +625,7 @@ static inline bool drgn_type_has_members(struct drgn_type *type)
 static inline struct drgn_type_member *drgn_type_members(struct drgn_type *type)
 {
 	assert(drgn_type_has_members(type));
-	return drgn_type_payload(type);
+	return type->_private.members;
 }
 /**
  * Get the number of members of a type. @ref drgn_type_has_members() must be
@@ -710,7 +702,7 @@ static inline struct drgn_type_enumerator *
 drgn_type_enumerators(struct drgn_type *type)
 {
 	assert(drgn_type_has_enumerators(type));
-	return drgn_type_payload(type);
+	return type->_private.enumerators;
 }
 /**
  * Get the number of enumerators of a type. @ref drgn_type_has_enumerators()
@@ -761,7 +753,7 @@ static inline bool drgn_type_has_parameters(struct drgn_type *type)
 static inline struct drgn_type_parameter *drgn_type_parameters(struct drgn_type *type)
 {
 	assert(drgn_type_has_parameters(type));
-	return drgn_type_payload(type);
+	return type->_private.parameters;
 }
 /**
  * Get the number of parameters of a type. @ref drgn_type_has_parameters() must

--- a/libdrgn/type.c
+++ b/libdrgn/type.c
@@ -258,14 +258,15 @@ void drgn_complex_type_init(struct drgn_type *type, const char *name,
 }
 
 void drgn_struct_type_init(struct drgn_type *type, const char *tag,
-			   uint64_t size, size_t num_members,
-			   const struct drgn_language *lang)
+			   uint64_t size, struct drgn_type_member *members,
+			   size_t num_members, const struct drgn_language *lang)
 {
 	type->_private.kind = DRGN_TYPE_STRUCT;
 	type->_private.is_complete = true;
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.tag = tag;
 	type->_private.size = size;
+	type->_private.members = members;
 	type->_private.num_members = num_members;
 	type->_private.language = drgn_language_or_default(lang);
 }
@@ -278,19 +279,21 @@ void drgn_struct_type_init_incomplete(struct drgn_type *type, const char *tag,
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.tag = tag;
 	type->_private.size = 0;
+	type->_private.members = NULL;
 	type->_private.num_members = 0;
 	type->_private.language = drgn_language_or_default(lang);
 }
 
 void drgn_union_type_init(struct drgn_type *type, const char *tag,
-			  uint64_t size, size_t num_members,
-			  const struct drgn_language *lang)
+			  uint64_t size, struct drgn_type_member *members,
+			  size_t num_members, const struct drgn_language *lang)
 {
 	type->_private.kind = DRGN_TYPE_UNION;
 	type->_private.is_complete = true;
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.tag = tag;
 	type->_private.size = size;
+	type->_private.members = members;
 	type->_private.num_members = num_members;
 	type->_private.language = drgn_language_or_default(lang);
 }
@@ -303,19 +306,21 @@ void drgn_union_type_init_incomplete(struct drgn_type *type, const char *tag,
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.tag = tag;
 	type->_private.size = 0;
+	type->_private.members = NULL;
 	type->_private.num_members = 0;
 	type->_private.language = drgn_language_or_default(lang);
 }
 
 void drgn_class_type_init(struct drgn_type *type, const char *tag,
-			  uint64_t size, size_t num_members,
-			  const struct drgn_language *lang)
+			  uint64_t size, struct drgn_type_member *members,
+			  size_t num_members, const struct drgn_language *lang)
 {
 	type->_private.kind = DRGN_TYPE_CLASS;
 	type->_private.is_complete = true;
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.tag = tag;
 	type->_private.size = size;
+	type->_private.members = members;
 	type->_private.num_members = num_members;
 	type->_private.language = drgn_language_or_default(lang);
 }
@@ -328,12 +333,14 @@ void drgn_class_type_init_incomplete(struct drgn_type *type, const char *tag,
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.tag = tag;
 	type->_private.size = 0;
+	type->_private.members = NULL;
 	type->_private.num_members = 0;
 	type->_private.language = drgn_language_or_default(lang);
 }
 
 void drgn_enum_type_init(struct drgn_type *type, const char *tag,
 			 struct drgn_type *compatible_type,
+			 struct drgn_type_enumerator *enumerators,
 			 size_t num_enumerators,
 			 const struct drgn_language *lang)
 {
@@ -344,6 +351,7 @@ void drgn_enum_type_init(struct drgn_type *type, const char *tag,
 	type->_private.tag = tag;
 	type->_private.type = compatible_type;
 	type->_private.qualifiers = 0;
+	type->_private.enumerators = enumerators;
 	type->_private.num_enumerators = num_enumerators;
 	type->_private.language = drgn_language_or_default(lang);
 }
@@ -357,6 +365,7 @@ void drgn_enum_type_init_incomplete(struct drgn_type *type, const char *tag,
 	type->_private.tag = tag;
 	type->_private.type = NULL;
 	type->_private.qualifiers = 0;
+	type->_private.enumerators = NULL;
 	type->_private.num_enumerators = 0;
 	type->_private.language = drgn_language_or_default(lang);
 }
@@ -420,6 +429,7 @@ void drgn_array_type_init_incomplete(struct drgn_type *type,
 
 void drgn_function_type_init(struct drgn_type *type,
 			     struct drgn_qualified_type return_type,
+			     struct drgn_type_parameter *parameters,
 			     size_t num_parameters, bool is_variadic,
 			     const struct drgn_language *lang)
 {
@@ -428,6 +438,7 @@ void drgn_function_type_init(struct drgn_type *type,
 	type->_private.primitive = DRGN_NOT_PRIMITIVE_TYPE;
 	type->_private.type = return_type.type;
 	type->_private.qualifiers = return_type.qualifiers;
+	type->_private.parameters = parameters;
 	type->_private.num_parameters = num_parameters;
 	type->_private.is_variadic = is_variadic;
 	type->_private.language = drgn_language_or_default(lang);


### PR DESCRIPTION
In anticipation of adding template type pointers in an array to `drgn_type`, I wanted  a way to add additional arrays to this structure. However, currently all variable length arrays are stored by reallocing the drgn_type object to be larger and appended to the object. This works for a single array, but for multiple arrays it won't. 

Since we don't want two methods of storing arrays in drgn_type, and because this was pretty confusing, I refactored the existing arrays into a dynamically allocated array. 

I'm still not 100% sure about the memory allocations (and I'm not sure how to properly run valgrind and other memory debuggers against python/c extensions), so that's the part that will probably need the most review.

After this and #50, I'm going to (hopefully) get template paramter types accessible through drgn!

I'll add more comments below.