### PR TITLE
Add basic support for parsing DWARF type units

### DIFF
--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -2986,8 +2986,19 @@ drgn_type_from_dwarf_internal(struct drgn_debug_info *dbinfo,
 					 "maximum DWARF type parsing depth exceeded");
 	}
 
-	/* If we got a declaration, try to find the definition. */
+	/* If the DIE has a type unit signature, follow it. */
 	Dwarf_Die definition_die;
+	{
+		Dwarf_Attribute attr_mem, *attr;
+		if ((attr = dwarf_attr_integrate(die, DW_AT_signature,
+						 &attr_mem))) {
+			if (!dwarf_formref_die(attr, &definition_die))
+				return drgn_error_libdw();
+			die = &definition_die;
+		}
+	}
+
+	/* If we got a declaration, try to find the definition. */
 	bool declaration;
 	if (dwarf_flag(die, DW_AT_declaration, &declaration))
 		return drgn_error_libdw();

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -2986,6 +2986,7 @@ drgn_type_from_dwarf_internal(struct drgn_debug_info *dbinfo,
 	}
 
 	/* If we got a declaration, try to find the definition. */
+	Dwarf_Die definition_die;
 	bool declaration;
 	if (dwarf_flag(die, DW_AT_declaration, &declaration))
 		return drgn_error_libdw();
@@ -3001,8 +3002,10 @@ drgn_type_from_dwarf_internal(struct drgn_debug_info *dbinfo,
 				return drgn_error_libdwfl();
 			uintptr_t start =
 				(uintptr_t)module->scn_data[DRGN_SCN_DEBUG_INFO]->d_buf;
-			if (!dwarf_offdie(dwarf, die_addr - start, die))
+			if (!dwarf_offdie(dwarf, die_addr - start,
+					  &definition_die))
 				return drgn_error_libdw();
+			die = &definition_die;
 		}
 	}
 

--- a/libdrgn/debug_info.h
+++ b/libdrgn/debug_info.h
@@ -52,6 +52,7 @@ enum drgn_debug_info_module_state {
 enum drgn_debug_info_scn {
 	/* Sections whose data we should cache when loading the module. */
 	DRGN_SCN_DEBUG_INFO,
+	DRGN_SCN_DEBUG_TYPES,
 	DRGN_SCN_DEBUG_ABBREV,
 	DRGN_SCN_DEBUG_STR,
 	DRGN_SCN_DEBUG_LINE,

--- a/libdrgn/dwarf_index.c
+++ b/libdrgn/dwarf_index.c
@@ -82,6 +82,7 @@ struct drgn_dwarf_index_cu {
 	uint8_t version;
 	uint8_t address_size;
 	bool is_64_bit;
+	bool is_type_unit;
 	/*
 	 * This is indexed on the DWARF abbreviation code minus one. It maps the
 	 * abbreviation code to an index in abbrev_insns where the instruction
@@ -585,6 +586,12 @@ static struct drgn_error *read_cu(struct drgn_dwarf_index_cu_buffer *buffer)
 					 &buffer->cu->address_size)))
 		return err;
 
+	/* Skip type_signature and type_offset for type units. */
+	if (buffer->cu->is_type_unit &&
+	    (err = binary_buffer_skip(&buffer->bb,
+				      buffer->cu->is_64_bit ? 16 : 12)))
+		return err;
+
 	return read_abbrev_table(buffer->cu, debug_abbrev_offset);
 }
 
@@ -776,7 +783,8 @@ index_cu_first_pass(struct drgn_dwarf_index *dindex,
 {
 	struct drgn_error *err;
 	struct drgn_dwarf_index_cu *cu = buffer->cu;
-	Elf_Data *debug_info = cu->module->scn_data[DRGN_SCN_DEBUG_INFO];
+	Elf_Data *debug_info = cu->module->scn_data[
+		cu->is_type_unit ? DRGN_SCN_DEBUG_TYPES : DRGN_SCN_DEBUG_INFO];
 	const char *debug_info_buffer = debug_info->d_buf;
 	unsigned int depth = 0;
 	for (;;) {
@@ -997,12 +1005,13 @@ skip:
 	return NULL;
 }
 
-void drgn_dwarf_index_read_module(struct drgn_dwarf_index_update_state *state,
-				  struct drgn_debug_info_module *module)
+static void drgn_dwarf_index_read_cus(struct drgn_dwarf_index_update_state *state,
+				      struct drgn_debug_info_module *module,
+				      enum drgn_debug_info_scn scn)
 {
 	struct drgn_error *err;
 	struct drgn_debug_info_buffer buffer;
-	drgn_debug_info_buffer_init(&buffer, module, DRGN_SCN_DEBUG_INFO);
+	drgn_debug_info_buffer_init(&buffer, module, scn);
 	while (binary_buffer_has_next(&buffer.bb)) {
 		const char *cu_buf = buffer.bb.pos;
 		uint32_t unit_length32;
@@ -1036,6 +1045,7 @@ void drgn_dwarf_index_read_module(struct drgn_dwarf_index_update_state *state,
 				.buf = cu_buf,
 				.len = cu_len,
 				.is_64_bit = is_64_bit,
+				.is_type_unit = scn == DRGN_SCN_DEBUG_TYPES,
 			};
 			struct drgn_dwarf_index_cu_buffer cu_buffer;
 			drgn_dwarf_index_cu_buffer_init(&cu_buffer, &cu);
@@ -1062,6 +1072,14 @@ cu_err:
 
 err:
 	drgn_dwarf_index_update_cancel(state, err);
+}
+
+void drgn_dwarf_index_read_module(struct drgn_dwarf_index_update_state *state,
+				  struct drgn_debug_info_module *module)
+{
+	drgn_dwarf_index_read_cus(state, module, DRGN_SCN_DEBUG_INFO);
+	if (module->scn_data[DRGN_SCN_DEBUG_TYPES])
+		drgn_dwarf_index_read_cus(state, module, DRGN_SCN_DEBUG_TYPES);
 }
 
 bool
@@ -1532,6 +1550,8 @@ drgn_dwarf_index_update_end(struct drgn_dwarf_index_update_state *state)
 		struct drgn_dwarf_index_cu_buffer buffer;
 		drgn_dwarf_index_cu_buffer_init(&buffer, cu);
 		buffer.bb.pos += cu->is_64_bit ? 23 : 11;
+		if (cu->is_type_unit)
+			buffer.bb.pos += cu->is_64_bit ? 16 : 12;
 		struct drgn_error *cu_err =
 			index_cu_second_pass(&dindex->global, &buffer);
 		if (cu_err)
@@ -1692,7 +1712,14 @@ struct drgn_error *drgn_dwarf_index_get_die(struct drgn_dwarf_index_die *die,
 		return drgn_error_libdwfl();
 	uintptr_t start =
 		(uintptr_t)die->module->scn_data[DRGN_SCN_DEBUG_INFO]->d_buf;
-	if (!dwarf_offdie(dwarf, die->addr - start, die_ret))
-		return drgn_error_libdw();
+	size_t size = die->module->scn_data[DRGN_SCN_DEBUG_INFO]->d_size;
+	if (die->addr >= start && die->addr < start + size) {
+		if (!dwarf_offdie(dwarf, die->addr - start, die_ret))
+			return drgn_error_libdw();
+	} else {
+		start = (uintptr_t)die->module->scn_data[DRGN_SCN_DEBUG_TYPES]->d_buf;
+		if (!dwarf_offdie_types(dwarf, die->addr - start, die_ret))
+			return drgn_error_libdw();
+	}
 	return NULL;
 }

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -3469,6 +3469,104 @@ class TestTypes(TestCase):
             prog.int_type("int", 4, True, language=DEFAULT_LANGUAGE),
         )
 
+    def test_base_type_unit(self):
+        prog = dwarf_program(
+            (
+                DwarfDie(
+                    DW_TAG.compile_unit,
+                    (),
+                    (
+                        DwarfDie(
+                            DW_TAG.base_type,
+                            (DwarfAttrib(DW_AT.signature, DW_FORM.ref_sig8, 0),),
+                        ),
+                        DwarfDie(
+                            DW_TAG.typedef,
+                            (
+                                DwarfAttrib(DW_AT.name, DW_FORM.string, "TEST"),
+                                DwarfAttrib(DW_AT.type, DW_FORM.ref4, 0),
+                            ),
+                        ),
+                    ),
+                ),
+                DwarfDie(DW_TAG.type_unit, (), ((int_die,))),
+            )
+        )
+        self.assertIdentical(prog.type("TEST").type, prog.int_type("int", 4, True))
+        self.assertIdentical(prog.type("int"), prog.type("TEST").type)
+
+    def test_struct_type_unit(self):
+        prog = dwarf_program(
+            (
+                DwarfDie(
+                    DW_TAG.compile_unit,
+                    (),
+                    (
+                        DwarfDie(
+                            DW_TAG.structure_type,
+                            (DwarfAttrib(DW_AT.signature, DW_FORM.ref_sig8, 0),),
+                        ),
+                        DwarfDie(
+                            DW_TAG.typedef,
+                            (
+                                DwarfAttrib(DW_AT.name, DW_FORM.string, "TEST"),
+                                DwarfAttrib(DW_AT.type, DW_FORM.ref4, 0),
+                            ),
+                        ),
+                    ),
+                ),
+                DwarfDie(
+                    DW_TAG.type_unit,
+                    (),
+                    (
+                        DwarfDie(
+                            DW_TAG.structure_type,
+                            (
+                                DwarfAttrib(DW_AT.name, DW_FORM.string, "point"),
+                                DwarfAttrib(DW_AT.byte_size, DW_FORM.data1, 8),
+                            ),
+                            (
+                                DwarfDie(
+                                    DW_TAG.member,
+                                    (
+                                        DwarfAttrib(DW_AT.name, DW_FORM.string, "x"),
+                                        DwarfAttrib(
+                                            DW_AT.data_member_location, DW_FORM.data1, 0
+                                        ),
+                                        DwarfAttrib(DW_AT.type, DW_FORM.ref4, 1),
+                                    ),
+                                ),
+                                DwarfDie(
+                                    DW_TAG.member,
+                                    (
+                                        DwarfAttrib(DW_AT.name, DW_FORM.string, "y"),
+                                        DwarfAttrib(
+                                            DW_AT.data_member_location, DW_FORM.data1, 4
+                                        ),
+                                        DwarfAttrib(DW_AT.type, DW_FORM.ref4, 1),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        int_die,
+                    ),
+                ),
+            )
+        )
+
+        self.assertIdentical(
+            prog.type("TEST").type,
+            prog.struct_type(
+                "point",
+                8,
+                (
+                    TypeMember(prog.int_type("int", 4, True), "x", 0),
+                    TypeMember(prog.int_type("int", 4, True), "y", 32),
+                ),
+            ),
+        )
+        self.assertIdentical(prog.type("struct point"), prog.type("TEST").type)
+
 
 class TestObjects(TestCase):
     def test_constant_signed_enum(self):


### PR DESCRIPTION
This ended up being more straightforward than expected - although there are still a couple rough edges (and no tests right now). The biggest change is removing all usages of offsets from the index. 

I'll highlight the biggest questionable things in comments below - hopefully I'll be able to add tests and clean this up a bit more next week :). 