### PR TITLE
WIP for adding key listing functionality to drgn

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    FrozenSet,
     Iterable,
     Iterator,
     Mapping,
@@ -106,6 +107,18 @@ class Program:
         Object(prog, 'volatile unsigned long', address=0xffffffff94c05000)
 
         :param name: The object name.
+        """
+        ...
+    def keys(self) -> FrozenSet[Object]:
+        """
+        Implement ``prog.keys()``. Get a set of objects (variable, constant, or
+        function).  This will return a FrozenSet (though in the future it might
+        return a View instead) that can be used to iterate through all
+        available objects.
+
+        >>> prog.keys()
+        FrozenSet(prog)
+
         """
         ...
     def variable(self, name: str, filename: Optional[str] = None) -> Object:

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -2671,6 +2671,14 @@ drgn_debug_info_find_object(const char *name, size_t name_len,
 	return &drgn_not_found;
 }
 
+struct drgn_error *
+drgn_debug_info_list_object(void *arg, drgn_visit_name_fn *callback,
+                void *callback_args)
+{
+    // TODO: Implement this
+    return &drgn_not_found;
+}
+
 struct drgn_error *drgn_debug_info_create(struct drgn_program *prog,
 					  struct drgn_debug_info **ret)
 {

--- a/libdrgn/debug_info.h
+++ b/libdrgn/debug_info.h
@@ -302,6 +302,11 @@ drgn_debug_info_find_object(const char *name, size_t name_len,
 			    enum drgn_find_object_flags flags, void *arg,
 			    struct drgn_object *ret);
 
+/** @ref drgn_object_list_fn() that uses debugging information. */
+struct drgn_error *
+drgn_debug_info_list_object(void *arg, drgn_visit_name_fn *callback,
+                void *callback_args);
+
 struct drgn_error *open_elf_file(const char *path, int *fd_ret, Elf **elf_ret);
 
 struct drgn_error *find_elf_file(char **path_ret, int *fd_ret, Elf **elf_ret,

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -567,6 +567,14 @@ enum drgn_find_object_flags {
 };
 
 /**
+ * Callback called for each matching name
+ *
+ * @param[in] name Name of object
+ * @param[in] arg Argument passed to @ref drgn_program_add_object_finder().
+ */
+typedef struct drgn_error * (*drgn_visit_name_fn)(const char *name, void *arg);
+
+/**
  * Callback for finding an object.
  *
  * @param[in] name Name of object. This is @em not null-terminated.
@@ -586,18 +594,38 @@ typedef struct drgn_error *
 		       struct drgn_object *ret);
 
 /**
+ * Callback for listing objects
+ *
+ * @param[in] arg Argument passed to @ref drgn_program_add_object_finder().
+ * @param[in] drgn_visit_name_fn Callback that will be called on each listed name
+ * @param[in] callback_arg Argument passed to drgn_visit_name_fn callback
+ * @param[out] ret Returned object. This must only be modified on success.
+ * @return @c NULL on success, non-@c NULL on error. In particular, if the
+ * object is not found, this should return &@ref drgn_not_found; any other
+ * errors are considered fatal.
+ */
+typedef struct drgn_error *
+(*drgn_object_list_fn)(void *arg, drgn_visit_name_fn *callback,
+                       void *callback_arg);
+
+/**
  * Register a object finding callback.
  *
  * Callbacks are called in reverse order of the order they were added until the
  * object is found. So, more recently added callbacks take precedence.
  *
- * @param[in] fn The callback.
+ * @param[in] find_fn The find callback.
+ * @param[in] list_fn The list callback.
  * @param[in] arg Argument to pass to @p fn.
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *
-drgn_program_add_object_finder(struct drgn_program *prog,
-			       drgn_object_find_fn fn, void *arg);
+drgn_program_add_object_finder(
+        struct drgn_program *prog,
+        drgn_object_find_fn find_fn,
+        drgn_object_list_fn list_fn,
+        void *find_arg,
+        void *list_arg);
 
 /**
  * Set a @ref drgn_program to a core dump.
@@ -673,6 +701,13 @@ struct drgn_error *drgn_program_from_kernel(struct drgn_program **ret);
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *drgn_program_from_pid(pid_t pid, struct drgn_program **ret);
+
+/**
+ * Set a @ref drgn_program to the running operating system kernel.
+ *
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_keys(struct drgn_program *prog, list_head *head)
 
 /** Get the set of @ref drgn_program_flags applying to a @ref drgn_program. */
 enum drgn_program_flags drgn_program_flags(struct drgn_program *prog);

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -334,6 +334,14 @@ struct drgn_error *linux_kernel_object_find(const char *name, size_t name_len,
 	return &drgn_not_found;
 }
 
+
+struct drgn_error *linux_kernel_object_list(void *arg,
+                        drgn_visit_name_fn *callback, void *callback_arg)
+{
+    // TODO: Implement this
+    return &drgn_not_found;
+}
+
 struct kernel_module_iterator {
 	char *name;
 	/* /proc/modules file or NULL. */

--- a/libdrgn/linux_kernel.h
+++ b/libdrgn/linux_kernel.h
@@ -28,6 +28,9 @@ struct drgn_error *linux_kernel_object_find(const char *name, size_t name_len,
 					    enum drgn_find_object_flags flags,
 					    void *arg, struct drgn_object *ret);
 
+struct drgn_error *linux_kernel_object_list(void *arg,
+                        drgn_visit_name_fn *callback, void *callback_arg);
+
 struct drgn_error *
 linux_kernel_report_debug_info(struct drgn_debug_info_load_state *load);
 

--- a/libdrgn/object_index.c
+++ b/libdrgn/object_index.c
@@ -26,15 +26,18 @@ void drgn_object_index_deinit(struct drgn_object_index *oindex)
 
 struct drgn_error *
 drgn_object_index_add_finder(struct drgn_object_index *oindex,
-			     drgn_object_find_fn fn, void *arg)
+			     drgn_object_find_fn find_fn, drgn_object_list_fn list_fn,
+                 void *find_arg, void *list_arg)
 {
 	struct drgn_object_finder *finder;
 
 	finder = malloc(sizeof(*finder));
 	if (!finder)
 		return &drgn_enomem;
-	finder->fn = fn;
-	finder->arg = arg;
+	finder->find_fn = find_fn;
+    finder->list_fn = list_fn,
+	finder->find_arg = find_arg;
+	finder->list_arg = list_arg;
 	finder->next = oindex->finders;
 	oindex->finders = finder;
 	return NULL;
@@ -66,7 +69,7 @@ struct drgn_error *drgn_object_index_find(struct drgn_object_index *oindex,
 	name_len = strlen(name);
 	finder = oindex->finders;
 	while (finder) {
-		err = finder->fn(name, name_len, filename, flags, finder->arg,
+		err = finder->find_fn(name, name_len, filename, flags, finder->find_arg,
 				 ret);
 		if (err != &drgn_not_found)
 			return err;

--- a/libdrgn/object_index.h
+++ b/libdrgn/object_index.h
@@ -29,10 +29,15 @@
 
 /** Registered callback in a @ref drgn_object_index. */
 struct drgn_object_finder {
-	/** The callback. */
-	drgn_object_find_fn fn;
-	/** Argument to pass to @ref drgn_object_finder::fn. */
-	void *arg;
+	/** The find callback. */
+	drgn_object_find_fn find_fn;
+
+    /** The list callback */
+	drgn_object_list_fn list_fn;
+	/** Argument to pass to @ref drgn_object_finder::find_fn. */
+	void *find_arg;
+	/** Argument to pass to @ref drgn_object_finder::list_fn. */
+    void *list_arg;
 	/** Next callback to try. */
 	struct drgn_object_finder *next;
 };
@@ -59,7 +64,8 @@ void drgn_object_index_deinit(struct drgn_object_index *oindex);
 /** @sa drgn_program_add_object_finder() */
 struct drgn_error *
 drgn_object_index_add_finder(struct drgn_object_index *oindex,
-			     drgn_object_find_fn fn, void *arg);
+			     drgn_object_find_fn find_fn, drgn_object_list_fn list_fn,
+			     void *find_arg, void *list_arg);
 
 /** Remove the most recently added object finding callback. */
 void drgn_object_index_remove_finder(struct drgn_object_index *oindex);

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -141,10 +141,14 @@ drgn_program_add_memory_segment(struct drgn_program *prog, uint64_t address,
 }
 
 LIBDRGN_PUBLIC struct drgn_error *
-drgn_program_add_object_finder(struct drgn_program *prog,
-			       drgn_object_find_fn fn, void *arg)
+drgn_program_add_object_finder(
+        struct drgn_program *prog,
+        drgn_object_find_fn find_fn,
+        drgn_object_list_fn list_fn,
+        void *find_arg,
+        void *list_arg)
 {
-	return drgn_object_index_add_finder(&prog->oindex, fn, arg);
+    return drgn_object_index_add_finder(&prog->oindex, find_fn, list_fn, list_arg, find_arg);
 }
 
 static struct drgn_error *
@@ -455,7 +459,9 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 	if (prog->flags & DRGN_PROGRAM_IS_LINUX_KERNEL) {
 		err = drgn_program_add_object_finder(prog,
 						     linux_kernel_object_find,
-						     prog);
+                             linux_kernel_object_list,
+						     prog,
+                             prog);
 		if (err)
 			goto out_segments;
 		if (!prog->lang)
@@ -543,7 +549,8 @@ struct drgn_error *drgn_program_get_dbinfo(struct drgn_program *prog,
 			return err;
 		err = drgn_program_add_object_finder(prog,
 						     drgn_debug_info_find_object,
-						     dbinfo);
+                             drgn_debug_info_list_object,
+						     dbinfo, dbinfo);
 		if (err) {
 			drgn_debug_info_destroy(dbinfo);
 			return err;


### PR DESCRIPTION
This is far from complete (it doesn't even compile yet), but I wanted to show where I was heading with this.

Primarily what I have so far is most of the libdrgn interface created and that interface at least partially hooked up to python.  The main logic for the listing operation as well has how it's handled in conversion to a frozenset and exposure to the user in the python code still needs to be implemented.

I'm considering using a linked list for accumulation of the keys in libdrgn, this would be easy to merge with items from multiple listing functions, then the deduplication occurs when adding to the frozenset in the Python c-api with a single iteration through the combined list.