### PR TITLE
Convert offsets to addresses and add lookup for indirect dies in type lookup

### DIFF
--- a/libdrgn/dwarf_index.c
+++ b/libdrgn/dwarf_index.c
@@ -1063,9 +1063,11 @@ err:
 	drgn_dwarf_index_update_cancel(state, err);
 }
 
-static bool find_definition(struct drgn_dwarf_index *dindex, uintptr_t die_addr,
-			    struct drgn_debug_info_module **module_ret,
-			    uintptr_t *addr_ret)
+bool
+drgn_dwarf_index_find_definition(struct drgn_dwarf_index *dindex,
+				 uintptr_t die_addr,
+				 struct drgn_debug_info_module **module_ret,
+				 uintptr_t *addr_ret)
 {
 	struct drgn_dwarf_index_specification_map_iterator it =
 		drgn_dwarf_index_specification_map_search(&dindex->specifications,
@@ -1406,8 +1408,10 @@ skip:
 				 */
 				die_addr = depth1_addr;
 			} else if (declaration &&
-				   !find_definition(ns->dindex, die_addr,
-						    &module, &die_addr)) {
+				   !drgn_dwarf_index_find_definition(ns->dindex,
+								     die_addr,
+								     &module,
+								     &die_addr)) {
 				goto next;
 			}
 

--- a/libdrgn/dwarf_index.h
+++ b/libdrgn/dwarf_index.h
@@ -314,6 +314,25 @@ drgn_dwarf_index_iterator_next(struct drgn_dwarf_index_iterator *it);
 struct drgn_error *drgn_dwarf_index_get_die(struct drgn_dwarf_index_die *die,
 					    Dwarf_Die *die_ret);
 
+
+/**
+ * Find a definition corresponding to a declaration DIE.
+ *
+ * This finds the address of a DIE with a @c DW_AT_specification attribute that
+ * refers to the given address.
+ *
+ * @param[in] die_addr The address of the declaration DIE.
+ * @param[out] module_ret Returned module containing the definition DIE.
+ * @param[out] addr_ret Returned address of the definition DIE.
+ * @return @c true if a definition DIE was found, @c false if not (in which case
+ * *@p module_ret and *@p addr_ret are not modified).
+ */
+bool
+drgn_dwarf_index_find_definition(struct drgn_dwarf_index *dindex,
+				 uintptr_t die_addr,
+				 struct drgn_debug_info_module **module_ret,
+				 uintptr_t *addr_ret);
+
 /** @} */
 
 #endif /* DRGN_DWARF_INDEX_H */

--- a/libdrgn/dwarf_index.h
+++ b/libdrgn/dwarf_index.h
@@ -80,7 +80,7 @@ struct drgn_dwarf_index_die {
 		struct drgn_dwarf_index_namespace *namespace;
 	};
 	struct drgn_debug_info_module *module;
-	size_t offset;
+	uintptr_t addr;
 };
 
 DEFINE_HASH_MAP_TYPE(drgn_dwarf_index_die_map, struct string, uint32_t)
@@ -110,9 +110,9 @@ struct drgn_dwarf_index_specification {
 	 * DW_AT_specification.
 	 */
 	uintptr_t declaration;
-	/* Module and offset of DIE. */
+	/* Module and address of DIE. */
 	struct drgn_debug_info_module *module;
-	size_t offset;
+	uintptr_t addr;
 };
 
 static inline uintptr_t


### PR DESCRIPTION
Continuation from https://github.com/osandov/drgn/pull/79#discussion_r554248032

I decided to leave the type cache for after the lookup,  as I don't think the extra lookup wll be too bad, and I think it will take a lot of space (and if it does seem slow, it should be an easy fix). This way seems simpler to me, so I think that's where we should start. 

The first commit should only have the minor changes requested, otherwise it should be the same.