### PR TITLE
Add methods for finding non-global symbols by name

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -189,7 +190,6 @@ class Program:
             the given file
         """
         ...
-    # address_or_name is positional-only.
     def symbol(self, address_or_name: Union[IntegerLike, str]) -> Symbol:
         """
         Get a symbol containing the given address, or a symbol with the given
@@ -202,11 +202,31 @@ class Program:
         :attr:`SymbolBinding.WEAK` symbol is found, it is returned. Otherwise,
         any matching symbol (e.g., :attr:`SymbolBinding.LOCAL`) is returned. If
         there are multiple matching symbols with the same binding, one is
-        returned arbitrarily.
+        returned arbitrarily. To retrieve all matching symbols, use
+        :meth:`symbols()`.
 
-        :param address_or_name: Address or name.
+        :param address_or_name: Address or name to search for. This parameter
+            is positional-only.
         :raises LookupError: if no symbol contains the given address or matches
             the given name
+        """
+        ...
+    def symbols(
+        self,
+        address_or_name: Union[None, IntegerLike, str] = None,
+    ) -> List[Symbol]:
+        """
+        Get a list of global and local symbols, optionally matching a name or
+        address.
+
+        If a string argument is given, this returns all symbols matching that
+        name. If an integer-like argument given, this returns a list of all
+        symbols containing that address. If no argument is given, all symbols
+        in the program are returned. In all cases, the symbols are returned in
+        an unspecified order.
+
+        :param address_or_name: Address or name to search for. This parameter
+            is positional-only.
         """
         ...
     def stack_trace(

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -818,6 +818,36 @@ struct drgn_error *drgn_program_find_symbol_by_name(struct drgn_program *prog,
 						    const char *name,
 						    struct drgn_symbol **ret);
 
+/**
+ * Get all global and local symbols, optionally with the given name.
+ *
+ * @param[in] prog Program.
+ * @param[in] name Name to match. If @c NULL, returns all symbols.
+ * @param[out] syms_ret Returned array of symbols. On success, this must be
+ * freed with @ref drgn_symbols_destroy().
+ * @param[out] count_ret Returned number of symbols in @p syms_ret.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_find_symbols_by_name(struct drgn_program *prog,
+						     const char *name,
+						     struct drgn_symbol ***syms_ret,
+						     size_t *count_ret);
+
+/**
+ * Get all symbols containing the given address.
+ *
+ * @param[in] prog Program.
+ * @param[in] address Address to search for.
+ * @param[out] syms_ret Returned array of symbols. On success, this must be
+ * freed with @ref drgn_symbols_destroy().
+ * @param[out] count_ret Returned number of symbols in @p syms_ret.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_find_symbols_by_address(struct drgn_program *prog,
+							uint64_t address,
+							struct drgn_symbol ***syms_ret,
+							size_t *count_ret);
+
 /** Element type and size. */
 struct drgn_element_info {
 	/** Type of the element. */
@@ -2599,6 +2629,16 @@ enum drgn_symbol_kind {
 
 /** Destroy a @ref drgn_symbol. */
 void drgn_symbol_destroy(struct drgn_symbol *sym);
+
+/**
+ * Destroy each @ref drgn_symbol in @syms, and free the array.
+ *
+ * This will ignore any @c NULL entry in the array, allowing you to take
+ * ownership of any symbol from the array prior to freeing the rest. For each
+ * symbol you take ownership of, you must free it with @ref
+ * drgn_symbol_destroy().
+ */
+void drgn_symbols_destroy(struct drgn_symbol **syms, size_t count);
 
 /**
  * Get the name of a @ref drgn_symbol.

--- a/libdrgn/symbol.c
+++ b/libdrgn/symbol.c
@@ -14,6 +14,14 @@ LIBDRGN_PUBLIC void drgn_symbol_destroy(struct drgn_symbol *sym)
 	free(sym);
 }
 
+LIBDRGN_PUBLIC void drgn_symbols_destroy(struct drgn_symbol **syms,
+					 size_t count)
+{
+	for (size_t i = 0; i < count; i++)
+		drgn_symbol_destroy(syms[i]);
+	free(syms);
+}
+
 void drgn_symbol_from_elf(const char *name, uint64_t address,
 			  const GElf_Sym *elf_sym, struct drgn_symbol *ret)
 {


### PR DESCRIPTION
This PR aims to address #47 by implementing `Prog.symbols()`, which searches for global and local symbols by a given name. Under the hood it's implemented with `drgn_program_find_symbols_by_name()` which is heavily adapted from `drgn_program_find_symbol_by_name()`, except it may return a list, and it doesn't terminate early after finding the first symbol.

I did verify this works by loading a kernel dump and trying out a few symbols. "name_show" is commonly used in sysfs, so it has several definitions. "slab_bug" is just a static function.

```python
>>> prog.symbol("name_show")
Traceback (most recent call last):
  File "<console>", line 1, in <module>
LookupError: could not find symbol with name 'name_show'
>>> prog.symbols("name_show")
[Symbol(name='name_show', address=0xffffffff927175d0, size=0x64), Symbol(name='name_show', address=0xffffffff92b84f30, size=0x46), Symbol(name='name_show', address=0xffffffff92c1d4a0, size=0x29), Symbol(name='name_show', address=0xffffffff92d068f0, size=0x40), Symbol(name='name_show', address=0xffffffff92d17660, size=0x26), Symbol(name='name_show', address=0xffffffff92d1e3a0, size=0x23), Symbol(name='name_show', address=0xffffffff92db0da0, size=0x23), Symbol(name='name_show', address=0xffffffff92db2800, size=0x2f), Symbol(name='name_show', address=0xffffffff92db48a0, size=0x39), Symbol(name='name_show', address=0xffffffff92db4f90, size=0x29), Symbol(name='name_show', address=0xffffffff92db6ef0, size=0x23)]

>>> prog.symbol("slab_bug")
Traceback (most recent call last):
  File "<console>", line 1, in <module>
LookupError: could not find symbol with name 'slab_bug'
>>> prog.symbols("slab_bug")
[Symbol(name='slab_bug', address=0xffffffff928a6df3, size=0xbc)]
```

For now this is more of a prototype, there are no tests and I don't know if the "symbol/symbols" naming is really good enough. It doesn't capture the distinction between global and non-global symbols. Also, there's no (implemented) way to determine whether a returned symbol is global or local, or its type or module. I don't know the best way for the API to reflect that.

I also toyed with the idea of making it so that `prog.symbols()` without any argument would simply list all symbols. This is something I've wanted to be able to do for a while, and it's quite easy with this implementation. But I'm not sure if that's a behavior you'd like to see added.