### PR TITLE
helpers: Add for_each_netns()

### DIFF
--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -13,15 +13,28 @@ import operator
 from typing import Iterator, Union
 
 from drgn import NULL, IntegerLike, Object, Program
-from drgn.helpers.linux.list import hlist_for_each_entry
+from drgn.helpers.linux.list import hlist_for_each_entry, list_for_each_entry
 from drgn.helpers.linux.list_nulls import hlist_nulls_for_each_entry
 
 __all__ = (
+    "for_each_net",
     "netdev_get_by_index",
     "netdev_get_by_name",
     "sk_fullsock",
     "sk_nulls_for_each",
 )
+
+
+def for_each_net(prog: Program) -> Iterator[Object]:
+    """
+    Iterate over all network namespaces in the system.
+
+    :return: Iterator of ``struct net *`` objects.
+    """
+    for net in list_for_each_entry(
+        "struct net", prog["net_namespace_list"].address_of_(), "list"
+    ):
+        yield net
 
 
 _NETDEV_HASHBITS = 8

--- a/tests/helpers/linux/test_net.py
+++ b/tests/helpers/linux/test_net.py
@@ -6,7 +6,12 @@ import socket
 
 from drgn import cast
 from drgn.helpers.linux.fs import fget
-from drgn.helpers.linux.net import netdev_get_by_index, netdev_get_by_name, sk_fullsock
+from drgn.helpers.linux.net import (
+    for_each_net,
+    netdev_get_by_index,
+    netdev_get_by_name,
+    sk_fullsock,
+)
 from drgn.helpers.linux.pid import find_task
 from tests.helpers.linux import LinuxHelperTestCase, create_socket
 
@@ -27,3 +32,6 @@ class TestNet(LinuxHelperTestCase):
         for index, name in socket.if_nameindex():
             netdev = netdev_get_by_name(self.prog, name)
             self.assertEqual(netdev.ifindex, index)
+
+    def test_for_each_net(self):
+        self.assertIn(self.prog["init_net"].address_of_(), for_each_net(self.prog))


### PR DESCRIPTION
Hi Omar,

Another simple helper to iterate over all `struct net`s.  Looking up by name is impractical since Linux kernel doesn't maintain name for netns.  One way would be let drgn read the corresponding nsfs node directly e.g. `/var/run/netns/foo`, but different userspace tools bind-mount `/proc/$PID/ns/net` to different places (e.g. `/var/run/netns/*` for `ip`, `/var/run/docker/*` for Docker)...I think a `for_each_` helper would be sufficient for now.

thanks,
ypl

---
Add a helper to iterate over all network namespaces in the system.  As
an example:

	>>> for net in for_each_netns(prog):
	...     if netdev_get_by_name(net, "enp0s3"):
	...         print(net.ipv4.sysctl_ip_early_demux.value_())
	...
	1

Also add a test for this new helper to tests/helpers/linux/test_net.py.