### PR TITLE
libdrgn: stretch minimum supported version of libelf to 0.170

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Debian/Ubuntu:
     $ sudo apt-get install autoconf automake gawk gcc libelf-dev libdw-dev libtool make pkgconf python3 python3-dev python3-setuptools
 
 Note that Debian Stretch, Ubuntu Trusty, and Ubuntu Xenial (and older) ship
-Python and elfutils versions which are too old. Python 3.6 and elfutils 0.176
+Python and elfutils versions which are too old. Python 3.6 and elfutils 0.170
 or newer must be installed manually.
 
 Fedora:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ Dependencies
 drgn depends on:
 
 - `Python <https://www.python.org/>`_ 3.6 or newer
-- `elfutils <https://sourceware.org/elfutils/>`_ 0.176 or newer
+- `elfutils <https://sourceware.org/elfutils/>`_ 0.170 or newer
 
 The build requires:
 

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -74,7 +74,7 @@ headers by setting the PYTHON_CPPFLAGS environment variable.])])
 
 PKG_PROG_PKG_CONFIG
 
-PKG_CHECK_MODULES(elfutils, [libelf >= 0.176 libdw >= 0.176])
+PKG_CHECK_MODULES(elfutils, [libelf >= 0.170 libdw >= 0.170])
 
 AC_ARG_WITH([libkdumpfile],
 	    [AS_HELP_STRING([--with-libkdumpfile],

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -7,6 +7,7 @@
 #include <elfutils/known-dwarf.h>
 #include <elfutils/libdw.h>
 #include <elfutils/libdwelf.h>
+#include <elfutils/version.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <gelf.h>
@@ -2466,6 +2467,17 @@ err:
 	drgn_compound_type_builder_deinit(&builder);
 	return err;
 }
+
+#if !_ELFUTILS_PREREQ(0, 171)
+#define DW_FORM_implicit_const 0x21
+#endif
+
+#if !_ELFUTILS_PREREQ(0, 175)
+static Elf *dwelf_elf_begin(int fd)
+{
+	return elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
+}
+#endif
 
 static struct drgn_error *
 parse_enumerator(Dwarf_Die *die, struct drgn_enum_type_builder *builder,

--- a/libdrgn/language.c
+++ b/libdrgn/language.c
@@ -67,7 +67,7 @@ struct drgn_error *drgn_language_from_die(Dwarf_Die *die, bool fall_back,
 					  const struct drgn_language **ret)
 {
 	Dwarf_Die cudie;
-	if (dwarf_cu_info(die->cu, NULL, NULL, &cudie, NULL, NULL, NULL, NULL))
+	if (!dwarf_cu_die(die->cu, &cudie, NULL, NULL, NULL, NULL, NULL, NULL))
 		return drgn_error_libdw();
 	switch (dwarf_srclang(&cudie)) {
 	case DW_LANG_C:

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -6,6 +6,7 @@
 #include <dwarf.h>
 #include <elf.h>
 #include <elfutils/libdw.h>
+#include <elfutils/version.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <gelf.h>
@@ -33,8 +34,10 @@ DEFINE_HASH_TABLE_FUNCTIONS(drgn_prstatus_map, int_key_hash_pair, scalar_key_eq)
 
 static Elf_Type note_header_type(GElf_Phdr *phdr)
 {
+#if _ELFUTILS_PREREQ(0, 175)
 	if (phdr->p_align == 8)
 		return ELF_T_NHDR8;
+#endif
 	return ELF_T_NHDR;
 }
 


### PR DESCRIPTION
Currently libdrgn requires libelf to be of version 0.175 or
later. This patch allows the library to be compiled with libelf
0.170 (the newest version supported by Ubuntu 18.04 LTS).

Signed-off-by: Serapheim Dimitropoulos <serapheim@delphix.com>