### PR TITLE
helpers: add kernel nodemask helpers

### DIFF
--- a/drgn/helpers/linux/cpumask.py
+++ b/drgn/helpers/linux/cpumask.py
@@ -21,6 +21,15 @@ __all__ = (
 )
 
 
+def _for_each_set_bit(bitmap: Object, size: int) -> Iterator[int]:
+    word_bits = 8 * sizeof(bitmap.type_.type)
+    for i in range((size + word_bits - 1) // word_bits):
+        word = bitmap[i].value_()
+        for j in range(min(word_bits, size - word_bits * i)):
+            if word & (1 << j):
+                yield (word_bits * i) + j
+
+
 def for_each_cpu(mask: Object) -> Iterator[int]:
     """
     Iterate over all of the CPUs in the given mask.
@@ -31,13 +40,7 @@ def for_each_cpu(mask: Object) -> Iterator[int]:
         nr_cpu_ids = mask.prog_["nr_cpu_ids"].value_()
     except KeyError:
         nr_cpu_ids = 1
-    bits = mask.bits
-    word_bits = 8 * sizeof(bits.type_.type)
-    for i in range((nr_cpu_ids + word_bits - 1) // word_bits):
-        word = bits[i].value_()
-        for j in range(min(word_bits, nr_cpu_ids - word_bits * i)):
-            if word & (1 << j):
-                yield (word_bits * i) + j
+    return _for_each_set_bit(mask.bits, nr_cpu_ids)
 
 
 def _for_each_cpu_mask(prog: Program, name: str) -> Iterator[int]:

--- a/drgn/helpers/linux/nodemask.py
+++ b/drgn/helpers/linux/nodemask.py
@@ -1,0 +1,55 @@
+# Copyright (c) ByteDance, Inc. and its affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+NUMA Node Masks
+---------------
+
+The ``drgn.helpers.linux.nodemask`` module provides helpers for working with
+NUMA node masks from :linux:`include/linux/nodemask.h`.
+"""
+
+from typing import Iterator
+
+from drgn import IntegerLike, Object, Program
+from drgn.helpers.linux.cpumask import _for_each_set_bit
+
+__all__ = (
+    "for_each_node",
+    "for_each_node_mask",
+    "for_each_node_state",
+    "for_each_online_node",
+)
+
+
+def for_each_node_mask(mask: Object) -> Iterator[int]:
+    """
+    Iterate over all of the NUMA nodes in the given mask.
+
+    :param mask: ``nodemask_t``
+    """
+    try:
+        nr_node_ids = mask.prog_["nr_node_ids"].value_()
+    except KeyError:
+        nr_node_ids = 1
+    return _for_each_set_bit(mask.bits, nr_node_ids)
+
+
+def for_each_node_state(prog: Program, state: IntegerLike) -> Iterator[int]:
+    """
+    Iterate over all NUMA nodes in the given state.
+
+    :param state: ``enum node_states`` (e.g., ``N_NORMAL_MEMORY``)
+    """
+    mask = prog["node_states"][state]
+    return for_each_node_mask(mask)
+
+
+def for_each_node(prog: Program) -> Iterator[int]:
+    """Iterate over all possible NUMA nodes."""
+    return for_each_node_state(prog, prog["N_POSSIBLE"])
+
+
+def for_each_online_node(prog: Program) -> Iterator[int]:
+    """Iterate over all online NUMA nodes."""
+    return for_each_node_state(prog, prog["N_ONLINE"])

--- a/tests/helpers/linux/__init__.py
+++ b/tests/helpers/linux/__init__.py
@@ -93,6 +93,17 @@ def proc_state(pid):
         return re.search(r"State:\s*(\S)", f.read(), re.M).group(1)
 
 
+def parse_range_list(s):
+    values = set()
+    for range_str in s.split(","):
+        first, sep, last = range_str.partition("-")
+        if sep:
+            values.update(range(int(first), int(last) + 1))
+        else:
+            values.add(int(first))
+    return values
+
+
 _c = ctypes.CDLL(None, use_errno=True)
 
 _mount = _c.mount

--- a/tests/helpers/linux/test_cpumask.py
+++ b/tests/helpers/linux/test_cpumask.py
@@ -8,27 +8,16 @@ from drgn.helpers.linux.cpumask import (
     for_each_possible_cpu,
     for_each_present_cpu,
 )
-from tests.helpers.linux import LinuxHelperTestCase
+from tests.helpers.linux import LinuxHelperTestCase, parse_range_list
 
 CPU_PATH = Path("/sys/devices/system/cpu")
-
-
-def parse_cpulist(cpulist):
-    cpus = set()
-    for cpu_range in cpulist.split(","):
-        first, sep, last = cpu_range.partition("-")
-        if sep:
-            cpus.update(range(int(first), int(last) + 1))
-        else:
-            cpus.add(int(first))
-    return cpus
 
 
 class TestCpuMask(LinuxHelperTestCase):
     def _test_for_each_cpu(self, func, name):
         self.assertEqual(
             list(func(self.prog)),
-            sorted(parse_cpulist((CPU_PATH / name).read_text())),
+            sorted(parse_range_list((CPU_PATH / name).read_text())),
         )
 
     def test_for_each_online_cpu(self):

--- a/tests/helpers/linux/test_nodemask.py
+++ b/tests/helpers/linux/test_nodemask.py
@@ -1,0 +1,25 @@
+# Copyright (c) ByteDance, Inc. and its affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from pathlib import Path
+import unittest
+
+from drgn.helpers.linux.nodemask import for_each_node, for_each_online_node
+from tests.helpers.linux import LinuxHelperTestCase, parse_range_list
+
+NODE_PATH = Path("/sys/devices/system/node")
+
+
+@unittest.skipUnless(NODE_PATH.exists(), "kernel does not support NUMA")
+class TestNodeMask(LinuxHelperTestCase):
+    def _test_for_each_node(self, func, name):
+        self.assertEqual(
+            list(func(self.prog)),
+            sorted(parse_range_list((NODE_PATH / name).read_text())),
+        )
+
+    def test_for_each_node(self):
+        self._test_for_each_node(for_each_node, "possible")
+
+    def test_for_each_online_node(self):
+        self._test_for_each_node(for_each_online_node, "online")


### PR DESCRIPTION
Sometimes we want to traverse numa nodes in the system,
so add kernel nodemask helpers to support this.

Signed-off-by: Qi Zheng <zhengqi.arch@bytedance.com>