### PR TITLE
libdrgn: reads from segment mapping

### DIFF
--- a/libdrgn/memory_reader.h
+++ b/libdrgn/memory_reader.h
@@ -134,6 +134,8 @@ struct drgn_memory_file_segment {
 	 * OS error.
 	 */
 	bool eio_is_fault;
+	/** segment mapping address. */
+	void *map_address;
 };
 
 /** @ref drgn_memory_read_fn which reads from a file. */
@@ -141,6 +143,10 @@ struct drgn_error *drgn_read_memory_file(void *buf, uint64_t address,
 					 size_t count, uint64_t offset,
 					 void *arg, bool physical);
 
+/** @ref drgn_memory_read_fn which reads from segment mmap. */
+struct drgn_error *drgn_read_memory_mmap(void *buf, uint64_t address,
+					 size_t count, uint64_t offset,
+					 void *arg, bool physical);
 /** @} */
 
 #endif /* DRGN_MEMORY_READER_H */


### PR DESCRIPTION
We added an mmap interface for kcore (https://lore.kernel.org/patchwork/patch/1453867/).
It can reduce system calls significantly when accessing the kernel data structures.
The patch will be merged into next kernel version.

Co-developed-by:Feng Zhou <zhoufeng.zf@bytedance.com>
Signed-off-by: chenying <chenying.kernel@bytedance.com>