### PR TITLE
Export function drgn_object_init()

### DIFF
--- a/libdrgn/object.c
+++ b/libdrgn/object.c
@@ -15,7 +15,8 @@
 #include "type.h"
 #include "type_index.h"
 
-void drgn_object_init(struct drgn_object *obj, struct drgn_program *prog)
+LIBDRGN_PUBLIC void drgn_object_init(struct drgn_object *obj,
+				     struct drgn_program *prog)
 {
 	obj->prog = prog;
 	obj->type = drgn_void_type(drgn_program_language(prog));


### PR DESCRIPTION
drgn_object_init() is available in drgh.h file and seems to a required
call before calling drgn_program_find_object().

Without this, trying to call drgn_object_init() from an external C
application results in undefined reference.

Let me know if there is anything else I need to run/test.

Signed-off-by: Aditya Sarwade <asarwade@fb.com>