### PR TITLE
libdrgn: Follow typedefs in enum backing type lookup

### DIFF
--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -4194,7 +4194,7 @@ drgn_enum_type_from_dwarf(struct drgn_debug_info *dbinfo,
 					   &qualified_compatible_type);
 		if (err)
 			goto err;
-		compatible_type = qualified_compatible_type.type;
+		compatible_type = drgn_underlying_type(qualified_compatible_type.type);
 		if (drgn_type_kind(compatible_type) != DRGN_TYPE_INT) {
 			err = drgn_error_create(DRGN_ERROR_OTHER,
 						"DW_AT_type of DW_TAG_enumeration_type is not an integer type");

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -1723,6 +1723,65 @@ class TestTypes(TestCase):
             ),
         )
 
+    def test_enum_typedef(self):
+        prog = dwarf_program(
+            wrap_test_type_dies(
+                (
+                    DwarfDie(
+                        DW_TAG.enumeration_type,
+                        (
+                            DwarfAttrib(DW_AT.name, DW_FORM.string, "color"),
+                            DwarfAttrib(DW_AT.type, DW_FORM.ref4, 1),
+                            DwarfAttrib(DW_AT.byte_size, DW_FORM.data1, 4),
+                        ),
+                        (
+                            DwarfDie(
+                                DW_TAG.enumerator,
+                                (
+                                    DwarfAttrib(DW_AT.name, DW_FORM.string, "RED"),
+                                    DwarfAttrib(DW_AT.const_value, DW_FORM.data1, 0),
+                                ),
+                            ),
+                            DwarfDie(
+                                DW_TAG.enumerator,
+                                (
+                                    DwarfAttrib(DW_AT.name, DW_FORM.string, "GREEN"),
+                                    DwarfAttrib(DW_AT.const_value, DW_FORM.data1, 1),
+                                ),
+                            ),
+                            DwarfDie(
+                                DW_TAG.enumerator,
+                                (
+                                    DwarfAttrib(DW_AT.name, DW_FORM.string, "BLUE"),
+                                    DwarfAttrib(DW_AT.const_value, DW_FORM.data1, 2),
+                                ),
+                            ),
+                        ),
+                    ),
+                    DwarfDie(
+                        DW_TAG.typedef,
+                        (
+                            DwarfAttrib(DW_AT.name, DW_FORM.string, "__uint32_t"),
+                            DwarfAttrib(DW_AT.type, DW_FORM.ref4, 2),
+                        ),
+                    ),
+                    unsigned_int_die,
+                )
+            )
+        )
+        self.assertIdentical(
+            prog.type("TEST").type,
+            prog.enum_type(
+                "color",
+                prog.int_type("unsigned int", 4, False),
+                (
+                    TypeEnumerator("RED", 0),
+                    TypeEnumerator("GREEN", 1),
+                    TypeEnumerator("BLUE", 2),
+                ),
+            ),
+        )
+
     def test_enum_anonymous(self):
         prog = dwarf_program(
             wrap_test_type_dies(


### PR DESCRIPTION
In C++ enums can be a typedef to an int, not just an int itself.

The one questionable part is that we store the underlying type and not the typedef in the enum - but that seems fine to me. However, I think I should be able to store the typedef if we would like as well, I just have to see if it's being used as if it was an int elsewhere.
