### PR TITLE
tests: properly escape regexp strings

### DIFF
--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -320,7 +320,7 @@ class TestMemory(TestCase):
         )
         self.assertRaisesRegex(
             ValueError,
-            "memory read callback returned buffer of length 0 \(expected 8\)",
+            r"memory read callback returned buffer of length 0 \(expected 8\)",
             prog.read,
             0xFFFF0000,
             8,

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -862,7 +862,7 @@ class TestType(MockProgramTestCase):
         )
 
         self.assertRaisesRegex(
-            TypeError, "must be _drgn\.Type", self.prog.function_type, None, ()
+            TypeError, r"must be _drgn\.Type", self.prog.function_type, None, ()
         )
         self.assertRaisesRegex(
             TypeError,


### PR DESCRIPTION
When running tests via pytest, it currently outputs these warnings:
```
tests/test_program.py:323
  /builddir/build/BUILD/drgn-0.0.10/tests/test_program.py:323: DeprecationWarning: invalid escape sequence \(
    "memory read callback returned buffer of length 0 \(expected 8\)",

<unknown>:323
<unknown>:323
<unknown>:323
<unknown>:323
<unknown>:323
  <unknown>:323: DeprecationWarning: invalid escape sequence \(

tests/test_type.py:865
  /builddir/build/BUILD/drgn-0.0.10/tests/test_type.py:865: DeprecationWarning: invalid escape sequence \.
    TypeError, "must be _drgn\.Type", self.prog.function_type, None, ()

<unknown>:865
<unknown>:865
<unknown>:865
<unknown>:865
<unknown>:865
  <unknown>:865: DeprecationWarning: invalid escape sequence \.

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```