### PR TITLE
Enable DWARF indexing to work with partial units

### DIFF
--- a/libdrgn/dwarf_index.c
+++ b/libdrgn/dwarf_index.c
@@ -1410,7 +1410,8 @@ static struct drgn_error *read_abbrev_decl(const char **ptr, const char *end,
 		break;
 	}
 
-	if (should_index || tag == DW_TAG_compile_unit)
+	if (should_index || tag == DW_TAG_compile_unit ||
+	    tag == DW_TAG_partial_unit)
 		die_flags = tag;
 	else
 		die_flags = 0;
@@ -1470,7 +1471,8 @@ static struct drgn_error *read_abbrev_decl(const char **ptr, const char *end,
 				break;
 			}
 		} else if (name == DW_AT_stmt_list &&
-			   tag == DW_TAG_compile_unit &&
+			   (tag == DW_TAG_compile_unit ||
+			    tag == DW_TAG_partial_unit) &&
 			   cu->sections[SECTION_DEBUG_LINE]) {
 			switch (form) {
 			case DW_FORM_data4:
@@ -2100,7 +2102,7 @@ static struct drgn_error *index_cu(struct drgn_dwarf_index *dindex,
 		}
 
 		tag = die.flags & TAG_MASK;
-		if (tag == DW_TAG_compile_unit) {
+		if (tag == DW_TAG_compile_unit || tag == DW_TAG_partial_unit) {
 			if (depth == 0 && die.stmt_list != SIZE_MAX &&
 			    (err = read_file_name_table(dindex, cu,
 							die.stmt_list,


### PR DESCRIPTION
Loading debuginfo from a kernel with separate or re-combined debuginfo
results in the following failure:

Traceback (most recent call last):
  File "/home/jeffm/.local/bin/drgn", line 11, in <module>
    load_entry_point('drgn==0.0.3+39.gbf05d9bf', 'console_scripts', 'drgn')()
  File "/home/jeffm/.local/lib/python3.6/site-packages/drgn-0.0.3+39.gbf05d9bf-py3.6-linux-x86_64.egg/drgn/internal/cli.py", line 121, in main
    prog.load_debug_info(args.symbols, **args.default_symbols)
Exception: invalid DW_AT_decl_file 10

A typical kernel build results in DWARF information with
DW_TAG_compile_unit tags but the objcopy --only-keep-debug and eu-unstrip
commands use DW_TAG_partial_unit tags.  The DWARF indexer only handles
the former, so the file table isn't populated and we get the exception.

Fortunately, the two are more or less interchangeable. (See
http://dwarfstd.org/doc/Dwarf3.pdf, section E.2.3).  Accepting both for
indexing compile units results in a working session.

The RPMs that SUSE ships contain stripped binaries with optional packages available for download that contain only the debuginfo. This change is mandatory for working with our kernel packages.