### PR TITLE
Add netdev_for_each_tx_queue() and qdisc_lookup()

### DIFF
--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -21,6 +21,7 @@ __all__ = (
     "for_each_net",
     "get_net_ns_by_inode",
     "get_net_ns_by_fd",
+    "netdev_for_each_tx_queue",
     "netdev_get_by_index",
     "netdev_get_by_name",
     "sk_fullsock",
@@ -74,6 +75,17 @@ def get_net_ns_by_fd(task: Object, fd: IntegerLike) -> Object:
     :raises ValueError: If *fd* does not refer to a network namespace inode
     """
     return get_net_ns_by_inode(fget(task, fd).f_inode)
+
+
+def netdev_for_each_tx_queue(dev: Object) -> Iterator[Object]:
+    """
+    Iterate over all TX queues for a network device.
+
+    :param dev: ``struct net_device *``
+    :return: Iterator of ``struct netdev_queue *`` objects.
+    """
+    for i in range(dev.num_tx_queues):
+        yield dev._tx + i
 
 
 _NETDEV_HASHBITS = 8

--- a/drgn/helpers/linux/tc.py
+++ b/drgn/helpers/linux/tc.py
@@ -1,0 +1,60 @@
+# Copyright (c) ByteDance, Inc. and its affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Traffic Control (TC)
+--------------------
+
+The ``drgn.helpers.linux.tc`` module provides helpers for working with the
+Linux kernel Traffic Control (TC) subsystem.
+"""
+
+import operator
+
+from drgn import NULL, IntegerLike, Object
+from drgn.helpers.linux.list import hlist_for_each_entry, list_for_each_entry
+
+__all__ = ("qdisc_lookup",)
+
+
+def qdisc_lookup(dev: Object, major: IntegerLike) -> Object:
+    """
+    Get a Qdisc from a device and a major handle number.  It is worth noting
+    that conventionally handles are hexadecimal, e.g. ``10:`` in a ``tc``
+    command means major handle 0x10.
+
+    :param dev: ``struct net_device *``
+    :param major: Qdisc major handle number.
+    :return: ``struct Qdisc *`` (``NULL`` if not found)
+    """
+    major = operator.index(major) << 16
+
+    roots = [dev.qdisc]
+    if dev.ingress_queue:
+        roots.append(dev.ingress_queue.qdisc_sleeping)
+
+    # Since Linux kernel commit 59cc1f61f09c ("net: sched: convert qdisc linked
+    # list to hashtable") (in v4.7), a device's child Qdiscs are maintained in
+    # a hashtable in its struct net_device. Before that, they are maintained in
+    # a linked list in their root Qdisc.
+    use_hashtable = dev.prog_.type("struct net_device").has_member("qdisc_hash")
+
+    for root in roots:
+        if root.handle == major:
+            return root
+
+        if use_hashtable:
+            for head in root.dev_queue.dev.qdisc_hash:
+                for qdisc in hlist_for_each_entry(
+                    "struct Qdisc", head.address_of_(), "hash"
+                ):
+                    if qdisc.handle == major:
+                        return qdisc
+        else:
+            for qdisc in list_for_each_entry(
+                "struct Qdisc", root.list.address_of_(), "list"
+            ):
+                if qdisc.handle == major:
+                    return qdisc
+
+    return NULL(dev.prog_, "struct Qdisc *")

--- a/tests/helpers/linux/test_net.py
+++ b/tests/helpers/linux/test_net.py
@@ -10,6 +10,7 @@ from drgn.helpers.linux.fs import fget
 from drgn.helpers.linux.net import (
     for_each_net,
     get_net_ns_by_fd,
+    netdev_for_each_tx_queue,
     netdev_get_by_index,
     netdev_get_by_name,
     sk_fullsock,
@@ -19,48 +20,58 @@ from tests.helpers.linux import LinuxHelperTestCase, create_socket
 
 
 class TestNet(LinuxHelperTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.pid = os.getpid()
+        cls.task = find_task(cls.prog, cls.pid)
+        with open(f"/proc/{cls.pid}/ns/net") as file:
+            cls.net = get_net_ns_by_fd(cls.task, file.fileno())
+
     def test_sk_fullsock(self):
         with create_socket() as sock:
-            file = fget(find_task(self.prog, os.getpid()), sock.fileno())
+            file = fget(self.task, sock.fileno())
             sk = cast("struct socket *", file.private_data).sk.read_()
             self.assertTrue(sk_fullsock(sk))
 
     def test_netdev_get_by_index(self):
         for index, name in socket.if_nameindex():
-            netdev = netdev_get_by_index(self.prog, index)
+            netdev = netdev_get_by_index(self.net, index)
             self.assertEqual(netdev.name.string_().decode(), name)
 
     def test_netdev_get_by_name(self):
         for index, name in socket.if_nameindex():
-            netdev = netdev_get_by_name(self.prog, name)
+            netdev = netdev_get_by_name(self.net, name)
             self.assertEqual(netdev.ifindex, index)
 
     def test_for_each_net(self):
         self.assertIn(self.prog["init_net"].address_of_(), for_each_net(self.prog))
 
     def test_get_net_ns_by_fd(self):
-        pid = os.getpid()
-        task = find_task(self.prog, pid)
-        with open(f"/proc/{pid}/ns/net") as file:
-            net = get_net_ns_by_fd(task, file.fileno())
-            for index, name in socket.if_nameindex():
-                netdev = netdev_get_by_index(net, index)
-                self.assertEqual(netdev.name.string_().decode(), name)
+        for index, name in socket.if_nameindex():
+            netdev = netdev_get_by_index(self.net, index)
+            self.assertEqual(netdev.name.string_().decode(), name)
 
         with tempfile.TemporaryFile("rb") as file:
             self.assertRaisesRegex(
                 ValueError,
                 "not a namespace inode",
                 get_net_ns_by_fd,
-                task,
+                self.task,
                 file.fileno(),
             )
 
-        with open(f"/proc/{pid}/ns/mnt") as file:
+        with open(f"/proc/{self.pid}/ns/mnt") as file:
             self.assertRaisesRegex(
                 ValueError,
                 "not a network namespace inode",
                 get_net_ns_by_fd,
-                task,
+                self.task,
                 file.fileno(),
             )
+
+    def test_netdev_for_each_tx_queue(self):
+        for index, _ in socket.if_nameindex():
+            netdev = netdev_get_by_index(self.net, index)
+            for queue in netdev_for_each_tx_queue(netdev):
+                self.assertEqual(queue.dev, netdev)

--- a/tests/helpers/linux/test_tc.py
+++ b/tests/helpers/linux/test_tc.py
@@ -1,0 +1,114 @@
+# Copyright (c) ByteDance, Inc. and its affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import random
+import string
+import unittest
+
+from drgn.helpers.linux.fs import path_lookup
+from drgn.helpers.linux.net import get_net_ns_by_inode, netdev_get_by_name
+from drgn.helpers.linux.tc import qdisc_lookup
+from tests.helpers.linux import LinuxHelperTestCase
+
+try:
+    from pyroute2 import NetNS
+    from pyroute2.netlink.exceptions import NetlinkError
+
+    have_pyroute2 = True
+except ImportError:
+    have_pyroute2 = False
+
+
+@unittest.skipUnless(have_pyroute2, "pyroute2 not found")
+class TestTc(LinuxHelperTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ns = None
+        while cls.ns is None:
+            try:
+                cls.name = "".join(
+                    random.choice(string.ascii_letters) for _ in range(16)
+                )
+                cls.ns = NetNS(cls.name, flags=os.O_CREAT | os.O_EXCL)
+            except FileExistsError:
+                pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ns.remove()
+        super().tearDownClass()
+
+    def test_qdisc_lookup(self):
+        try:
+            self.ns.link("add", ifname="dummy0", kind="dummy")
+        except NetlinkError:
+            self.skipTest("kernel does not support dummy interface (CONFIG_DUMMY)")
+
+        dummy = self.ns.link_lookup(ifname="dummy0")[0]
+
+        # tc qdisc add dev dummy0 root handle 1: prio
+        try:
+            self.ns.tc(
+                "add",
+                kind="prio",
+                index=dummy,
+                handle="1:",
+                # default TCA_OPTIONS for sch_prio, see [iproute2] tc/q_prio.c:prio_parse_opt()
+                bands=3,
+                priomap=[1, 2, 2, 2, 1, 2, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+            )
+        except NetlinkError:
+            self.ns.link("delete", ifname="dummy0")
+            self.skipTest(
+                "kernel does not support Multi Band Priority Queueing (CONFIG_NET_SCH_PRIO)"
+            )
+        # tc qdisc add dev dummy0 parent 1:1 handle 10: sfq
+        try:
+            self.ns.tc("add", kind="sfq", index=dummy, parent="1:1", handle="10:")
+        except NetlinkError:
+            self.ns.link("delete", ifname="dummy0")
+            self.skipTest(
+                "kernel does not support Stochastic Fairness Queueing (CONFIG_NET_SCH_SFQ)"
+            )
+        # tc qdisc add dev dummy0 parent 1:2 handle 20: tbf rate 20kbit buffer 1600 limit 3000
+        try:
+            self.ns.tc(
+                "add",
+                kind="tbf",
+                index=dummy,
+                parent="1:2",
+                handle="20:",
+                rate=2500,
+                burst=1600,
+                limit=3000,
+            )
+        except NetlinkError:
+            self.ns.link("delete", ifname="dummy0")
+            self.skipTest(
+                "kernel does not support Token Bucket Filter (CONFIG_NET_SCH_TBF)"
+            )
+        # tc qdisc add dev dummy0 parent 1:3 handle 30: sfq
+        self.ns.tc("add", kind="sfq", index=dummy, parent="1:3", handle="30:")
+        # tc qdisc add dev dummy0 ingress
+        try:
+            self.ns.tc("add", kind="ingress", index=dummy)
+        except NetlinkError:
+            self.ns.link("delete", ifname="dummy0")
+            self.skipTest(
+                "kernel does not support ingress Qdisc (CONFIG_NET_SCH_INGRESS)"
+            )
+
+        inode = path_lookup(
+            self.prog, os.path.realpath(f"/var/run/netns/{self.name}")
+        ).dentry.d_inode
+        netdev = netdev_get_by_name(get_net_ns_by_inode(inode), "dummy0")
+
+        self.assertEqual(qdisc_lookup(netdev, 0x1).ops.id.string_(), b"prio")
+        self.assertEqual(qdisc_lookup(netdev, 0x10).ops.id.string_(), b"sfq")
+        self.assertEqual(qdisc_lookup(netdev, 0x20).ops.id.string_(), b"tbf")
+        self.assertEqual(qdisc_lookup(netdev, 0x30).ops.id.string_(), b"sfq")
+        self.assertEqual(qdisc_lookup(netdev, 0xFFFF).ops.id.string_(), b"ingress")
+
+        self.ns.link("delete", ifname="dummy0")


### PR DESCRIPTION
Hi Omar,

Two more helpers:
1. netdev_for_each_tx_queue(), this one is simple.
2. qdisc_lookup(), this one is for debugging Traffic Control (TC) issues.  I created new files for it (and its test) since TC setup is more complicated (I'm already depending on 5 kernel configs for testing a semi-realistic scenario, see commit message below), and we are planning to add more TC helpers :-)

I'm using `pyroute2` for TC testing, some questions:
1. Is it okay to use a `try` block around `pyroute2` `import`s and skip the entire `TestTc` upon `ImportError`?
2. I've tested it locally with several kernel configs on and off.  What should I do to let GitHub CI use `pyroute2` (and enable those kernel configs), or could you make that happen?
3. Should I, and/or where should I document that `drgn` testing now depends on `pyroute2`?

thanks,
ypl

---
[1/2] helpers: Add netdev_for_each_tx_queue()

Add a helper, netdev_for_each_tx_queue(), to iterate over all TX queues of
a network device.  As an example:

	>>> eth0 = netdev_get_by_name(prog, "eth0")
	>>> for txq in netdev_for_each_tx_queue(eth0):
	...     print(txq.qdisc.ops.id.string_().decode())
	...
	sfq
	tbf
	prio
	pfifo_fast
---
[2/2] helpers: Add qdisc_lookup()

Add a helper, qdisc_lookup(), to get a Qdisc (struct Qdisc *) from a
network device and a major handle number.  As an example:

	>>> eth0 = netdev_get_by_name(prog, "eth0")
	>>> tbf = qdisc_lookup(eth0, 0x20)
	>>> tbf.ops.id.string_().decode()
	tbf
	>>> ingress = qdisc_lookup(eth0, 0xffff)
	>>> ingress.ops.id.string_().decode()
	ingress

Testing depends on pyroute2.  `TestTc` is skipped if pyroute2 is not
found; test_qdisc_lookup() is skipped if the kernel is not build with the
following options:

	CONFIG_DUMMY
	CONFIG_NET_SCH_PRIO
	CONFIG_NET_SCH_SFQ
	CONFIG_NET_SCH_TBF
	CONFIG_NET_SCH_INGRESS