### PR TITLE
Ensure compile_commands.json contains `-Wall`

### DIFF
--- a/scripts/iwyu.py
+++ b/scripts/iwyu.py
@@ -169,6 +169,7 @@ def ignore_line(path, state, line):
 
 
 def main():
+    os.environ["CFLAGS"] = "-Wall"
     parser = argparse.ArgumentParser(description="run include-what-you-use on drgn")
     parser.add_argument(
         "source", nargs="*", help="run on given file instead of all source files"


### PR DESCRIPTION
This minor change is a quality of life improvement ensuring developers
receive more warnings and diagnostics in their editors.

Signed-off-by: Kevin Svetlitski <svetlitski@fb.com>