### PR TITLE
Silence mypy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Generate version.py
         run: python setup.py --version
       - name: Check with mypy
-        run: mypy --strict --no-warn-return-any drgn _drgn.pyi
+        run: mypy --strict --no-warn-return-any --no-warn-unused-ignores drgn _drgn.pyi
       - name: Build and test with ${{ matrix.cc }}
         run: python setup.py test -K
 

--- a/drgn/helpers/linux/__init__.py
+++ b/drgn/helpers/linux/__init__.py
@@ -32,8 +32,9 @@ Translates to the following code in Python:
 
 import importlib
 import pkgutil
+from typing import List
 
-__all__ = []
+__all__: List[str] = []
 for _module_info in pkgutil.iter_modules(
     __path__,  # type: ignore[name-defined]  # python/mypy#1422
     prefix=__name__ + ".",


### PR DESCRIPTION
With mypy 0.920, two warnings appear on current main:

```
$ mypy --strict --no-warn-return-any drgn _drgn.pyi
drgn/helpers/linux/__init__.py:36: error: Need type annotation for "__all__" (hint: "__all__: List[<type>] = ...")
drgn/helpers/linux/__init__.py:38: error: unused "type: ignore" comment
Found 2 errors in 1 file (checked 33 source files)
```

The "unused" type:ignore directive was necessary for prior versions, so
add --no-warn-unused-ignores, so that we pass on multiple versions.
Apply a List[str] annotation to the __all__ variable to silence the
other error.