### PR TITLE
examples: add missing shebangs

### DIFF
--- a/examples/linux/cgroup.py
+++ b/examples/linux/cgroup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env drgn
 # Copyright (c) Facebook, Inc. and its affiliates.
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/examples/linux/fs_inodes.py
+++ b/examples/linux/fs_inodes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env drgn
 # Copyright (c) Facebook, Inc. and its affiliates.
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/examples/linux/lsmod.py
+++ b/examples/linux/lsmod.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env drgn
 # Copyright (c) Facebook, Inc. and its affiliates.
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/examples/linux/ps.py
+++ b/examples/linux/ps.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env drgn
 # Copyright (c) Facebook, Inc. and its affiliates.
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/examples/linux/tcp_sock.py
+++ b/examples/linux/tcp_sock.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env drgn
 # Copyright (c) Facebook, Inc. and its affiliates.
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
These are executable, so they should have a shebang.