### PR TITLE
Rewrite linux helper iterators in C

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -2219,3 +2219,41 @@ def _linux_helper_kaslr_offset(prog: Program) -> int:
 def _linux_helper_pgtable_l5_enabled(prog: Program) -> bool:
     """Return whether 5-level paging is enabled."""
     ...
+
+def _linux_helper_radix_tree_for_each(root: Object) -> Iterator[Tuple[int, Object]]:
+    """
+    Iterate over all of the entries in a radix tree.
+
+    :param root: ``struct radix_tree_root *``
+    :return: Iterator of (index, ``void *``) tuples.
+    """
+    ...
+
+def _linux_helper_idr_for_each(idr: Object) -> Iterator[Tuple[int, Object]]:
+    """
+    Iterate over all of the entries in an IDR.
+
+    :param idr: ``struct idr *``
+    :return: Iterator of (index, ``void *``) tuples.
+    """
+    ...
+
+def _linux_helper_for_each_pid(prog_or_ns: Union[Program, Object]) -> Iterator[Object]:
+    """
+    Iterate over all PIDs in a namespace.
+
+    :param prog_or_ns: ``struct pid_namespace *`` to iterate over, or
+        :class:`Program` to iterate over initial PID namespace.
+    :return: Iterator of ``struct pid *`` objects.
+    """
+    ...
+
+def _linux_helper_for_each_task(prog_or_ns: Union[Program, Object]) -> Iterator[Object]:
+    """
+    Iterate over all of the tasks visible in a namespace.
+
+    :param prog_or_ns: ``struct pid_namespace *`` to iterate over, or
+        :class:`Program` to iterate over initial PID namespace.
+    :return: Iterator of ``struct task_struct *`` objects.
+    """
+    ...

--- a/drgn/helpers/linux/idr.py
+++ b/drgn/helpers/linux/idr.py
@@ -11,28 +11,12 @@ an ID to a pointer. This currently only supports Linux v4.11+; before this,
 IDRs were not based on radix trees.
 """
 
-from typing import Iterator, Tuple
-
-from _drgn import _linux_helper_idr_find as idr_find
-from drgn import Object
-from drgn.helpers.linux.radixtree import radix_tree_for_each
+from _drgn import (
+    _linux_helper_idr_find as idr_find,
+    _linux_helper_idr_for_each as idr_for_each,
+)
 
 __all__ = (
     "idr_find",
     "idr_for_each",
 )
-
-
-def idr_for_each(idr: Object) -> Iterator[Tuple[int, Object]]:
-    """
-    Iterate over all of the entries in an IDR.
-
-    :param idr: ``struct idr *``
-    :return: Iterator of (index, ``void *``) tuples.
-    """
-    try:
-        base = idr.idr_base.value_()
-    except AttributeError:
-        base = 0
-    for index, entry in radix_tree_for_each(idr.idr_rt.address_of_()):
-        yield index + base, entry

--- a/drgn/helpers/linux/pid.py
+++ b/drgn/helpers/linux/pid.py
@@ -9,16 +9,13 @@ The ``drgn.helpers.linux.pid`` module provides helpers for looking up process
 IDs and processes.
 """
 
-from typing import Iterator, Union
-
 from _drgn import (
     _linux_helper_find_pid as find_pid,
     _linux_helper_find_task as find_task,
+    _linux_helper_for_each_pid as for_each_pid,
+    _linux_helper_for_each_task as for_each_task,
     _linux_helper_pid_task as pid_task,
 )
-from drgn import Object, Program, cast, container_of
-from drgn.helpers.linux.idr import idr_for_each
-from drgn.helpers.linux.list import hlist_for_each_entry
 
 __all__ = (
     "find_pid",
@@ -27,49 +24,3 @@ __all__ = (
     "for_each_task",
     "pid_task",
 )
-
-
-def for_each_pid(prog_or_ns: Union[Program, Object]) -> Iterator[Object]:
-    """
-    Iterate over all PIDs in a namespace.
-
-    :param prog_or_ns: ``struct pid_namespace *`` to iterate over, or
-        :class:`Program` to iterate over initial PID namespace.
-    :return: Iterator of ``struct pid *`` objects.
-    """
-    if isinstance(prog_or_ns, Program):
-        prog = prog_or_ns
-        ns = prog_or_ns["init_pid_ns"].address_of_()
-    else:
-        prog = prog_or_ns.prog_
-        ns = prog_or_ns
-    if hasattr(ns, "idr"):
-        for nr, entry in idr_for_each(ns.idr):
-            yield cast("struct pid *", entry)
-    else:
-        pid_hash = prog["pid_hash"]
-        for i in range(1 << prog["pidhash_shift"].value_()):
-            for upid in hlist_for_each_entry(
-                "struct upid", pid_hash[i].address_of_(), "pid_chain"
-            ):
-                if upid.ns == ns:
-                    yield container_of(upid, "struct pid", f"numbers[{int(ns.level)}]")
-
-
-def for_each_task(prog_or_ns: Union[Program, Object]) -> Iterator[Object]:
-    """
-    Iterate over all of the tasks visible in a namespace.
-
-    :param prog_or_ns: ``struct pid_namespace *`` to iterate over, or
-        :class:`Program` to iterate over initial PID namespace.
-    :return: Iterator of ``struct task_struct *`` objects.
-    """
-    if isinstance(prog_or_ns, Program):
-        prog = prog_or_ns
-    else:
-        prog = prog_or_ns.prog_
-    PIDTYPE_PID = prog["PIDTYPE_PID"].value_()
-    for pid in for_each_pid(prog_or_ns):
-        task = pid_task(pid, PIDTYPE_PID)
-        if task:
-            yield task

--- a/drgn/helpers/linux/radixtree.py
+++ b/drgn/helpers/linux/radixtree.py
@@ -9,54 +9,12 @@ The ``drgn.helpers.linux.radixtree`` module provides helpers for working with
 radix trees from :linux:`include/linux/radix-tree.h`.
 """
 
-from typing import Iterator, Tuple
-
-from _drgn import _linux_helper_radix_tree_lookup as radix_tree_lookup
-from drgn import Object, cast
+from _drgn import (
+    _linux_helper_radix_tree_for_each as radix_tree_for_each,
+    _linux_helper_radix_tree_lookup as radix_tree_lookup,
+)
 
 __all__ = (
     "radix_tree_for_each",
     "radix_tree_lookup",
 )
-
-_RADIX_TREE_ENTRY_MASK = 3
-
-
-def _is_internal_node(node: Object, internal_node: int) -> bool:
-    return (node.value_() & _RADIX_TREE_ENTRY_MASK) == internal_node
-
-
-def _entry_to_node(node: Object, internal_node: int) -> Object:
-    return Object(node.prog_, node.type_, value=node.value_() & ~internal_node)
-
-
-def _radix_tree_root_node(root: Object) -> Tuple[Object, int]:
-    try:
-        node = root.xa_head
-    except AttributeError:
-        return root.rnode.read_(), 1
-    else:
-        return cast("struct xa_node *", node).read_(), 2
-
-
-def radix_tree_for_each(root: Object) -> Iterator[Tuple[int, Object]]:
-    """
-    Iterate over all of the entries in a radix tree.
-
-    :param root: ``struct radix_tree_root *``
-    :return: Iterator of (index, ``void *``) tuples.
-    """
-    node, RADIX_TREE_INTERNAL_NODE = _radix_tree_root_node(root)
-
-    def aux(node: Object, index: int) -> Iterator[Tuple[int, Object]]:
-        if _is_internal_node(node, RADIX_TREE_INTERNAL_NODE):
-            parent = _entry_to_node(node, RADIX_TREE_INTERNAL_NODE)
-            for i, slot in enumerate(parent.slots):
-                yield from aux(
-                    cast(parent.type_, slot).read_(),
-                    index + (i << parent.shift.value_()),
-                )
-        elif node:
-            yield index, cast("void *", node)
-
-    yield from aux(node, 0)

--- a/libdrgn/helpers.h
+++ b/libdrgn/helpers.h
@@ -15,6 +15,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "drgn.h"
+#include "vector.h"
 
 struct drgn_object;
 struct drgn_program;
@@ -42,5 +44,101 @@ struct drgn_error *linux_helper_pid_task(struct drgn_object *res,
 struct drgn_error *linux_helper_find_task(struct drgn_object *res,
 					  const struct drgn_object *ns,
 					  uint64_t pid);
+
+/**
+ * Iterator convention:
+ *
+ * For all of the iterators defined below, the convention for each of the
+ * `*_next` functions is that upon returning, `*ret` will point to space
+ * allocated inside of `iter`. The caller is free to do what they wish with
+ * this return value, but should note that it will be overwritten the next time
+ * the `*_next` function is called.
+ */
+
+DEFINE_VECTOR_TYPE(linux_helper_radix_tree_iter_frame_vector,
+		   struct linux_helper_radix_tree_iter_frame)
+
+struct linux_helper_radix_tree_iter_entry {
+	uint64_t index;
+	struct drgn_object node;
+};
+
+struct linux_helper_radix_tree_iter {
+	bool started;
+	struct drgn_object root;
+	// Current value to be yielded
+	struct linux_helper_radix_tree_iter_entry entry;
+	// We need this for later initialization of `drgn_object`s
+	struct drgn_program *prog;
+	// Frames to keep track of generator state
+	struct linux_helper_radix_tree_iter_frame_vector frames;
+	// One-time setup values that are persistent
+	uint64_t RADIX_TREE_INTERNAL_NODE;
+	uint64_t RADIX_TREE_MAP_MASK;
+	struct drgn_qualified_type node_type;
+};
+
+struct drgn_error *linux_helper_radix_tree_iter_init(struct linux_helper_radix_tree_iter *iter,
+						     const struct drgn_object *root);
+
+void linux_helper_radix_tree_iter_deinit(struct linux_helper_radix_tree_iter *iter);
+
+struct drgn_error *linux_helper_radix_tree_iter_next(struct linux_helper_radix_tree_iter *iter,
+						     struct linux_helper_radix_tree_iter_entry **ret);
+
+struct linux_helper_idr_iter {
+	struct linux_helper_radix_tree_iter iter;
+	uint64_t base;
+};
+
+struct drgn_error *linux_helper_idr_iter_init(struct linux_helper_idr_iter *iter,
+					      const struct drgn_object *idr);
+
+void linux_helper_idr_iter_deinit(struct linux_helper_idr_iter *iter);
+
+struct drgn_error *linux_helper_idr_iter_next(struct linux_helper_idr_iter *iter,
+					      struct linux_helper_radix_tree_iter_entry **ret);
+
+struct linux_helper_pid_iter {
+	bool has_idr;
+	struct drgn_qualified_type pid_type;
+	union {
+		// if has_idr
+		struct linux_helper_idr_iter iter;
+		// else
+		struct {
+			struct drgn_qualified_type upid_type;
+			struct drgn_object pid_hash;
+			struct drgn_object pos; // a `struct hlist_node*`
+			struct drgn_object ns;
+			struct drgn_object entry; // Current value of the iterator
+			size_t index; // Current loop index
+			char member_specifier[sizeof("numbers[]") + 20];
+			// 20 = maximum length of a uint64_t as a string
+			// Space for the null terminator is included as part of the sizeof on the string literal
+		};
+	};
+};
+
+struct drgn_error *linux_helper_pid_iter_init(struct linux_helper_pid_iter *iter,
+					      const struct drgn_object *ns);
+
+void linux_helper_pid_iter_deinit(struct linux_helper_pid_iter *iter);
+
+struct drgn_error *linux_helper_pid_iter_next(struct linux_helper_pid_iter *iter,
+					      struct drgn_object **ret);
+
+struct linux_helper_task_iter {
+	struct linux_helper_pid_iter iter;
+	uint64_t PIDTYPE_PID;
+};
+
+struct drgn_error *linux_helper_task_iter_init(struct linux_helper_task_iter *iter,
+					       const struct drgn_object *ns);
+
+void linux_helper_task_iter_deinit(struct linux_helper_task_iter *iter);
+
+struct drgn_error *linux_helper_task_iter_next(struct linux_helper_task_iter *iter,
+					       struct drgn_object **ret);
 
 #endif /* DRGN_HELPERS_H */

--- a/libdrgn/python/drgnpy.h
+++ b/libdrgn/python/drgnpy.h
@@ -97,6 +97,14 @@ typedef struct {
 	struct pyobjectp_set objects;
 } Program;
 
+typedef struct _GenericIterator {
+	PyObject_HEAD
+	Program *prog;
+	void *iter;
+	PyObject *(*next)(struct _GenericIterator *);
+	void (*iter_deinit)(void *);
+} GenericIterator;
+
 typedef struct {
 	PyObject_HEAD
 	const struct drgn_register *reg;
@@ -167,6 +175,7 @@ extern PyObject *TypeKind_class;
 extern PyTypeObject DrgnObject_type;
 extern PyTypeObject DrgnType_type;
 extern PyTypeObject FaultError_type;
+extern PyTypeObject GenericIterator_type;
 extern PyTypeObject Language_type;
 extern PyTypeObject ObjectIterator_type;
 extern PyTypeObject Platform_type;
@@ -297,5 +306,17 @@ PyObject *drgnpy_linux_helper_kaslr_offset(PyObject *self, PyObject *args,
 					   PyObject *kwds);
 PyObject *drgnpy_linux_helper_pgtable_l5_enabled(PyObject *self, PyObject *args,
 						 PyObject *kwds);
+GenericIterator *drgnpy_linux_helper_for_each_task(PyObject *self,
+						      PyObject *args,
+						      PyObject *kwds);
+GenericIterator *drgnpy_linux_helper_for_each_pid(PyObject *self,
+						     PyObject *args,
+						     PyObject *kwds);
+GenericIterator *drgnpy_linux_helper_idr_for_each(PyObject *self,
+						     PyObject *args,
+						     PyObject *kwds);
+GenericIterator *drgnpy_linux_helper_radix_tree_for_each(PyObject *self,
+							    PyObject *args,
+							    PyObject *kwds);
 
 #endif /* DRGNPY_H */

--- a/libdrgn/python/helpers.c
+++ b/libdrgn/python/helpers.c
@@ -249,3 +249,251 @@ PyObject *drgnpy_linux_helper_pgtable_l5_enabled(PyObject *self, PyObject *args,
 		return PyErr_Format(PyExc_ValueError, "not Linux kernel");
 	Py_RETURN_BOOL(prog->prog.vmcoreinfo.pgtable_l5_enabled);
 }
+
+static void GenericIterator_dealloc(GenericIterator *self)
+{
+	if (self->iter) {
+		self->iter_deinit(self->iter);
+		free(self->iter);
+	}
+	Py_XDECREF(self->prog);
+	Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyObject *GenericIterator_next(GenericIterator *self)
+{
+	return self->next(self);
+}
+
+PyTypeObject GenericIterator_type = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	.tp_name = "_drgn._GenericIterator",
+	.tp_basicsize = sizeof(GenericIterator),
+	.tp_dealloc = (destructor)GenericIterator_dealloc,
+	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_iter = PyObject_SelfIter,
+	.tp_iternext = (iternextfunc)GenericIterator_next,
+};
+
+static PyObject *for_each_task_next(GenericIterator *self)
+{
+	struct drgn_error *err;
+	struct drgn_object *entry;
+	err = linux_helper_task_iter_next(self->iter, &entry);
+	if (err)
+		return set_drgn_error(err);
+	if (!entry)
+		return NULL;
+	DrgnObject *ret = DrgnObject_alloc(self->prog);
+	if (!ret)
+		return NULL;
+	err = drgn_object_copy(&ret->obj, entry);
+	if (err) {
+		Py_DECREF(ret);
+		return set_drgn_error(err);
+	}
+	return (PyObject *)ret;
+}
+
+GenericIterator *drgnpy_linux_helper_for_each_task(PyObject *self,
+						   PyObject *args,
+						   PyObject *kwds)
+{
+	static char *keywords[] = {"prog_or_ns", NULL};
+	struct drgn_error *err = NULL;
+	struct prog_or_ns_arg prog_or_ns;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&:for_each_task",
+					 keywords, &prog_or_pid_ns_converter,
+					 &prog_or_ns))
+		return NULL;
+
+	GenericIterator *iterator =
+		(GenericIterator *)GenericIterator_type.tp_alloc(
+			&GenericIterator_type, 0);
+	if (!iterator)
+		goto out;
+	iterator->prog = prog_or_ns.prog;
+	Py_INCREF(iterator->prog);
+	iterator->next = for_each_task_next;
+	iterator->iter_deinit = (void (*)(void *))linux_helper_task_iter_deinit;
+	iterator->iter = malloc(sizeof(struct linux_helper_task_iter));
+	if (!iterator->iter) {
+		PyErr_NoMemory();
+		Py_DECREF(iterator);
+		iterator = NULL;
+		goto out;
+	}
+	err = linux_helper_task_iter_init(iterator->iter, prog_or_ns.ns);
+	if (err) {
+		set_drgn_error(err);
+		Py_DECREF(iterator);
+		iterator = NULL;
+	}
+out:
+	prog_or_ns_cleanup(&prog_or_ns);
+	return iterator;
+}
+
+static PyObject *for_each_pid_next(GenericIterator *self)
+{
+	struct drgn_error *err;
+	struct drgn_object *entry;
+	err = linux_helper_pid_iter_next(self->iter, &entry);
+	if (err)
+		return set_drgn_error(err);
+	if (!entry)
+		return NULL;
+	DrgnObject *ret = DrgnObject_alloc(self->prog);
+	if (!ret)
+		return NULL;
+	err = drgn_object_copy(&ret->obj, entry);
+	if (err) {
+		Py_DECREF(ret);
+		return set_drgn_error(err);
+	}
+	return (PyObject *)ret;
+}
+
+GenericIterator *
+drgnpy_linux_helper_for_each_pid(PyObject *self, PyObject *args, PyObject *kwds)
+{
+	static char *keywords[] = {"prog_or_ns", NULL};
+	struct drgn_error *err = NULL;
+	struct prog_or_ns_arg prog_or_ns;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&:for_each_pid",
+					 keywords, &prog_or_pid_ns_converter,
+					 &prog_or_ns))
+		return NULL;
+
+	GenericIterator *iterator =
+		(GenericIterator *)GenericIterator_type.tp_alloc(
+			&GenericIterator_type, 0);
+	if (!iterator)
+		goto out;
+	iterator->prog = prog_or_ns.prog;
+	Py_INCREF(iterator->prog);
+	iterator->next = for_each_pid_next;
+	iterator->iter_deinit = (void (*)(void *))linux_helper_pid_iter_deinit;
+	iterator->iter = malloc(sizeof(struct linux_helper_pid_iter));
+	if (!iterator->iter) {
+		PyErr_NoMemory();
+		Py_DECREF(iterator);
+		iterator = NULL;
+		goto out;
+	}
+	err = linux_helper_pid_iter_init(iterator->iter, prog_or_ns.ns);
+	if (err) {
+		set_drgn_error(err);
+		Py_DECREF(iterator);
+		iterator = NULL;
+	}
+out:
+	prog_or_ns_cleanup(&prog_or_ns);
+	return iterator;
+}
+
+static PyObject *idr_iter_entry_wrap(struct linux_helper_radix_tree_iter_entry *entry,
+				     Program *prog)
+{
+	DrgnObject *node = DrgnObject_alloc(prog);
+	if (!node)
+		return NULL;
+	struct drgn_error *err = drgn_object_copy(&node->obj, &entry->node);
+	if (err) {
+		Py_DECREF(node);
+		return set_drgn_error(err);
+	}
+	PyObject *ret =
+		Py_BuildValue("KO", (unsigned long long)entry->index, node);
+	Py_DECREF(node);
+	return ret;
+}
+
+static PyObject *idr_for_each_next(GenericIterator *self)
+{
+	struct linux_helper_radix_tree_iter_entry *entry;
+	struct drgn_error *err = linux_helper_idr_iter_next(self->iter, &entry);
+	if (err)
+		return set_drgn_error(err);
+	if (!entry)
+		return NULL;
+	return idr_iter_entry_wrap(entry, self->prog);
+}
+
+GenericIterator *
+drgnpy_linux_helper_idr_for_each(PyObject *self, PyObject *args, PyObject *kwds)
+{
+	static char *keywords[] = {"idr", NULL};
+	struct drgn_error *err;
+	DrgnObject *idr;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!:idr_for_each",
+					 keywords, &DrgnObject_type, &idr))
+		return NULL;
+
+	GenericIterator *iterator =
+		(GenericIterator *)GenericIterator_type.tp_alloc(
+			&GenericIterator_type, 0);
+	if (!iterator)
+		return NULL;
+	iterator->prog = DrgnObject_prog(idr);
+	Py_INCREF(iterator->prog);
+	iterator->next = idr_for_each_next;
+	iterator->iter_deinit = (void (*)(void *))linux_helper_idr_iter_deinit;
+	iterator->iter = malloc(sizeof(struct linux_helper_idr_iter));
+	if (!iterator->iter) {
+		Py_DECREF(iterator);
+		return (GenericIterator *)PyErr_NoMemory();
+	}
+	err = linux_helper_idr_iter_init(iterator->iter, &idr->obj);
+	if (err) {
+		Py_DECREF(iterator);
+		return set_drgn_error(err);
+	}
+	return iterator;
+}
+
+static PyObject *radix_tree_for_each_next(GenericIterator *self)
+{
+	struct linux_helper_radix_tree_iter_entry *entry;
+	struct drgn_error *err = linux_helper_radix_tree_iter_next(self->iter, &entry);
+	if (err)
+		return set_drgn_error(err);
+	if (!entry)
+		return NULL;
+	return idr_iter_entry_wrap(entry, self->prog);
+}
+
+GenericIterator *drgnpy_linux_helper_radix_tree_for_each(PyObject *self,
+							 PyObject *args,
+							 PyObject *kwds)
+{
+	static char *keywords[] = {"root", NULL};
+	struct drgn_error *err;
+	DrgnObject *root;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!:radix_tree_for_each",
+					 keywords, &DrgnObject_type, &root))
+		return NULL;
+
+	GenericIterator *iterator =
+		(GenericIterator *)GenericIterator_type.tp_alloc(
+			&GenericIterator_type, 0);
+	if (!iterator)
+		return NULL;
+	iterator->prog = DrgnObject_prog(root);
+	Py_INCREF(iterator->prog);
+	iterator->next = radix_tree_for_each_next;
+	iterator->iter_deinit = (void (*)(void *))linux_helper_radix_tree_iter_deinit;
+	iterator->iter = malloc(sizeof(struct linux_helper_radix_tree_iter));
+	if (!iterator->iter) {
+		Py_DECREF(iterator);
+		return (GenericIterator *)PyErr_NoMemory();
+	}
+	err = linux_helper_radix_tree_iter_init(iterator->iter, &root->obj);
+	if (err) {
+		Py_DECREF(iterator);
+		return set_drgn_error(err);
+	}
+	return iterator;
+}

--- a/libdrgn/python/module.c
+++ b/libdrgn/python/module.c
@@ -141,6 +141,18 @@ static PyMethodDef drgn_methods[] = {
 	{"_linux_helper_pgtable_l5_enabled",
 	 (PyCFunction)drgnpy_linux_helper_pgtable_l5_enabled,
 	 METH_VARARGS | METH_KEYWORDS},
+	{"_linux_helper_for_each_task",
+	 (PyCFunction)drgnpy_linux_helper_for_each_task,
+	 METH_VARARGS | METH_KEYWORDS, drgn__linux_helper_for_each_task_DOC},
+	{"_linux_helper_for_each_pid",
+	 (PyCFunction)drgnpy_linux_helper_for_each_pid,
+	 METH_VARARGS | METH_KEYWORDS, drgn__linux_helper_for_each_pid_DOC},
+	{"_linux_helper_idr_for_each",
+	 (PyCFunction)drgnpy_linux_helper_idr_for_each,
+	 METH_VARARGS | METH_KEYWORDS, drgn__linux_helper_idr_for_each_DOC},
+	{"_linux_helper_radix_tree_for_each",
+	 (PyCFunction)drgnpy_linux_helper_radix_tree_for_each,
+	 METH_VARARGS | METH_KEYWORDS, drgn__linux_helper_radix_tree_for_each_DOC},
 	{},
 };
 
@@ -230,6 +242,7 @@ DRGNPY_PUBLIC PyMODINIT_FUNC PyInit__drgn(void)
 	    add_type(m, &StackTrace_type) ||
 	    add_type(m, &Symbol_type) ||
 	    add_type(m, &DrgnType_type) ||
+	    add_type(m, &GenericIterator_type) ||
 	    add_type(m, &TypeEnumerator_type) ||
 	    add_type(m, &TypeMember_type) ||
 	    add_type(m, &TypeParameter_type) ||


### PR DESCRIPTION
This was split off from #129 per @osandov's request.

In preparation for introducing an API to represent threads, the linux
helper iterators, radix_tree_for_each, idr_for_each, for_each_pid, and
for_each_task have been rewritten in C. This will allow them to be
accessed from libdrgn, which will be necessary for the threads API.

Signed-off-by: Kevin Svetlitski <svetlitski@fb.com>