### PR TITLE
libdrgn: Make CUs persistent through dwfl module userdata

### DIFF
--- a/libdrgn/dwarf_index.h
+++ b/libdrgn/dwarf_index.h
@@ -133,6 +133,8 @@ struct drgn_dwfl_module_userdata {
 	Elf *elf;
 	int fd;
 	enum drgn_dwarf_module_state state;
+	struct compilation_unit *cus;
+	size_t num_cus;
 };
 
 DEFINE_VECTOR_TYPE(drgn_dwarf_module_vector, struct drgn_dwarf_module *)


### PR DESCRIPTION
No rush on this, I'm just putting this up so it's ready to review once everything settles down.

This is a quick diff to try to make CUs persistent, by attaching them to DWFL userdata. In the process I removed the temporary arrays being used to store CUs entirely, and instead just stored the CUs directly in the userdata to begin with. Then the code that used to read the CU array pulls from the dwfl userdata. 

I'm not sure if these userdata objects stick around, if they don't there might be an issue. Another quirk is that only one of the module objects in the array actually has a CU associated with it (I think) so there is a little bit of unneeded iteration to find that module. I also think the omp parallelization might not be as efficient as it used to be, are there any perf tests I can use to evaluate that?

Right now I'm just storing the abbrev table in the CUs, but it should be trivial to store more information. On the namespace diff, I'm planning on just keeping a pointer to the CU object (which shouldn't be deleted), and through that getting any information we might need.