### PR TITLE
dwarf_index.c: lazily allocate shards to avoid memory use on empy ns

### DIFF
--- a/libdrgn/dwarf_index.c
+++ b/libdrgn/dwarf_index.c
@@ -19,6 +19,9 @@
 #include "platform.h"
 #include "util.h"
 
+static const size_t DRGN_DWARF_INDEX_SHARD_BITS = 8;
+static const size_t DRGN_DWARF_INDEX_NUM_SHARDS = 1 << DRGN_DWARF_INDEX_SHARD_BITS;
+
 struct drgn_dwarf_index_pending_cu {
 	struct drgn_debug_info_module *module;
 	const char *buf;
@@ -199,21 +202,35 @@ static inline size_t hash_pair_to_shard(struct hash_pair hp)
 	 */
 	return ((hp.first >>
 		 (8 * sizeof(size_t) - 8 - DRGN_DWARF_INDEX_SHARD_BITS)) &
-		(((size_t)1 << DRGN_DWARF_INDEX_SHARD_BITS) - 1));
+		(DRGN_DWARF_INDEX_NUM_SHARDS - 1));
 }
 
 static void
 drgn_dwarf_index_namespace_init(struct drgn_dwarf_index_namespace *ns,
 				struct drgn_dwarf_index *dindex)
 {
-	array_for_each(shard, ns->shards) {
+	ns->shards = NULL;
+	ns->dindex = dindex;
+	drgn_dwarf_index_pending_die_vector_init(&ns->pending_dies);
+	ns->saved_err = NULL;
+}
+
+static bool
+drgn_dwarf_index_namespace_shards_init(struct drgn_dwarf_index_namespace *ns)
+{
+	if (ns->shards)
+		return true;
+	ns->shards = malloc_array(DRGN_DWARF_INDEX_NUM_SHARDS,
+				  sizeof(*ns->shards));
+	if (!ns->shards)
+		return false;
+	for (size_t i = 0; i < DRGN_DWARF_INDEX_NUM_SHARDS; i++) {
+		struct drgn_dwarf_index_shard *shard = &ns->shards[i];
 		omp_init_lock(&shard->lock);
 		drgn_dwarf_index_die_map_init(&shard->map);
 		drgn_dwarf_index_die_vector_init(&shard->dies);
 	}
-	ns->dindex = dindex;
-	drgn_dwarf_index_pending_die_vector_init(&ns->pending_dies);
-	ns->saved_err = NULL;
+	return true;
 }
 
 void drgn_dwarf_index_init(struct drgn_dwarf_index *dindex)
@@ -236,17 +253,21 @@ drgn_dwarf_index_namespace_deinit(struct drgn_dwarf_index_namespace *ns)
 {
 	drgn_error_destroy(ns->saved_err);
 	drgn_dwarf_index_pending_die_vector_deinit(&ns->pending_dies);
-	array_for_each(shard, ns->shards) {
-		for (size_t j = 0; j < shard->dies.size; j++) {
-			struct drgn_dwarf_index_die *die = &shard->dies.data[j];
-			if (die->tag == DW_TAG_namespace) {
-				drgn_dwarf_index_namespace_deinit(die->namespace);
-				free(die->namespace);
+	if (ns->shards) {
+		for (size_t i = 0; i < DRGN_DWARF_INDEX_NUM_SHARDS; i++) {
+			struct drgn_dwarf_index_shard *shard = &ns->shards[i];
+			for (size_t j = 0; j < shard->dies.size; j++) {
+				struct drgn_dwarf_index_die *die = &shard->dies.data[j];
+				if (die->tag == DW_TAG_namespace) {
+					drgn_dwarf_index_namespace_deinit(die->namespace);
+					free(die->namespace);
+				}
 			}
+			drgn_dwarf_index_die_vector_deinit(&shard->dies);
+			drgn_dwarf_index_die_map_deinit(&shard->map);
+			omp_destroy_lock(&shard->lock);
 		}
-		drgn_dwarf_index_die_vector_deinit(&shard->dies);
-		drgn_dwarf_index_die_map_deinit(&shard->map);
-		omp_destroy_lock(&shard->lock);
+		free(ns->shards);
 	}
 }
 
@@ -2473,7 +2494,8 @@ next:
 
 static void drgn_dwarf_index_rollback(struct drgn_dwarf_index *dindex)
 {
-	array_for_each(shard, dindex->global.shards) {
+	for (size_t i = 0; i < DRGN_DWARF_INDEX_NUM_SHARDS; i++) {
+		struct drgn_dwarf_index_shard *shard = &dindex->global.shards[i];
 		/*
 		 * Because we're deleting everything that was added since the
 		 * last update, we can just shrink the dies array to the first
@@ -2535,6 +2557,9 @@ struct drgn_error *
 drgn_dwarf_index_update(struct drgn_dwarf_index_update_state *state)
 {
 	struct drgn_dwarf_index *dindex = state->dindex;
+
+	if (!drgn_dwarf_index_namespace_shards_init(&dindex->global))
+		return &drgn_enomem;
 
 	size_t old_cus_size = dindex->cus.size;
 	size_t new_cus_size = old_cus_size;
@@ -2640,6 +2665,9 @@ static struct drgn_error *index_namespace(struct drgn_dwarf_index_namespace *ns)
 {
 	if (ns->saved_err)
 		return drgn_error_copy(ns->saved_err);
+
+	if (!drgn_dwarf_index_namespace_shards_init(ns))
+		return &drgn_enomem;
 
 	struct drgn_error *err = NULL;
 	#pragma omp for schedule(dynamic)

--- a/libdrgn/dwarf_index.h
+++ b/libdrgn/dwarf_index.h
@@ -109,8 +109,6 @@ struct drgn_dwarf_index_shard {
 	struct drgn_dwarf_index_die_vector dies;
 };
 
-#define DRGN_DWARF_INDEX_SHARD_BITS 8
-
 /* A DIE with a DW_AT_specification attribute. */
 struct drgn_dwarf_index_specification {
 	/*
@@ -145,7 +143,7 @@ struct drgn_dwarf_index_namespace {
 	 *
 	 * This is sharded to reduce lock contention.
 	 */
-	struct drgn_dwarf_index_shard shards[1 << DRGN_DWARF_INDEX_SHARD_BITS];
+	struct drgn_dwarf_index_shard *shards;
 	/** Parent DWARF index. */
 	struct drgn_dwarf_index *dindex;
 	/** DIEs we have not indexed yet. */


### PR DESCRIPTION
Previously shards were allocated as soon as a namespace was
encountered, which means that we had a large array sitting around for
every ns we saw. By allocating them lazily, we can reduce this usage.

I'm not sure how much of a regression this will cause, but to me it seems pretty minimal.

I could have used a pointer to a fixed size array here instead of a normal pointer, but since this will likely become a dynamically sized array in the future, I left the type as a simple pointer.

There is one usage of shards in `drgn_dwarf_index_iterator_next` before initialization, but assuming that next is not called while the iterator is being initialized, it should be safe to my knowledge)