### PR TITLE
Add scripts to build manylinux2010 wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /drgn.egg-info
 /htmlcov
 __pycache__
+/wheels/*.whl
+/wheels/*.tar.*

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -1,0 +1,20 @@
+Build Wheels
+============
+
+This directory contains scripts for creating manylinux wheels. The following are
+required:
+
+* docker
+* curl
+* bash
+
+To build wheels:
+
+    cd wheels  # your working directory MUST be wheels
+    ./build_drgn.sh "36 37 38"
+
+The above builds wheels for Python 3.6, 3.7, and 3.8. The quotes are required.
+Resulting wheels will be placed in the current directory.
+
+If your user account is not authorized to use Docker commands, but you have
+sudo, you can use `DOCKER="sudo docker" ./build_drgn.sh ...` instead.

--- a/wheels/build_drgn.sh
+++ b/wheels/build_drgn.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Build a drgn wheel for the manylinux2010 platform.
+#
+# This script simply prepares sources and then executes a script within the
+# "manylinux" docker image to actually build the necessary components.
+
+if [ -z "$1" ]; then
+	echo "usage: ./build_drgn.sh PYSHORTVER"
+	echo "PYSHORTVER may be, e.g.: 36, 37, 38, 39"
+	echo "PYSHORTVER may contain multiple versions; they must be quoted:"
+	echo " e.g.: ./build_drgn.sh \"36 37 38\""
+	exit 1
+fi
+
+set -x
+set -e
+
+PYTHON_VERSIONS="$1"
+
+LIBKDUMPFILE_COMMIT=a83a6e528a779a8b85f55a12e6488b48f13d9abd
+LIBKDUMPFILE=libkdumpfile-$LIBKDUMPFILE_COMMIT
+LIBKDUMPFILEF=$LIBKDUMPFILE.tar.gz
+LIBKDUMPFILE_URL=https://github.com/ptesarik/libkdumpfile/archive/$LIBKDUMPFILE_COMMIT/$LIBKDUMPFILEF
+LIBKDUMPFILE_LOCAL=$LIBKDUMPFILEF
+if [ ! -f "$LIBKDUMPFILE_LOCAL" ]; then
+	curl -L "$LIBKDUMPFILE_URL" -o "$LIBKDUMPFILE_LOCAL"
+fi
+LIBKDUMPFILE_SHA256=51e269f96a0cec43b7bc91b15fd97cacde33e5f26dcedf2ddaf138def2d49bef
+echo "$LIBKDUMPFILE_SHA256 $LIBKDUMPFILE_LOCAL" | sha256sum -c -
+
+# See build_drgn_in_docker.sh for details on why this is necessary :/
+GAWK=gawk-4.2.1
+GAWKF=$GAWK.tar.xz
+GAWK_URL=https://ftp.gnu.org/gnu/gawk/$GAWKF
+GAWK_LOCAL=$GAWKF
+if [ ! -f "$GAWK_LOCAL" ]; then
+	curl "$GAWK_URL" -o "$GAWK_LOCAL"
+fi
+GAWK_SHA256=d1119785e746d46a8209d28b2de404a57f983aa48670f4e225531d3bdc175551
+echo "$GAWK_SHA256 $GAWK_LOCAL" | sha256sum -c -
+
+# Use the "sdist" created by setup.py
+pushd ..
+DRGN=drgn-$(./setup.py --version)
+DRGNF=$DRGN.tar.gz
+if [ ! -f "dist/$DRGNF" ]; then
+	./setup.py sdist
+fi
+popd
+cp ../dist/$DRGNF .
+DRGN_LOCAL=$DRGNF
+
+# Allow users to do DOCKER="sudo docker" ./build_drgn.sh if necessary.
+DOCKER=${DOCKER:-docker}
+$DOCKER pull quay.io/pypa/manylinux2010_x86_64
+$DOCKER run -it \
+	-v $(pwd):/mnt/io \
+	-h DOCKER \
+	-w /mnt/io \
+	--rm \
+	quay.io/pypa/manylinux2010_x86_64 \
+	./build_drgn_in_docker.sh \
+	$LIBKDUMPFILE_LOCAL \
+	$GAWK_LOCAL \
+	$DRGN_LOCAL \
+	"$PYTHON_VERSIONS" \
+	"$(id -u):$(id -g)"

--- a/wheels/build_drgn_in_docker.sh
+++ b/wheels/build_drgn_in_docker.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Build a drgn wheel - intended to be run within the manylinux2010 docker image.
+#
+# This script first installs system dependencies. Then it extracts, compiles,
+# and installs dependencies. For each specified Python version, we create a
+# virtual environment and build a wheel. Finally, for each version, we use the
+# auditwheel tool to vendor any non-standard libraries (such as libkdumpfile).
+set -x
+set -e
+
+TOP=$(pwd)
+# Extract env vars which got stuck into the commandline
+LIBKDUMPFILE_LOCAL=$TOP/$1
+LIBKDUMPFILE=$(echo "$1" | sed 's/\.tar.*//')
+GAWK_LOCAL=$TOP/$2
+GAWK=$(echo "$2" | sed 's/\.tar.*//')
+DRGN_LOCAL=$TOP/$3
+DRGN=$(echo "$3" | sed 's/\.tar.*//')
+PYTHON_VERSIONS="$4"
+OWNER=$5
+
+mkdir -p /tmp/build
+cd /tmp/build
+
+# Install dependencies.
+yum install -y bzip2-devel lzo-devel snappy-devel xz xz-devel zlib-devel \
+	flex bison autoconf automake libtool pkgconfig
+
+# The manylinux image contains an upgraded autotools, but the pkg-config macros
+# are not present for this upgraded package.
+# https://github.com/pypa/manylinux/issues/731
+# Copy them in:
+cp /usr/share/aclocal/pkg.m4 /usr/local/share/aclocal-1.16/
+
+# Save original CFLAGS var (although it is probably empty) since we'll be
+# mucking with it.
+OLD_CFLAGS="$CFLAGS"
+
+# Compile and install libkdumpfile.
+tar xf $LIBKDUMPFILE_LOCAL
+cd $LIBKDUMPFILE
+# In newer zlib, the z_const symbol is defined to const, we provide this here to
+# prevent the build from failing.
+export CFLAGS="$OLD_CFLAGS -Dz_const=const"
+# Since this is not a "release version" of libkdumpfile, we need to generate the
+# configure script ourselves.
+autoreconf -fiv
+./configure --with-lzo --with-snappy --with-zlib --without-python
+make -j9
+make install
+cd ..
+
+
+# Unfortunately, drgn's build scripts rely on gawk >= 4.0, due to their use of
+# BEGINFILE. Thankfully, gawk is pretty fast and easy to compile. We use the
+# latest 4.x release here to avoid any incompatibilities with an "overly new"
+# version.
+tar xf $GAWK_LOCAL
+cd $GAWK
+export CFLAGS="$OLD_CFLAGS"
+./configure
+make -j9
+make install
+cd ..
+
+for pyver in $PYTHON_VERSIONS; do
+	if [ "$pyver" -ge "38" ]; then
+		verstring=cp$pyver-cp$pyver
+	else
+		verstring=cp$pyver-cp${pyver}m
+	fi
+	python=/opt/python/$verstring/bin/python
+
+	# Create a virtual environment in which we will build drgn. Make sure we
+	# include the most recent pip and wheel.
+	$python -m venv venv$pyver
+	source venv$pyver/bin/activate
+	pip install --upgrade pip wheel auditwheel
+
+	# For some reason, compile fails on these "static_assert()" calls in
+	# drgn. The docker image uses the devtoolset-8, which is sufficiently
+	# recent to use the C11 _Static_assert function, so we #define it here.
+	export CFLAGS="$OLD_CFLAGS -Dstatic_assert=_Static_assert"
+
+	tar xf $DRGN_LOCAL
+	cd $DRGN
+	# Finally, do the build!
+	python setup.py bdist_wheel --verbose
+
+	# At this point, we've built a linux wheel. To support the full
+	# "manylinux2010" standard, we must now run "auditwheel fix", which will
+	# vendor in any libraries which the Python standard doesn't mandate to
+	# be present. The biggest one here would be the libkdumpfile lib.
+	wheelfile=$(ls dist/*.whl | head -n 1)
+	auditwheel repair --plat manylinux2010_x86_64 $wheelfile
+	finalwheel=$(ls wheelhouse/*.whl | head -n 1)
+	finalwheel=$(basename $finalwheel)
+	mv wheelhouse/$finalwheel /mnt/io/$finalwheel
+	chown $OWNER /mnt/io/$finalwheel
+
+	cd ..
+	deactivate
+	rm -rf venv$pyver
+	rm -rf $DRGN
+done


### PR DESCRIPTION
Here are the scripts mentioned in #68, along with a short readme. For the most part, they are standard build steps (which could be part of a packaging script), but a few slight hacks are included, most to do with libkdumpfile. Below is what I ran for verification, I can provide the wheels if necessary (github doesn't support attaching wheels in PRs).

    ./build_drgn.sh "36 37 38"

I'm not sure how this will best fit into the repository (e.g. as a travis job?) but am sure something can be worked out.

