### PR TITLE
helpers: Add netdev_get_by_name()

### DIFF
--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -18,6 +18,7 @@ from drgn.helpers.linux.list_nulls import hlist_nulls_for_each_entry
 
 __all__ = (
     "netdev_get_by_index",
+    "netdev_get_by_name",
     "sk_fullsock",
     "sk_nulls_for_each",
 )
@@ -49,6 +50,47 @@ def netdev_get_by_index(
     for netdev in hlist_for_each_entry("struct net_device", head, "index_hlist"):
         if netdev.ifindex == ifindex:
             return netdev
+
+    return NULL(prog_or_net.prog_, "struct net_device *")
+
+
+def netdev_get_by_name(
+    prog_or_net: Union[Program, Object], name: Union[str, bytes]
+) -> Object:
+    """
+    Get the network device with the given interface name.
+
+    :param prog_or_net: ``struct net *`` containing the device, or
+        :class:`Program` to use the initial network namespace.
+    :param name: Network interface name.
+    :return: ``struct net_device *`` (``NULL`` if not found)
+    """
+    if isinstance(prog_or_net, Program):
+        prog_or_net = prog_or_net["init_net"]
+    if isinstance(name, str):
+        name = name.encode()
+
+    # Since Linux kernel commit ff92741270bf ("net: introduce name_node struct
+    # to be used in hashlist") (in v5.5), the device name hash table contains
+    # struct netdev_name_node entries. Before that, it contained the struct
+    # net_device directly.
+    try:
+        entry_type = prog_or_net.prog_.type("struct netdev_name_node")
+        member = "hlist"
+        entry_is_name_node = True
+    except LookupError:
+        entry_type = prog_or_net.prog_.type("struct net_device")
+        member = "name_hlist"
+        entry_is_name_node = False
+
+    for i in range(_NETDEV_HASHENTRIES):
+        head = prog_or_net.dev_name_head[i]
+        for entry in hlist_for_each_entry(entry_type, head, member):
+            if entry.name.string_() == name:
+                if entry_is_name_node:
+                    return entry.dev
+                else:
+                    return entry
 
     return NULL(prog_or_net.prog_, "struct net_device *")
 

--- a/tests/helpers/linux/test_net.py
+++ b/tests/helpers/linux/test_net.py
@@ -6,7 +6,7 @@ import socket
 
 from drgn import cast
 from drgn.helpers.linux.fs import fget
-from drgn.helpers.linux.net import netdev_get_by_index, sk_fullsock
+from drgn.helpers.linux.net import netdev_get_by_index, netdev_get_by_name, sk_fullsock
 from drgn.helpers.linux.pid import find_task
 from tests.helpers.linux import LinuxHelperTestCase, create_socket
 
@@ -22,3 +22,8 @@ class TestNet(LinuxHelperTestCase):
         for index, name in socket.if_nameindex():
             netdev = netdev_get_by_index(self.prog, index)
             self.assertEqual(netdev.name.string_().decode(), name)
+
+    def test_netdev_get_by_name(self):
+        for index, name in socket.if_nameindex():
+            netdev = netdev_get_by_name(self.prog, name)
+            self.assertEqual(netdev.ifindex, index)


### PR DESCRIPTION
Hi Omar,

Here's netdev_get_by_name() and a test, as we discussed.  Currently the `name` parameter is `str` since I didn't find the `str` version of `IntegerLike`; should we use something like `Path`?

---
Add a helper to get the network device ("struct net_device *") given an
interface name.  As an example:

    >>> netdev = netdev_get_by_name(prog["init_net"], "lo")
    >>> netdev.ifindex.value_()
    1

Or pass a "Program" as the first argument, and let the helper find in
the initial network namespace (i.e. "init_net"):

    >>> netdev = netdev_get_by_index(prog, "dummy0")
    >>> netdev.ifindex.value_()
    2

Also add a test for this new helper to tests/helpers/linux/test_net.py.

This helper simply does a linear search over the name hash table of the
network namespace, since implementing hashing in drgn is non-trivial.
It is obviously slower than net/core/dev.c:netdev_name_node_lookup() in
the kernel, but still useful.

Signed-off-by: Peilin Ye <peilin.ye@bytedance.com>