### PR TITLE
libdrgn: fix for compilation error

### DIFF
--- a/libdrgn/dwarf_info.c
+++ b/libdrgn/dwarf_info.c
@@ -177,7 +177,7 @@ DEFINE_HASH_MAP(drgn_dwarf_index_die_map, struct nstring, uint32_t,
 		nstring_hash_pair, nstring_eq)
 DEFINE_VECTOR(drgn_dwarf_index_die_vector, struct drgn_dwarf_index_die)
 
-static const size_t DRGN_DWARF_INDEX_SHARD_BITS = 8;
+#define DRGN_DWARF_INDEX_SHARD_BITS 8
 static const size_t DRGN_DWARF_INDEX_NUM_SHARDS = 1 << DRGN_DWARF_INDEX_SHARD_BITS;
 
 /** Shard of a @ref drgn_namespace_dwarf_index. */


### PR DESCRIPTION
On older gcc version e.g. 7.3.1 , we get following compilation error

  CC       libdrgnimpl_la-dwarf_info.lo
../../libdrgn/dwarf_info.c:181:51: error: initializer element is not
constant
 static const size_t DRGN_DWARF_INDEX_NUM_SHARDS = 1 <<
DRGN_DWARF_INDEX_SHARD_BITS;

This fixes the compilation error on older versions of gcc

Signed-off-by: Alakesh Haloi <alakesh.haloi@gmail.com>