### PR TITLE
libkdumpfile API usage regression - fix kdump_vmcoreinfo_raw leak

### DIFF
--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -70,8 +70,8 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 	struct drgn_error *err;
 	kdump_ctx_t *ctx;
 	kdump_status ks;
-	const char *vmcoreinfo;
 	struct drgn_platform platform;
+	char *vmcoreinfo = NULL;
 
 	ctx = kdump_new();
 	if (!ctx) {
@@ -135,6 +135,7 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 	return NULL;
 
 err:
+	free(vmcoreinfo);
 	kdump_free(ctx);
 	return err;
 }


### PR DESCRIPTION
As of b4b3c94cc24dc88d08701ebe35f72a1f1785046a , libkdumpfile
changed some of its API infrastructure and ended up breaking
`kdump_vmcoreinfo_raw` temporarily - The regression was later
fixed with fedbe7f66561754782165be2512bca0ed1b775e9 but the
call now allocates a buffer in `kdump_vmcoreinfo_raw` that
is later up to the caller to free it. This patch updates our
usage of this function so we free our vmcoreinfo string buffer
after we copy the contents that we need from it.

Closes #75.

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>