### PR TITLE
Allow name lookup to fallback to local symbols

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -192,8 +192,12 @@ class Program:
     # address_or_name is positional-only.
     def symbol(self, address_or_name: Union[IntegerLike, str]) -> Symbol:
         """
-        Get the symbol containing the given address, or the global symbol with
-        the given name.
+        Get the symbol containing the given address, or symbol with the given
+        name.
+
+        When performing name lookups, global (i.e.
+        :class:`SymbolBinding.GLOBAL`) symbols are preferred, but a local
+        symbol may be returned if there is a local match and no global.
 
         :param address_or_name: The address or name.
         :raises LookupError: if no symbol contains the given address or matches

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -809,6 +809,11 @@ drgn_program_find_symbol_by_address(struct drgn_program *prog, uint64_t address,
 /**
  * Get the symbol corresponding to the given name.
  *
+ * If there is a global symbol which matches this name, then it is returned.
+ * Otherwise, an arbitrary local symbol may be returned if that is found. If
+ * there are no global or local symbols with this name, then the lookup fails
+ * with ::DRGN_ERROR_LOOKUP.
+ *
  * @param[out] ret The returned symbol. It should be freed with @ref
  * drgn_symbol_destroy().
  * @return @c NULL on success, non-@c NULL on error.


### PR DESCRIPTION
As discussed in #108, this commit allows the `Program.symbol()` method (or `drgn_program_find_symbol_by_name`) to fall back to returning a local symbol if no global is found. (Sorry for the delay)

The naive implementation would search once for globals, and then again for locals. But this would cause two lookups in the case of failure. So my implementation does a single search. When a global symbol is found, the search immediately returns. When a local symbol is found, it is stored for later use, unless another local symbol was already found.

If the search returned early, either an error occurred or a global was found, so free the fallback if necessary and return. If the search finished without aborting early, then return a fallback symbol if it w as found. Otherwise, raise a lookup error.

Testing below with drgn on a vmcore:

```
$ drgn -c vmcore -s vmlinux
could not get debugging information for:
kernel modules (could not read depmod: open: /lib/modules/5.4.17-2102.203.6.el8uek.x86_64/modules.dep.bin: No such file or directory)
drgn 0.0.14+30.g861160b.dirty (using Python 3.9.5, elfutils 0.180, with libkdumpfile)
For help, type help(drgn).
>>> import drgn
>>> from drgn import NULL, Object, cast, container_of, execscript, offsetof, reinterpret, sizeof
>>> from drgn.helpers.linux import *
>>> prog.symbol("schedule")
Symbol(name='schedule', address=0xffffffff92fd92e0, size=0x9a, binding=<SymbolBinding.GLOBAL: 2>, kind=<SymbolKind.FUNC: 2>)
>>> prog.symbol("slab_bug")
Symbol(name='slab_bug', address=0xffffffff928a6df3, size=0xbc, binding=<SymbolBinding.LOCAL: 1>, kind=<SymbolKind.FUNC: 2>)
>>> prog.symbol("name_show")
Symbol(name='name_show', address=0xffffffff927175d0, size=0x64, binding=<SymbolBinding.LOCAL: 1>, kind=<SymbolKind.FUNC: 2>)
```

I want to add some form of test -- it seems like it would be good to create a C program with a couple compilation units, add some static and global symbols, and make it call `abort()`. Then we could use the core dump to test symbol lookup without requiring root to look at the running kernel? Let me know your thoughts on this.