### PR TITLE
libdrgn: reads from segment mapping

### DIFF
--- a/libdrgn/memory_reader.c
+++ b/libdrgn/memory_reader.c
@@ -284,3 +284,29 @@ struct drgn_error *drgn_read_memory_file(void *buf, uint64_t address,
 	memset(p, 0, count);
 	return NULL;
 }
+
+struct drgn_error *drgn_read_memory_mmap(void *buf, uint64_t address,
+					 size_t count, uint64_t offset,
+					 void *arg, bool physical)
+{
+	struct drgn_memory_file_segment *file_segment = arg;
+	char *p = buf;
+	char *map_address = file_segment->map_address;
+	size_t file_count;
+
+	if (offset < file_segment->file_size) {
+		file_count = min((uint64_t)count,
+				 file_segment->file_size - offset);
+		count -= file_count;
+	} else {
+		file_count = 0;
+	}
+
+	if (file_count) {
+		memcpy(p, map_address + offset, file_count);
+		p += file_count;
+	}
+	memset(p, 0, count);
+
+	return NULL;
+}

--- a/libdrgn/memory_reader.h
+++ b/libdrgn/memory_reader.h
@@ -15,6 +15,9 @@
 #include "binary_search_tree.h"
 #include "drgn.h"
 
+/* align addr on a size boundary - adjust address down if needed */
+#define ALIGN_DOWN(x, a) ((uint64_t)(x)&(~((uint64_t)(a) - 1)))
+
 /**
  * @ingroup Internals
  *
@@ -134,6 +137,8 @@ struct drgn_memory_file_segment {
 	 * OS error.
 	 */
 	bool eio_is_fault;
+	/** segment mapping address. */
+	void *map_address;
 };
 
 /** @ref drgn_memory_read_fn which reads from a file. */
@@ -141,6 +146,10 @@ struct drgn_error *drgn_read_memory_file(void *buf, uint64_t address,
 					 size_t count, uint64_t offset,
 					 void *arg, bool physical);
 
+/** @ref drgn_memory_read_fn which reads from segment mmap. */
+struct drgn_error *drgn_read_memory_mmap(void *buf, uint64_t address,
+					 size_t count, uint64_t offset,
+					 void *arg, bool physical);
 /** @} */
 
 #endif /* DRGN_MEMORY_READER_H */

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -78,6 +78,8 @@ struct drgn_program {
 	struct drgn_memory_reader reader;
 	/* Elf core dump or /proc/pid/mem file segments. */
 	struct drgn_memory_file_segment *file_segments;
+	/* Number of loadable segments */
+	uint32_t num_file_segments;
 	/* Elf core dump. Not valid for live programs or kdump files. */
 	Elf *core;
 	/* File descriptor for ELF core dump, kdump file, or /proc/pid/mem. */


### PR DESCRIPTION
We added an mmap interface for kcore (https://lore.kernel.org/patchwork/patch/1453867/).
It can reduce system calls significantly when accessing the kernel data structures.
The patch will be merged into next kernel version.

Co-developed-by: Feng Zhou <zhoufeng.zf@bytedance.com>
Signed-off-by: chenying <chenying.kernel@bytedance.com>
