### PR TITLE
Stack vars poc3

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -1046,6 +1046,15 @@ class StackFrame:
     """
     A ``StackFrame`` represents a single *frame* (i.e., function call) in a
     thread's call stack.
+
+    :class:`str() <str>` returns a pretty-printed stack frame:
+
+    >>> prog.stack_trace(1)[0]
+    #0 at 0xffffffff9a883039 (__schedule+0x2c9/0x75d)
+
+    This includes more information than when printing the full stack trace. The
+    drgn CLI is set up so that stack frames are displayed with ``str()`` by
+    default.
     """
 
     pc: int

--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -21,6 +21,10 @@ from typing import (
     overload,
 )
 
+# OrderedDict was added to Python 3.8's typing module but it's broken
+# and fails with error: Variable "typing.OrderedDict" is not valid as a type
+OrderedDict = Dict
+
 class Program:
     """
     A ``Program`` represents a crashed or running program. It can be used to
@@ -1090,6 +1094,17 @@ class StackFrame:
     An inline frame shares the same stack frame in memory as its caller.
     Therefore, it has the same registers (including program counter and thus
     symbol).
+
+    The variables and parameters within the frame can be accessed directly
+    by name using the :meth:`[] <.__getitem__>` operator.
+    """
+
+    parameters: OrderedDict[str, Object]
+    """
+    The parameters passed to this function.
+
+    The objects representing the parameters will contain the current values,
+    which may be different than the values passed to the function initially.
     """
 
     pc: int
@@ -1101,6 +1116,15 @@ class StackFrame:
     generally the return address, i.e., the value of the program counter when
     control returns to this frame.
     """
+
+    variables: Dict[str, Object]
+    """
+    The variables available within this stack frame.
+
+    If a variable shadows another with the same name, the one in the
+    in the deepest scope will be used.
+    """
+
     def source(self) -> Tuple[str, int, int]:
         """
         Get the source code location of this frame.

--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -720,6 +720,7 @@ class Object:
 
         :param idx: The array index.
         :raises TypeError: if this object is not a pointer or array
+        :raises FaultError: if the pointer points to an invalid location
         """
         ...
     def __len__(self) -> int:

--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -599,12 +599,15 @@ class Object:
     * Bitwise operators: ``<<``, ``>>``, ``&``, ``|``, ``^``, ``~``
     * Relational operators: ``==``, ``!=``, ``<``, ``>``, ``<=``, ``>=``
     * Subscripting: :meth:`[] <__getitem__>` (Python does not have a unary
-      ``*`` operator, so pointers are dereferenced with ``ptr[0]``)
+      ``*`` operator, so pointers are dereferenced with ``ptr[0]`` or with
+      the :meth:`drgn.Object.dereference_()` method)
     * Member access: :meth:`. <__getattribute__>` (Python does not have a
       ``->`` operator, so ``.`` is also used to access members of pointers to
       structures)
     * The address-of operator: :meth:`drgn.Object.address_of_()` (this is a
       method because Python does not have a ``&`` operator)
+    * The dereference operator: :meth:`drgn.Object.dereference_()` (this is a
+      method because Python does not have a ``*`` operator)
     * Array length: :meth:`len() <__len__>`
 
     These operators all have the semantics of the program's programming
@@ -796,6 +799,19 @@ class Object:
         ``int``.
 
         :raises ValueError: if this object is a value
+        """
+        ...
+    def dereference_(self) -> Object:
+        """
+        Get the target object pointed to by this object.
+
+        This corresponds to the dereference (``*``) operator in C. It is only
+        possible for pointer type objects.
+
+        This is equivalent to subscripting the object with an index of ``0``.
+
+        :raises TypeError: if this object is is not a pointer type
+        :raises FaultError: if the pointer points to an invalid location
         """
         ...
     def read_(self) -> Object:

--- a/drgn/internal/cli.py
+++ b/drgn/internal/cli.py
@@ -24,7 +24,7 @@ def displayhook(value: Any) -> None:
     setattr(builtins, "_", None)
     if isinstance(value, drgn.Object):
         text = value.format_(columns=shutil.get_terminal_size((0, 0)).columns)
-    elif isinstance(value, (drgn.StackTrace, drgn.Type)):
+    elif isinstance(value, (drgn.StackFrame, drgn.StackTrace, drgn.Type)):
         text = str(value)
     else:
         text = repr(value)

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -55,6 +55,7 @@ libdrgnimpl_la_SOURCES = $(ARCH_INS:.c.in=.c) \
 			 siphash.h \
 			 splay_tree.c \
 			 stack_trace.c \
+			 stack_trace.h \
 			 string_builder.c \
 			 string_builder.h \
 			 symbol.c \

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2423,12 +2423,10 @@ size_t drgn_stack_trace_num_frames(struct drgn_stack_trace *trace);
 /**
  * Format a stack trace as a string.
  *
- * @param[out] ret Returned string. On success, it must be freed with @c free().
- * On error, its contents are undefined.
- * @return @c NULL on success, non-@c NULL on error.
+ * @return Non-@c NULL string on success (must be freed with @c free()), @c NULL
+ * if memory could not be allocated.
  */
-struct drgn_error *drgn_format_stack_trace(struct drgn_stack_trace *trace,
-					   char **ret);
+char *drgn_format_stack_trace(struct drgn_stack_trace *trace);
 
 /** Get the return address at a stack frame. */
 uint64_t drgn_stack_frame_pc(struct drgn_stack_frame frame);

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2409,16 +2409,11 @@ bool drgn_symbol_eq(struct drgn_symbol *a, struct drgn_symbol *b);
 
 struct drgn_stack_trace;
 
-struct drgn_stack_frame {
-	struct drgn_stack_trace *trace;
-	size_t i;
-};
-
 /** Destroy a @ref drgn_stack_trace. */
 void drgn_stack_trace_destroy(struct drgn_stack_trace *trace);
 
 /** Get the number of stack frames in a stack trace. */
-size_t drgn_stack_trace_num_frames(struct drgn_stack_trace *trace);
+int drgn_stack_trace_num_frames(struct drgn_stack_trace *trace);
 
 /**
  * Format a stack trace as a string.
@@ -2429,7 +2424,7 @@ size_t drgn_stack_trace_num_frames(struct drgn_stack_trace *trace);
 char *drgn_format_stack_trace(struct drgn_stack_trace *trace);
 
 /** Get the return address at a stack frame. */
-uint64_t drgn_stack_frame_pc(struct drgn_stack_frame frame);
+uint64_t drgn_stack_frame_pc(struct drgn_stack_trace *trace, int frame);
 
 /**
  * Get the function symbol at a stack frame.
@@ -2438,17 +2433,18 @@ uint64_t drgn_stack_frame_pc(struct drgn_stack_frame frame);
  * drgn_symbol_destroy(). On error, its contents are undefined.
  * @return @c NULL on success, non-@c NULL on error.
  */
-struct drgn_error *drgn_stack_frame_symbol(struct drgn_stack_frame frame,
-					   struct drgn_symbol **ret);
+struct drgn_error *drgn_stack_frame_symbol(struct drgn_stack_trace *trace,
+					   int frame, struct drgn_symbol **ret);
 
 /** Get the value of a register (by number) in a stack frame. */
-struct drgn_error *drgn_stack_frame_register(struct drgn_stack_frame frame,
+struct drgn_error *drgn_stack_frame_register(struct drgn_stack_trace *trace,
+					     int frame,
 					     enum drgn_register_number regno,
 					     uint64_t *ret);
 
 /** Get the value of a register (by name) in a stack frame. */
 struct drgn_error *
-drgn_stack_frame_register_by_name(struct drgn_stack_frame frame,
+drgn_stack_frame_register_by_name(struct drgn_stack_trace *trace, int frame,
 				  const char *name, uint64_t *ret);
 
 /**

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2431,6 +2431,16 @@ char *drgn_format_stack_trace(struct drgn_stack_trace *trace);
  */
 char *drgn_format_stack_frame(struct drgn_stack_trace *trace, int frame);
 
+/* TODO */
+const char *drgn_stack_frame_name(struct drgn_stack_trace *trace, int frame);
+
+/* TODO */
+bool drgn_stack_frame_is_inline(struct drgn_stack_trace *trace, int frame);
+
+/* TODO */
+const char *drgn_stack_frame_source(struct drgn_stack_trace *trace, int frame,
+				    int *line_ret, int *column_ret);
+
 /** Get the return address at a stack frame. */
 uint64_t drgn_stack_frame_pc(struct drgn_stack_trace *trace, int frame);
 

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2423,6 +2423,14 @@ int drgn_stack_trace_num_frames(struct drgn_stack_trace *trace);
  */
 char *drgn_format_stack_trace(struct drgn_stack_trace *trace);
 
+/**
+ * Format a stack frame as a string.
+ *
+ * @return Non-@c NULL string on success (must be freed with @c free()), @c NULL
+ * if memory could not be allocated.
+ */
+char *drgn_format_stack_frame(struct drgn_stack_trace *trace, int frame);
+
 /** Get the return address at a stack frame. */
 uint64_t drgn_stack_frame_pc(struct drgn_stack_trace *trace, int frame);
 

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -75,6 +75,16 @@ enum drgn_error_code {
 	DRGN_ERROR_ZERO_DIVISION,
 	/** Array out of bounds */
 	DRGN_ERROR_OUT_OF_BOUNDS,
+	/** Variable was optimized out: No location debuginfo found */
+	DRGN_ERROR_VAR_OPTIMIZED_OUT,
+	/** Location debuginfo is present but not for the described address */
+	DRGN_ERROR_VAR_LOCATION_UNAVAILABLE,
+	/**
+	 * Location debuginfo is present for the described address but
+	 * obtaining the value isn't possible.  This is usually due to
+	 * the registers not being populated initially.
+	 */
+	DRGN_ERROR_VAR_VALUE_UNAVAILABLE,
 	/** Number of defined error codes. */
 	DRGN_NUM_ERROR_CODES,
 } __attribute__((packed));
@@ -1647,6 +1657,8 @@ struct drgn_object {
 	bool is_reference;
 	/** Whether this object is a bit field. */
 	bool is_bit_field;
+	/** Whether this object is on the stack and needs to be evaluated. */
+	bool needs_stack_evaluation;
 	/** Reference to this object in @ref drgn_object::prog, or its value. */
 	union {
 		/** Value. */
@@ -1664,6 +1676,8 @@ struct drgn_object {
 			/** Whether the referenced object is little-endian. */
 			bool little_endian;
 		} reference;
+		/** The context for objects located on the stack */
+		struct drgn_stack_object *stack;
 	};
 };
 
@@ -2465,6 +2479,41 @@ struct drgn_error *
 drgn_stack_frame_register_by_name(struct drgn_stack_trace *trace, int frame,
 				  const char *name, uint64_t *ret);
 
+/** Get the number of parameters to the function in a stack frame. */
+struct drgn_error *
+drgn_stack_frame_num_parameters(struct drgn_stack_trace *trace, int frame,
+				size_t *count);
+
+/** Get the value of a parameter (by name) in a stack frame. */
+struct drgn_error *
+drgn_stack_frame_parameter_by_name(struct drgn_stack_trace *trace, int frame,
+				   const char *name,
+				   struct drgn_object *ret_obj);
+
+/** Get the value of a parameter (by index) in a stack frame. */
+struct drgn_error *
+drgn_stack_frame_parameter_by_index(struct drgn_stack_trace *trace, int frame,
+				    size_t index, const char **name,
+				    struct drgn_object *ret_obj);
+
+/** Get the number of variables in a stack frame. */
+struct drgn_error *
+drgn_stack_frame_num_variables(struct drgn_stack_trace *trace, int frame,
+			       size_t *count);
+
+/** Get the value of a variable (by name) in a stack frame. */
+struct drgn_error *
+drgn_stack_frame_variable_by_name(struct drgn_stack_trace *trace, int frame,
+				  const char *name,
+				  struct drgn_object *ret_obj);
+
+/** Get the value of a variable (by index) in a stack frame. */
+struct drgn_error *
+drgn_stack_frame_variable_by_index(struct drgn_stack_trace *trace, int frame,
+				   size_t index, const char **name,
+				   struct drgn_object *ret_obj);
+
+
 /**
  * Get a stack trace for the thread with the given thread ID.
  *
@@ -2484,6 +2533,17 @@ struct drgn_error *drgn_program_stack_trace(struct drgn_program *prog,
 struct drgn_error *drgn_object_stack_trace(const struct drgn_object *obj,
 					   struct drgn_stack_trace **ret);
 
+/**
+ * Get the location (or value) for a variable or parameter located on the
+ * stack represented by @p obj.
+ *
+ * @param[out] address Returned address if @p is_reference is true.
+ * Otherwise, the value contained within a register.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *
+drgn_stack_frame_object_location(const struct drgn_object *obj,
+				 uint64_t *address, bool *is_reference);
 /** @} */
 
 #endif /* DRGN_H */

--- a/libdrgn/dwarf_info_cache.h
+++ b/libdrgn/dwarf_info_cache.h
@@ -98,6 +98,15 @@ drgn_dwarf_object_find(const char *name, size_t name_len, const char *filename,
 		       enum drgn_find_object_flags flags, void *arg,
 		       struct drgn_object *ret);
 
+struct drgn_error *
+drgn_type_from_dwarf_child(struct drgn_dwarf_info_cache *dicache,
+			   Dwarf_Die *parent_die,
+			   const struct drgn_language *parent_lang,
+			   const char *tag_name,
+			   bool can_be_void, bool can_be_incomplete_array,
+			   bool *is_incomplete_array_ret,
+			   struct drgn_qualified_type *ret);
+
 /** @} */
 
 #endif /* DRGN_DWARF_INFO_CACHE_H */

--- a/libdrgn/elfutils/libdw/libdw.h
+++ b/libdrgn/elfutils/libdw/libdw.h
@@ -834,6 +834,9 @@ extern int dwarf_default_lower_bound (int lang, Dwarf_Sword *result)
 extern int dwarf_getscopes (Dwarf_Die *cudie, Dwarf_Addr pc,
 			    Dwarf_Die **scopes);
 
+extern int dwarf_getallscopes (Dwarf_Die *cudie, Dwarf_Addr pc,
+			       Dwarf_Die **scopes);
+
 /* Return scope DIEs containing the given DIE.
    Sets *SCOPES to a malloc'd array of Dwarf_Die structures,
    and returns the number of elements in the array.

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -1469,6 +1469,7 @@ static struct drgn_error *report_vmlinux(struct drgn_program *prog,
 		 * information, so check for those first.
 		 */
 		"/usr/lib/debug/boot/vmlinux-%s",
+		"/usr/lib/debug/boot/vmlinux-%s.debug",
 		"/usr/lib/debug/lib/modules/%s/vmlinux",
 		"/boot/vmlinux-%s",
 		"/lib/modules/%s/build/vmlinux",

--- a/libdrgn/object.h
+++ b/libdrgn/object.h
@@ -104,6 +104,7 @@ static inline void drgn_object_reinit(struct drgn_object *obj,
 	obj->bit_size = bit_size;
 	obj->is_bit_field = type->bit_field_size != 0;
 	obj->is_reference = is_reference;
+	obj->needs_stack_evaluation = false;
 }
 
 /**

--- a/libdrgn/python/drgnpy.h
+++ b/libdrgn/python/drgnpy.h
@@ -97,14 +97,13 @@ typedef struct {
 
 typedef struct {
 	PyObject_HEAD
-	Program *prog;
 	struct drgn_stack_trace *trace;
 } StackTrace;
 
 typedef struct {
 	PyObject_HEAD
 	StackTrace *trace;
-	struct drgn_stack_frame frame;
+	int i;
 } StackFrame;
 
 typedef struct {

--- a/libdrgn/python/error.c
+++ b/libdrgn/python/error.c
@@ -178,6 +178,7 @@ DRGNPY_PUBLIC void *set_drgn_error(struct drgn_error *err)
 		PyErr_SetString(PyExc_SyntaxError, err->message);
 		break;
 	case DRGN_ERROR_LOOKUP:
+	case DRGN_ERROR_VAR_OPTIMIZED_OUT:
 		PyErr_SetString(PyExc_LookupError, err->message);
 		break;
 	case DRGN_ERROR_FAULT: {
@@ -197,6 +198,10 @@ DRGNPY_PUBLIC void *set_drgn_error(struct drgn_error *err)
 		break;
 	case DRGN_ERROR_OUT_OF_BOUNDS:
 		PyErr_SetString(OutOfBoundsError, err->message);
+		break;
+	case DRGN_ERROR_VAR_VALUE_UNAVAILABLE:
+	case DRGN_ERROR_VAR_LOCATION_UNAVAILABLE:
+		PyErr_SetString(PyExc_ValueError, err->message);
 		break;
 	default:
 		PyErr_SetString(PyExc_Exception, err->message);

--- a/libdrgn/python/object.c
+++ b/libdrgn/python/object.c
@@ -1554,6 +1554,20 @@ static DrgnObject *DrgnObject_subscript(DrgnObject *self, PyObject *key)
 	return DrgnObject_subscript_impl(self, index.svalue);
 }
 
+static DrgnObject *DrgnObject_dereference(DrgnObject *self)
+{
+	struct drgn_type *underlying_type;
+
+	underlying_type = drgn_underlying_type(self->obj.type);
+	if (drgn_type_kind(underlying_type) != DRGN_TYPE_POINTER) {
+		set_error_type_name("'%s' is not a pointer type",
+				    drgn_object_qualified_type(&self->obj));
+		return NULL;
+	}
+
+	return DrgnObject_subscript_impl(self, 0);
+}
+
 static ObjectIterator *DrgnObject_iter(DrgnObject *self)
 {
 	struct drgn_type *underlying_type;
@@ -1671,6 +1685,8 @@ static PyMethodDef DrgnObject_methods[] = {
 	 METH_VARARGS | METH_KEYWORDS, drgn_Object_member__DOC},
 	{"address_of_", (PyCFunction)DrgnObject_address_of, METH_NOARGS,
 	 drgn_Object_address_of__DOC},
+	{"dereference_", (PyCFunction)DrgnObject_dereference, METH_NOARGS,
+	 drgn_Object_dereference__DOC},
 	{"read_", (PyCFunction)DrgnObject_read, METH_NOARGS,
 	 drgn_Object_read__DOC},
 	{"format_", (PyCFunction)DrgnObject_format,

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -750,7 +750,6 @@ static StackTrace *Program_stack_trace(Program *self, PyObject *args,
 		return NULL;
 	}
 	ret->trace = trace;
-	ret->prog = self;
 	Py_INCREF(self);
 	return ret;
 }

--- a/libdrgn/python/stack_trace.c
+++ b/libdrgn/python/stack_trace.c
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0+
 
 #include "drgnpy.h"
+#include "../stack_trace.h"
 
 static void StackTrace_dealloc(StackTrace *self)
 {
+	struct drgn_program *prog = self->trace->prog;
+
 	drgn_stack_trace_destroy(self->trace);
-	Py_XDECREF(self->prog);
+	Py_XDECREF(container_of(prog, Program, prog));
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
@@ -40,8 +43,7 @@ static StackFrame *StackTrace_item(StackTrace *self, Py_ssize_t i)
 	ret = (StackFrame *)StackFrame_type.tp_alloc(&StackFrame_type, 0);
 	if (!ret)
 		return NULL;
-	ret->frame.trace = self->trace;
-	ret->frame.i = i;
+	ret->i = i;
 	ret->trace = self;
 	Py_INCREF(self);
 	return ret;
@@ -72,13 +74,14 @@ static void StackFrame_dealloc(StackFrame *self)
 static PyObject *StackFrame_symbol(StackFrame *self)
 {
 	struct drgn_error *err;
+	Program *prog = container_of(self->trace->trace->prog, Program, prog);
 	struct drgn_symbol *sym;
 	PyObject *ret;
 
-	err = drgn_stack_frame_symbol(self->frame, &sym);
+	err = drgn_stack_frame_symbol(self->trace->trace, self->i, &sym);
 	if (err)
 		return set_drgn_error(err);
-	ret = Symbol_wrap(sym, self->trace->prog);
+	ret = Symbol_wrap(sym, prog);
 	if (!ret) {
 		drgn_symbol_destroy(sym);
 		return NULL;
@@ -92,7 +95,8 @@ static PyObject *StackFrame_register(StackFrame *self, PyObject *arg)
 	uint64_t value;
 
 	if (PyUnicode_Check(arg)) {
-		err = drgn_stack_frame_register_by_name(self->frame,
+		err = drgn_stack_frame_register_by_name(self->trace->trace,
+							self->i,
 							PyUnicode_AsUTF8(arg),
 							&value);
 	} else {
@@ -102,8 +106,8 @@ static PyObject *StackFrame_register(StackFrame *self, PyObject *arg)
 			arg = PyStructSequence_GET_ITEM(arg, 1);
 		if (!index_converter(arg, &number))
 			return NULL;
-		err = drgn_stack_frame_register(self->frame, number.uvalue,
-						&value);
+		err = drgn_stack_frame_register(self->trace->trace, self->i,
+						number.uvalue, &value);
 	}
 	if (err)
 		return set_drgn_error(err);
@@ -120,7 +124,7 @@ static PyObject *StackFrame_registers(StackFrame *self)
 	dict = PyDict_New();
 	if (!dict)
 		return NULL;
-	platform = drgn_program_platform(&self->trace->prog->prog);
+	platform = drgn_program_platform(self->trace->trace->prog);
 	num_registers = drgn_platform_num_registers(platform);
 	for (i = 0; i < num_registers; i++) {
 		const struct drgn_register *reg;
@@ -129,7 +133,7 @@ static PyObject *StackFrame_registers(StackFrame *self)
 		int ret;
 
 		reg = drgn_platform_register(platform, i);
-		err = drgn_stack_frame_register(self->frame,
+		err = drgn_stack_frame_register(self->trace->trace, self->i,
 						drgn_register_number(reg),
 						&value);
 		if (err) {
@@ -154,7 +158,10 @@ static PyObject *StackFrame_registers(StackFrame *self)
 
 static PyObject *StackFrame_get_pc(StackFrame *self, void *arg)
 {
-	return PyLong_FromUnsignedLongLong(drgn_stack_frame_pc(self->frame));
+	uint64_t pc;
+
+	pc = drgn_stack_frame_pc(self->trace->trace, self->i);
+	return PyLong_FromUnsignedLongLong(pc);
 }
 
 static PyMethodDef StackFrame_methods[] = {

--- a/libdrgn/python/stack_trace.c
+++ b/libdrgn/python/stack_trace.c
@@ -12,14 +12,12 @@ static void StackTrace_dealloc(StackTrace *self)
 
 static PyObject *StackTrace_str(StackTrace *self)
 {
-	struct drgn_error *err;
 	PyObject *ret;
 	char *str;
 
-	err = drgn_format_stack_trace(self->trace, &str);
-	if (err)
-		return set_drgn_error(err);
-
+	str = drgn_format_stack_trace(self->trace);
+	if (!str)
+		return PyErr_NoMemory();
 	ret = PyUnicode_FromString(str);
 	free(str);
 	return ret;

--- a/libdrgn/python/stack_trace.c
+++ b/libdrgn/python/stack_trace.c
@@ -71,6 +71,19 @@ static void StackFrame_dealloc(StackFrame *self)
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
+static PyObject *StackFrame_str(StackFrame *self)
+{
+	PyObject *ret;
+	char *str;
+
+	str = drgn_format_stack_frame(self->trace->trace, self->i);
+	if (!str)
+		return PyErr_NoMemory();
+	ret = PyUnicode_FromString(str);
+	free(str);
+	return ret;
+}
+
 static PyObject *StackFrame_symbol(StackFrame *self)
 {
 	struct drgn_error *err;
@@ -184,6 +197,7 @@ PyTypeObject StackFrame_type = {
 	.tp_name = "_drgn.StackFrame",
 	.tp_basicsize = sizeof(StackFrame),
 	.tp_dealloc = (destructor)StackFrame_dealloc,
+	.tp_str = (reprfunc)StackFrame_str,
 	.tp_flags = Py_TPFLAGS_DEFAULT,
 	.tp_doc = drgn_StackFrame_DOC,
 	.tp_methods = StackFrame_methods,

--- a/libdrgn/python/stack_trace.c
+++ b/libdrgn/python/stack_trace.c
@@ -84,6 +84,22 @@ static PyObject *StackFrame_str(StackFrame *self)
 	return ret;
 }
 
+static PyObject *StackFrame_source(StackFrame *self)
+{
+	const char *filename;
+	int line;
+	int column;
+
+	filename = drgn_stack_frame_source(self->trace->trace, self->i, &line,
+					   &column);
+	if (!filename) {
+		PyErr_SetString(PyExc_LookupError,
+				"source code location not available");
+		return NULL;
+	}
+	return Py_BuildValue("sii", filename, line, column);
+}
+
 static PyObject *StackFrame_symbol(StackFrame *self)
 {
 	struct drgn_error *err;
@@ -169,6 +185,25 @@ static PyObject *StackFrame_registers(StackFrame *self)
 	return dict;
 }
 
+static PyObject *StackFrame_get_name(StackFrame *self, void *arg)
+{
+	const char *name;
+
+	name = drgn_stack_frame_name(self->trace->trace, self->i);
+	if (name)
+		return PyUnicode_FromString(name);
+	else
+		Py_RETURN_NONE;
+}
+
+static PyObject *StackFrame_get_is_inline(StackFrame *self, void *arg)
+{
+	if (drgn_stack_frame_is_inline(self->trace->trace, self->i))
+		Py_RETURN_TRUE;
+	else
+		Py_RETURN_FALSE;
+}
+
 static PyObject *StackFrame_get_pc(StackFrame *self, void *arg)
 {
 	uint64_t pc;
@@ -178,6 +213,8 @@ static PyObject *StackFrame_get_pc(StackFrame *self, void *arg)
 }
 
 static PyMethodDef StackFrame_methods[] = {
+	{"source", (PyCFunction)StackFrame_source, METH_NOARGS,
+	 drgn_StackFrame_source_DOC},
 	{"symbol", (PyCFunction)StackFrame_symbol, METH_NOARGS,
 	 drgn_StackFrame_symbol_DOC},
 	{"register", (PyCFunction)StackFrame_register,
@@ -188,6 +225,9 @@ static PyMethodDef StackFrame_methods[] = {
 };
 
 static PyGetSetDef StackFrame_getset[] = {
+	{"name", (getter)StackFrame_get_name, NULL, drgn_StackFrame_name_DOC},
+	{"is_inline", (getter)StackFrame_get_is_inline, NULL,
+	 drgn_StackFrame_is_inline_DOC},
 	{"pc", (getter)StackFrame_get_pc, NULL, drgn_StackFrame_pc_DOC},
 	{},
 };

--- a/libdrgn/python/stack_trace.c
+++ b/libdrgn/python/stack_trace.c
@@ -204,6 +204,150 @@ static PyObject *StackFrame_get_is_inline(StackFrame *self, void *arg)
 		Py_RETURN_FALSE;
 }
 
+static PyObject *StackFrame_parameters(StackFrame *self, void *arg)
+{
+	Program *prog = container_of(self->trace->trace->prog, Program, prog);
+	DrgnObject *ret;
+	struct drgn_error *err;
+	PyObject *parameters_obj;
+	size_t num_parameters, i;
+
+	parameters_obj = PyODict_New();
+	if (!parameters_obj)
+		return NULL;
+
+	err = drgn_stack_frame_num_parameters(self->trace->trace, self->i,
+					      &num_parameters);
+	if (err) {
+		set_drgn_error(err);
+		goto err;
+	}
+
+	for (i = 0; i < num_parameters; i++) {
+		const char *pname;
+		PyObject *name;
+
+		ret = DrgnObject_alloc(prog);
+		if (!ret)
+			goto err;
+
+		err = drgn_stack_frame_parameter_by_index(self->trace->trace,
+							  self->i, i,
+							  &pname, &ret->obj);
+		if (err) {
+			set_drgn_error(err);
+			Py_DECREF(ret);
+			goto err;
+		}
+
+		name = PyUnicode_FromString(pname);
+		if (!name) {
+			Py_DECREF(ret);
+			goto err;
+		}
+
+		PyODict_SetItem(parameters_obj, name, (PyObject *)ret);
+	}
+
+	return parameters_obj;
+err:
+	Py_DECREF(parameters_obj);
+	return NULL;
+}
+
+static PyObject *StackFrame_variables(StackFrame *self, void *arg)
+{
+	Program *prog = container_of(self->trace->trace->prog, Program, prog);
+	struct drgn_error *err;
+	size_t num_variables;
+	PyObject *dict;
+	int i;
+
+	dict = PyDict_New();
+	if (!dict)
+		return NULL;
+
+	err = drgn_stack_frame_num_variables(self->trace->trace, self->i,
+					     &num_variables);
+	if (err) {
+		if (err->code == DRGN_ERROR_LOOKUP)
+			return dict;
+		Py_DECREF(dict);
+		set_drgn_error(err);
+		return NULL;
+	}
+
+	/*
+	 * Iterate the variables in reverse order so that shadowed variables
+	 * in outer scopes are properly obscured.
+	 */
+	for (i = num_variables - 1; i >= 0; i--) {
+		const char *name;
+		DrgnObject *ret;
+
+		ret = DrgnObject_alloc(prog);
+		if (!ret)
+			goto error;
+
+		err = drgn_stack_frame_variable_by_index(self->trace->trace,
+							 self->i, i, &name,
+							 &ret->obj);
+		if (err) {
+			Py_DECREF((PyObject *)ret);
+			set_drgn_error(err);
+			goto error;
+		}
+
+		if (PyDict_SetItemString(dict, name, (PyObject *)ret)) {
+			Py_DECREF(Py_None);
+			goto error;
+		}
+	}
+
+	return dict;
+
+error:
+	Py_DECREF(dict);
+	return NULL;
+}
+
+static DrgnObject *StackFrame_subscript(StackFrame *self, PyObject *key)
+{
+	Program *prog = container_of(self->trace->trace->prog, Program, prog);
+	struct drgn_error *err;
+	const char *name;
+	DrgnObject *ret;
+
+	if (!PyUnicode_Check(key)) {
+		PyErr_SetObject(PyExc_KeyError, key);
+		return NULL;
+	}
+
+	name = PyUnicode_AsUTF8(key);
+	if (!name)
+		return NULL;
+
+	ret = DrgnObject_alloc(prog);
+	if (!ret)
+		return NULL;
+
+	err = drgn_stack_frame_variable_by_name(self->trace->trace, self->i,
+						name, &ret->obj);
+	if (err && err->code != DRGN_ERROR_LOOKUP) {
+		set_drgn_error(err);
+		return NULL;
+	}
+
+	err = drgn_stack_frame_parameter_by_name(self->trace->trace, self->i,
+						 name, &ret->obj);
+	if (err) {
+		set_drgn_error(err);
+		return NULL;
+	}
+
+	return ret;
+}
+
 static PyObject *StackFrame_get_pc(StackFrame *self, void *arg)
 {
 	uint64_t pc;
@@ -229,7 +373,15 @@ static PyGetSetDef StackFrame_getset[] = {
 	{"is_inline", (getter)StackFrame_get_is_inline, NULL,
 	 drgn_StackFrame_is_inline_DOC},
 	{"pc", (getter)StackFrame_get_pc, NULL, drgn_StackFrame_pc_DOC},
+	{"variables", (getter)StackFrame_variables, NULL,
+	 drgn_StackFrame_variables_DOC },
+	{"parameters", (getter)StackFrame_parameters, NULL,
+	 drgn_StackFrame_parameters_DOC },
 	{},
+};
+
+static PyMappingMethods StackFrame_as_mapping = {
+	.mp_subscript = (binaryfunc)StackFrame_subscript,
 };
 
 PyTypeObject StackFrame_type = {
@@ -237,6 +389,7 @@ PyTypeObject StackFrame_type = {
 	.tp_name = "_drgn.StackFrame",
 	.tp_basicsize = sizeof(StackFrame),
 	.tp_dealloc = (destructor)StackFrame_dealloc,
+	.tp_as_mapping = &StackFrame_as_mapping,
 	.tp_str = (reprfunc)StackFrame_str,
 	.tp_flags = Py_TPFLAGS_DEFAULT,
 	.tp_doc = drgn_StackFrame_DOC,

--- a/libdrgn/stack_trace.h
+++ b/libdrgn/stack_trace.h
@@ -1,0 +1,20 @@
+// Copyright 2019-2020 - Omar Sandoval
+// SPDX-License-Identifier: GPL-3.0+
+
+#ifndef DRGN_STACK_TRACE_H
+#define DRGN_STACK_TRACE_H
+
+#include <elfutils/libdwfl.h>
+
+struct drgn_stack_trace {
+	struct drgn_program *prog;
+	union {
+		Dwfl_Thread *thread;
+		/* Used during creation. */
+		int capacity;
+	};
+	int num_frames;
+	Dwfl_Frame *frames[];
+};
+
+#endif /* DRGN_STACK_TRACE_H */

--- a/libdrgn/stack_trace.h
+++ b/libdrgn/stack_trace.h
@@ -8,6 +8,9 @@
 
 struct drgn_stack_frame {
 	Dwfl_Frame *state;
+	Dwarf_Die *scopes;
+	int num_scopes;
+	int subprogram;
 };
 
 struct drgn_stack_trace {

--- a/libdrgn/stack_trace.h
+++ b/libdrgn/stack_trace.h
@@ -6,6 +6,10 @@
 
 #include <elfutils/libdwfl.h>
 
+struct drgn_stack_frame {
+	Dwfl_Frame *state;
+};
+
 struct drgn_stack_trace {
 	struct drgn_program *prog;
 	union {
@@ -14,7 +18,7 @@ struct drgn_stack_trace {
 		int capacity;
 	};
 	int num_frames;
-	Dwfl_Frame *frames[];
+	struct drgn_stack_frame frames[];
 };
 
 #endif /* DRGN_STACK_TRACE_H */

--- a/libdrgn/stack_trace.h
+++ b/libdrgn/stack_trace.h
@@ -6,11 +6,25 @@
 
 #include <elfutils/libdwfl.h>
 
+struct drgn_frame_symbol {
+	const char *name;
+	Dwarf_Die var_die;
+};
+
+DEFINE_VECTOR(drgn_frame_symbol_vector, struct drgn_frame_symbol);
+
 struct drgn_stack_frame {
 	Dwfl_Frame *state;
 	Dwarf_Die *scopes;
 	int num_scopes;
 	int subprogram;
+	struct drgn_frame_symbol_vector variables;
+	struct drgn_frame_symbol_vector parameters;
+	uint64_t bias;
+	struct {
+		bool variables : 1;
+		bool parameters : 1;
+	} valid;
 };
 
 struct drgn_stack_trace {


### PR DESCRIPTION
Hi Omar -

I don't expect this pull request to be accepted but I wanted to post what I have so far for discussion.  I've gotten stack variables and parameters working, hooked into the python code, and run through some testing (e.g. for_each_task print all variables and params in all frames). I've rebased it on your stack-trace-variables branch -- at least everything until the stack variable commit itself. I had introduced a block cache tree which had the benefit of delaying resolution of scopes until needed, but at the cost of indexing a bunch of new tags and building a tree subject to a single lock. I like attaching the scopes to the frame a lot more.

I haven't modified the stack frame formatter to incorporate the parameters but it will probably make sense to do that.  If we go that route, that'll change how I handle parameters entirely.  The code right now enumerates parameters and locals when the value for one or the count are requested. It keeps a vector of each as symbols (name, Dwarf_Die). When an object is required, it creates one to represent a stack object with type, size, etc but no value or address. It's a normal object but has a needs_stack_evaluation flag set that causes temporary object to be used to evaluate the location when the value is requested and uses the result to populate the new object. If we include parameters in the formatter, I'd likely just keep a vector of named objects instead of the symbols.