### PR TITLE
libdrgn: allow to build without openmp

### DIFF
--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -30,6 +30,8 @@ AS_CASE(["x$enable_openmp"],
 	 OPENMP_LIBS=-l$enable_openmp])
 AC_SUBST(OPENMP_CFLAGS)
 AC_SUBST(OPENMP_LIBS)
+AM_CONDITIONAL([WITH_OPENMP], [test "x$enable_openmp" != xno])
+AM_COND_IF([WITH_OPENMP], [AC_DEFINE(WITH_OPENMP)])
 
 AC_ARG_WITH([python],
 	    [AS_HELP_STRING([--with-python@<:@=ARG@:>@],

--- a/libdrgn/dwarf_index.h
+++ b/libdrgn/dwarf_index.h
@@ -53,9 +53,18 @@ struct drgn_dwarf_index_die;
 DEFINE_HASH_MAP_TYPE(drgn_dwarf_index_die_map, struct string, size_t)
 DEFINE_VECTOR_TYPE(drgn_dwarf_index_die_vector, struct drgn_dwarf_index_die)
 
+#ifndef WITH_OPENMP
+#define omp_init_lock(lock) do {} while(0)
+#define omp_set_lock(lock) do {} while(0)
+#define omp_unset_lock(lock) do {} while(0)
+#define omp_destroy_lock(lock) do {} while(0)
+#endif
+
 struct drgn_dwarf_index_shard {
+#ifdef WITH_OPENMP
 	/** @privatesection */
 	omp_lock_t lock;
+#endif
 	struct drgn_dwarf_index_die_map map;
 	/*
 	 * We store all entries in a shard as a single array, which is more


### PR DESCRIPTION
The configure script allows the user to not use any openmp implementation
but dwarf_index.c uses the locking APIs unconditionally.

Adding simple stubs for the locking API and allows it to build properly.
This is useful when debugging crashes in dwarf indexing during development.