### PR TITLE
libdrgn: Fix lookup of indexed incomplete classes

### DIFF
--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -1144,6 +1144,18 @@ static int dwarf_flag(Dwarf_Die *die, unsigned int name, bool *ret)
 	Dwarf_Attribute attr_mem;
 	Dwarf_Attribute *attr;
 
+	if (!(attr = dwarf_attr(die, name, &attr_mem))) {
+		*ret = false;
+		return 0;
+	}
+	return dwarf_formflag(attr, ret);
+}
+
+static int dwarf_flag_integrate(Dwarf_Die *die, unsigned int name, bool *ret)
+{
+	Dwarf_Attribute attr_mem;
+	Dwarf_Attribute *attr;
+
 	if (!(attr = dwarf_attr_integrate(die, name, &attr_mem))) {
 		*ret = false;
 		return 0;
@@ -1773,7 +1785,7 @@ parse_template_parameter(struct drgn_debug_info *dbinfo,
 	}
 
 	bool defaulted;
-	if (dwarf_flag(die, DW_AT_default_value, &defaulted)) {
+	if (dwarf_flag_integrate(die, DW_AT_default_value, &defaulted)) {
 		return drgn_error_format(DRGN_ERROR_OTHER,
 					 "%s has invalid DW_AT_default_value",
 					 dwarf_tag_str(die, tag_buf));

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -879,6 +879,71 @@ class TestTypes(TestCase):
             prog.type("TEST").type, prog.pointer_type(prog.struct_type("point"))
         )
 
+    def test_incomplete_to_complete_specification(self):
+        prog = dwarf_program(
+            test_type_dies(
+                (
+                    DwarfDie(
+                        DW_TAG.pointer_type,
+                        (
+                            DwarfAttrib(DW_AT.byte_size, DW_FORM.data1, 8),
+                            DwarfAttrib(DW_AT.type, DW_FORM.ref4, 1),
+                        ),
+                    ),
+                    DwarfDie(
+                        DW_TAG.structure_type,
+                        (
+                            DwarfAttrib(DW_AT.name, DW_FORM.string, "point"),
+                            DwarfAttrib(DW_AT.declaration, DW_FORM.flag_present, True),
+                        ),
+                    ),
+                    DwarfDie(
+                        DW_TAG.structure_type,
+                        (
+                            DwarfAttrib(DW_AT.specification, DW_FORM.ref4, 1),
+                            DwarfAttrib(DW_AT.byte_size, DW_FORM.data1, 8),
+                        ),
+                        (
+                            DwarfDie(
+                                DW_TAG.member,
+                                (
+                                    DwarfAttrib(DW_AT.name, DW_FORM.string, "x"),
+                                    DwarfAttrib(
+                                        DW_AT.data_member_location, DW_FORM.data1, 0
+                                    ),
+                                    DwarfAttrib(DW_AT.type, DW_FORM.ref4, 3),
+                                ),
+                            ),
+                            DwarfDie(
+                                DW_TAG.member,
+                                (
+                                    DwarfAttrib(DW_AT.name, DW_FORM.string, "y"),
+                                    DwarfAttrib(
+                                        DW_AT.data_member_location, DW_FORM.data1, 4
+                                    ),
+                                    DwarfAttrib(DW_AT.type, DW_FORM.ref4, 3),
+                                ),
+                            ),
+                        ),
+                    ),
+                    int_die,
+                )
+            )
+        )
+        self.assertIdentical(
+            prog.type("TEST").type,
+            prog.pointer_type(
+                prog.struct_type(
+                    "point",
+                    8,
+                    (
+                        TypeMember(prog.int_type("int", 4, True), "x"),
+                        TypeMember(prog.int_type("int", 4, True), "y", 32),
+                    ),
+                )
+            ),
+        )
+
     def test_filename(self):
         dies = list(base_type_dies) + [
             DwarfDie(


### PR DESCRIPTION
Previously, if a class, struct, or enum was both indexed and
incomplete, the check to see if the class was a declaration or
specification during type lookup would always return as a declaration.
This would cause the "complete type" to be looked up again, which
triggers a recursion loop.

One note - I applied this to enums too although I haven't tested that case - as it does the same declaration lookup.