### PR TITLE
dwarf_index.c: Shrink abbrev tables before saving them in CUs

### DIFF
--- a/libdrgn/dwarf_index.c
+++ b/libdrgn/dwarf_index.c
@@ -838,6 +838,8 @@ static struct drgn_error *read_abbrev_table(struct drgn_dwarf_index_cu *cu,
 			return err;
 		}
 	}
+	uint8_vector_shrink_to_fit(&insns);
+	uint32_vector_shrink_to_fit(&decls);
 	cu->abbrev_decls = decls.data;
 	cu->num_abbrev_decls = decls.size;
 	cu->abbrev_insns = insns.data;


### PR DESCRIPTION
Firstly, there's no rush on the pulls I'm submitting at all - I'm just putting it on the queue for discussion later on.

In larger binaries, there can be a large number of CUs, and since we
store an abbrev table for each CU the extra space starts to add up.
The simplest way to mitigate this is to shrink the vectors before
saving them.

On a large binary, I noticed a memory reduction from 20.4G RES to 18.6G
RES (on initial load-in).

I'm not sure if this will cause a CPU regression, but at worst this would be an extra copy (and hopefully a realloc is cheaper than that), but I think the memory savings are worth it. I don't think a length is stored anywhere for abbrev tables, so I don't think we can pre-calculate the size here.
