### PR TITLE
helpers: Add netdev_get_by_index()

### DIFF
--- a/tests/helpers/linux/test_net.py
+++ b/tests/helpers/linux/test_net.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
+import socket
 
 from drgn import cast
 from drgn.helpers.linux.fs import fget
-from drgn.helpers.linux.net import sk_fullsock
+from drgn.helpers.linux.net import netdev_get_by_index, sk_fullsock
 from drgn.helpers.linux.pid import find_task
 from tests.helpers.linux import LinuxHelperTestCase, create_socket
 
@@ -16,3 +17,8 @@ class TestNet(LinuxHelperTestCase):
             file = fget(find_task(self.prog, os.getpid()), sock.fileno())
             sk = cast("struct socket *", file.private_data).sk.read_()
             self.assertTrue(sk_fullsock(sk))
+
+    def test_netdev_get_by_index(self):
+        for index, name in socket.if_nameindex():
+            netdev = netdev_get_by_index(self.prog, index)
+            self.assertEqual(netdev.name.string_().decode(), name)


### PR DESCRIPTION
Add a helper to find the "struct net_device *" object given the
corresponding interface index.  As an example:

	>>> netdev = find_netdev_by_index(prog.object("init_net"), 1)
	>>> netdev.name.string_().decode()
	'lo'

Currently looking up by name is non-trivial to do in drgn, see kernel
function net/core/dev.c:netdev_name_node_lookup() for reference.  Use
socket.if_nametoindex() instead:

	>>> dummy = find_netdev_by_index(prog.object("init_net"), \
	...                              socket.if_nametoindex("dummy0"))
	>>> dummy.name.string_().decode()
	'dummy0'

Also add a test for this new helper to tests/helpers/linux/test_net.py.

Signed-off-by: Peilin Ye <peilin.ye@bytedance.com>