### PR TITLE
Add pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install busybox-static libelf-dev libdw-dev qemu-kvm zstd ${{ matrix.cc == 'clang' && 'libomp-$(clang --version | sed -rn "s/.*clang version ([0-9]+).*/\\1/p")-dev' || '' }}
-          pip install mypy pyroute2
+          pip install pyroute2 pre-commit
       - name: Generate version.py
         run: python setup.py --version
       - name: Check with mypy
-        run: mypy --strict --no-warn-return-any --no-warn-unused-ignores drgn _drgn.pyi
+        run: pre-commit run --all-files mypy
       - name: Build and test with ${{ matrix.cc }}
         run: python setup.py test -K
 
@@ -38,8 +38,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
       - name: Install dependencies
-        run: pip install black isort
-      - name: Check with black
-        run: black --check --diff .
-      - name: Check with isort
-        run: isort --check --diff .
+        run: pip install pre-commit
+      - name: Run pre-commit hooks
+        run: SKIP=mypy pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
+        name: isort (python)
+-   repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+    -   id: mypy
+        args: [--strict, --no-warn-return-any, --no-warn-unused-ignores]
+        files: ^drgn/.*\.py|_drgn.pyi$

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,6 +109,15 @@ and `isort <https://github.com/timothycrosley/isort>`_:
 Type hints should be provided for all interfaces (including helpers and the C
 extension).
 
+These requirements are checked by automated builds for pull requests. If you'd
+like to have them automatically checked prior to submission, you can install
+`pre-commit <https://pre-commit.com/>`_ hooks which will apply the isort, black,
+and mypy rules prior to committing:
+
+.. code-block:: console
+
+    $ pip install pre-commit && pre-commit install --install-hooks
+
 Submitting PRs
 --------------
 

--- a/libdrgn/build-aux/gen_constants.py
+++ b/libdrgn/build-aux/gen_constants.py
@@ -127,7 +127,7 @@ PyObject *TypeKind_class;
         "SymbolBinding",
         "Enum",
         (),
-        "DRGN_SYMBOL_BINDING_([a-z-A-Z0-9_]+)"
+        "DRGN_SYMBOL_BINDING_([a-z-A-Z0-9_]+)",
     )
     gen_constant_class(
         drgn_h,
@@ -135,7 +135,7 @@ PyObject *TypeKind_class;
         "SymbolKind",
         "Enum",
         (),
-        "DRGN_SYMBOL_KIND_([a-z-A-Z0-9_]+)"
+        "DRGN_SYMBOL_KIND_([a-z-A-Z0-9_]+)",
     )
     gen_constant_class(
         drgn_h, output_file, "TypeKind", "Enum", (), r"DRGN_TYPE_([a-zA-Z0-9_]+)"


### PR DESCRIPTION
In my past Python projects I've relied on pre-commit hooks to catch lint errors before I even push my branch to CI. I found this to be super useful (and have already re-pushed quite a few drgn commits after realizing I forgot to run black / isort / mypy).

This PR adds support for the pre-commit tool, including the equivalent checks which are run during test/lint stages. Developers can install it locally with `pre-commit install --install-hooks`, where it will check your changed files prior to each commit. I ran the pre-commit hooks across all files and caught one black reformatting (which may have been my fault anyway...), which I included here. Finally, I updated the CI steps to directly call pre-commit for linting.

This means that all linter versions and arguments can be stored in a single place (`.pre-commit-config.yaml`), and since the versions are pinned, the lint errors should be reproducible locally and on CI.

Consider this closer to an RFC. It's ready to merge but I don't know if it's a direction you're interested in going.