### PR TITLE
Live userspace process support for the Threads API

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -853,6 +853,21 @@ class Thread:
         :meth:`Program.stack_trace()`.
         """
         ...
+    def pause(self) -> None:
+        """
+        Suspend execution of this thread until :meth:`Thread.resume()` is called.
+
+        This function shoulld only be called when debugging a live userspace process.
+        """
+        ...
+    def resume(self) -> None:
+        """
+        Resume execution of this thread. It is an error to call this function
+        without having previously called :meth:`Thread.pause()`.
+
+        This function should only be called when debugging a live userspace process.
+        """
+        ...
 
 def filename_matches(haystack: Optional[str], needle: Optional[str]) -> bool:
     """

--- a/libdrgn/arch_x86_64.c
+++ b/libdrgn/arch_x86_64.c
@@ -341,6 +341,16 @@ pt_regs_get_initial_registers_x86_64(const struct drgn_object *obj,
 }
 
 static struct drgn_error *
+user_regs_struct_get_initial_registers_x86_64(struct drgn_program *prog,
+					      const void *user_regs_struct,
+					      struct drgn_register_state **ret)
+{
+	return get_initial_registers_from_struct_x86_64(
+		prog, user_regs_struct, arch_info_x86_64.user_regs_struct_size,
+		ret);
+}
+
+static struct drgn_error *
 prstatus_get_initial_registers_x86_64(struct drgn_program *prog,
 				      const void *prstatus, size_t size,
 				      struct drgn_register_state **ret)
@@ -751,10 +761,12 @@ const struct drgn_architecture_info arch_info_x86_64 = {
 	.default_flags = (DRGN_PLATFORM_IS_64_BIT |
 			  DRGN_PLATFORM_IS_LITTLE_ENDIAN),
 	DRGN_ARCHITECTURE_REGISTERS,
+	.user_regs_struct_size = 216,
 	.default_dwarf_cfi_row = &default_dwarf_cfi_row_x86_64,
 	.orc_to_cfi = orc_to_cfi_x86_64,
 	.fallback_unwind = fallback_unwind_x86_64,
 	.pt_regs_get_initial_registers = pt_regs_get_initial_registers_x86_64,
+	.user_regs_struct_get_initial_registers = user_regs_struct_get_initial_registers_x86_64,
 	.prstatus_get_initial_registers = prstatus_get_initial_registers_x86_64,
 	.linux_kernel_get_initial_registers =
 		linux_kernel_get_initial_registers_x86_64,

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2825,6 +2825,31 @@ struct drgn_error *drgn_thread_dup(const struct drgn_thread *thread,
 void drgn_thread_destroy(struct drgn_thread *thread);
 
 /**
+ * Suspend the execution of a thread.
+ *
+ * This function may only be called when the target program is a live userspace
+ * process. Calling this function more than once on the same @p thread without
+ * first calling @ref drgn_thread_resume on @p thread will result in an error.
+ *
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_thread_pause(struct drgn_thread *thread);
+
+/**
+ * Resume the execution of a paused thread.
+ *
+ * This function may only be called when the target program is a live userspace
+ * process. Calling this function on a given @p thread without having
+ * previously paused that thread (via @ref drgn_thread_pause) will result in an
+ * error. Similarly, calling this function more than once on the same @p thread
+ * without first calling @ref drgn_thread_pause on @p thread will result in an
+ * error.
+ *
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_thread_resume(struct drgn_thread *thread);
+
+/**
  * @struct drgn_thread_iterator
  *
  * An iterator over all the threads in a program.

--- a/libdrgn/platform.h
+++ b/libdrgn/platform.h
@@ -82,6 +82,7 @@ struct drgn_architecture_info {
 	enum drgn_platform_flags default_flags;
 	const struct drgn_register *registers;
 	size_t num_registers;
+	size_t user_regs_struct_size;
 	const struct drgn_register *(*register_by_name)(const char *name);
 	const struct drgn_register_layout *register_layout;
 	drgn_register_number (*dwarf_regno_to_internal)(uint64_t);
@@ -100,6 +101,9 @@ struct drgn_architecture_info {
 	/* Given pt_regs as a value buffer object. */
 	struct drgn_error *(*pt_regs_get_initial_registers)(const struct drgn_object *,
 							    struct drgn_register_state **);
+	struct drgn_error *(*user_regs_struct_get_initial_registers)(struct drgn_program *,
+								const void *,
+								struct drgn_register_state **);
 	struct drgn_error *(*prstatus_get_initial_registers)(struct drgn_program *,
 							     const void *,
 							     size_t,

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -71,9 +71,15 @@ struct drgn_thread {
 	struct drgn_object object;
 };
 
+struct drgn_thread_status {
+	uint32_t tid;
+	bool is_paused;
+};
+
 DEFINE_VECTOR_TYPE(drgn_typep_vector, struct drgn_type *)
 DEFINE_VECTOR_TYPE(drgn_prstatus_vector, struct nstring)
 DEFINE_HASH_TABLE_TYPE(drgn_thread_set, struct drgn_thread)
+DEFINE_HASH_TABLE_TYPE(drgn_thread_status_set, struct drgn_thread_status)
 
 struct drgn_thread_iterator;
 
@@ -151,8 +157,11 @@ struct drgn_program {
 		 * map.
 		 */
 		struct drgn_prstatus_vector prstatus_vector;
-		/* For userspace programs, threads indexed by PID. */
+		/* For userspace core dumps, threads indexed by PID. */
 		struct drgn_thread_set thread_set;
+		/* For live userspace programs, tracks if threads are paused,
+		 * indexed by PID. */
+		struct drgn_thread_status_set thread_status_set;
 	};
 	struct drgn_thread *crashed_thread;
 	bool core_dump_notes_cached;
@@ -265,6 +274,10 @@ drgn_program_address_mask(const struct drgn_program *prog, uint64_t *ret)
 	*ret = drgn_platform_address_mask(&prog->platform);
 	return NULL;
 }
+
+
+struct drgn_error *drgn_thread_is_paused(const struct drgn_thread *thread,
+					 bool *ret);
 
 struct drgn_error *drgn_thread_dup_internal(const struct drgn_thread *thread,
 					    struct drgn_thread *ret);

--- a/libdrgn/python/thread.c
+++ b/libdrgn/python/thread.c
@@ -66,6 +66,22 @@ static PyObject *Thread_stack_trace(Thread *self)
 	return ret;
 }
 
+static PyObject* Thread_pause(Thread *self)
+{
+	struct drgn_error *err = drgn_thread_pause(&self->thread);
+	if (err)
+		return set_drgn_error(err);
+	Py_RETURN_NONE;
+}
+
+static PyObject* Thread_resume(Thread *self)
+{
+	struct drgn_error *err = drgn_thread_resume(&self->thread);
+	if (err)
+		return set_drgn_error(err);
+	Py_RETURN_NONE;
+}
+
 static PyGetSetDef Thread_getset[] = {
 	{"tid", (getter)Thread_get_tid, NULL, drgn_Thread_tid_DOC},
 	{"object", (getter)Thread_get_object, NULL, drgn_Thread_object_DOC},
@@ -75,6 +91,10 @@ static PyGetSetDef Thread_getset[] = {
 static PyMethodDef Thread_methods[] = {
 	{"stack_trace", (PyCFunction)Thread_stack_trace, METH_NOARGS,
 	 drgn_Thread_stack_trace_DOC},
+	{"pause", (PyCFunction)Thread_pause, METH_NOARGS,
+	 drgn_Thread_pause_DOC},
+	{"resume", (PyCFunction)Thread_resume, METH_NOARGS,
+	 drgn_Thread_resume_DOC},
 	{},
 };
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import functools
+import os
+import signal
 from typing import Any, NamedTuple, Optional
 import unittest
 
@@ -22,6 +24,19 @@ from drgn import (
 )
 
 DEFAULT_LANGUAGE = Language.C
+
+
+def fork_and_pause(fn=None):
+    pid = os.fork()
+    if pid == 0:
+        if fn:
+            fn()
+        try:
+            while True:
+                signal.pause()
+        finally:
+            os._exit(1)
+    return pid
 
 
 MOCK_32BIT_PLATFORM = Platform(Architecture.UNKNOWN, PlatformFlags.IS_LITTLE_ENDIAN)

--- a/tests/helpers/linux/__init__.py
+++ b/tests/helpers/linux/__init__.py
@@ -77,19 +77,6 @@ def wait_until(fn, *args, **kwds):
         sleep *= 2
 
 
-def fork_and_pause(fn=None):
-    pid = os.fork()
-    if pid == 0:
-        if fn:
-            fn()
-        try:
-            while True:
-                signal.pause()
-        finally:
-            os._exit(1)
-    return pid
-
-
 def proc_state(pid):
     with open(f"/proc/{pid}/status", "r") as f:
         return re.search(r"State:\s*(\S)", f.read(), re.M).group(1)

--- a/tests/helpers/linux/test_cgroup.py
+++ b/tests/helpers/linux/test_cgroup.py
@@ -16,12 +16,12 @@ from drgn.helpers.linux.cgroup import (
     css_for_each_descendant_pre,
 )
 from drgn.helpers.linux.pid import find_task
+from tests import fork_and_pause
 from tests.helpers.linux import (
     MS_NODEV,
     MS_NOEXEC,
     MS_NOSUID,
     LinuxHelperTestCase,
-    fork_and_pause,
     mount,
     umount,
 )

--- a/tests/helpers/linux/test_rbtree.py
+++ b/tests/helpers/linux/test_rbtree.py
@@ -16,7 +16,8 @@ from drgn.helpers.linux.rbtree import (
     rbtree_inorder_for_each,
     rbtree_inorder_for_each_entry,
 )
-from tests.helpers.linux import LinuxHelperTestCase, fork_and_pause
+from tests import fork_and_pause
+from tests.helpers.linux import LinuxHelperTestCase
 
 
 class TestRbtree(LinuxHelperTestCase):

--- a/tests/helpers/linux/test_sched.py
+++ b/tests/helpers/linux/test_sched.py
@@ -7,13 +7,8 @@ import signal
 from drgn.helpers.linux.cpumask import for_each_possible_cpu
 from drgn.helpers.linux.pid import find_task
 from drgn.helpers.linux.sched import idle_task, task_state_to_char
-from tests.helpers.linux import (
-    LinuxHelperTestCase,
-    fork_and_pause,
-    proc_state,
-    smp_enabled,
-    wait_until,
-)
+from tests import fork_and_pause
+from tests.helpers.linux import LinuxHelperTestCase, proc_state, smp_enabled, wait_until
 
 
 class TestSched(LinuxHelperTestCase):

--- a/tests/helpers/linux/test_stack_trace.py
+++ b/tests/helpers/linux/test_stack_trace.py
@@ -6,13 +6,8 @@ import signal
 
 from drgn import Object, Program, cast
 from drgn.helpers.linux.pid import find_task
-from tests.helpers.linux import (
-    LinuxHelperTestCase,
-    fork_and_pause,
-    proc_blocked,
-    setenv,
-    wait_until,
-)
+from tests import fork_and_pause
+from tests.helpers.linux import LinuxHelperTestCase, proc_blocked, setenv, wait_until
 
 
 class TestStackTrace(LinuxHelperTestCase):

--- a/tests/helpers/linux/test_user.py
+++ b/tests/helpers/linux/test_user.py
@@ -6,12 +6,8 @@ import os
 import signal
 
 from drgn.helpers.linux.user import find_user, for_each_user
-from tests.helpers.linux import (
-    LinuxHelperTestCase,
-    fork_and_pause,
-    proc_state,
-    wait_until,
-)
+from tests import fork_and_pause
+from tests.helpers.linux import LinuxHelperTestCase, proc_state, wait_until
 
 
 class TestUser(LinuxHelperTestCase):

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -3,12 +3,18 @@
 
 import os
 import os.path
+from pathlib import Path
+import platform
+import re
+import signal
 import subprocess
 import tempfile
+from threading import Thread
+from time import sleep
 import unittest
 
-from drgn import Program
-from tests import TestCase
+from drgn import MissingDebugInfoError, Program
+from tests import TestCase, fork_and_pause
 
 
 class TestCoreDump(TestCase):
@@ -63,3 +69,200 @@ class TestCoreDump(TestCase):
 
     def test_crashed_thread(self):
         self.assertEqual(self.prog.crashed_thread().tid, self.CRASHED_TID)
+
+
+class TestPauseResumeMultithread(TestCase):
+    def test_pause_resume_multithread(self):
+        """
+        We use a pipe for synchronization and the raw `os.fork()` interface
+        instead of the standard library's `multiprocessing` module because the
+        cleanup code in the `multiprocessing` module doesn't play nicely with
+        our use of `ptrace` (in particular, it breaks some assertions that use
+        `waitpid` and its associated macros).
+        """
+        NUM_THREADS = 12
+        read, write = os.pipe()
+
+        def child_main():
+            os.close(0)
+            os.close(1)
+            os.close(read)
+            threads = [Thread(target=sleep, args=(100,)) for _ in range(NUM_THREADS)]
+            for thread in threads:
+                thread.start()
+            os.close(write)  # Synchronize with parent process
+
+        pid = fork_and_pause(child_main)
+        try:
+            os.close(write)
+            proc_path = Path(f"/proc/{pid}/task")
+            with os.fdopen(read) as sync:
+                """
+                Synchronize with the child process, waiting until it's
+                done spawning all of its threads.
+                """
+                sync.read()
+            tasks = list(proc_path.iterdir())
+            self.assertEqual(len(tasks), NUM_THREADS + 1)
+
+            def grep(path, *patterns):
+                with open(path, "r") as file:
+                    lines = list(file)
+                    for pattern in patterns:
+                        pattern = re.compile(pattern)
+                        self.assertTrue(
+                            any(pattern.search(line) for line in lines),
+                            "\n".join(lines),
+                        )
+
+            not_paused_pattern = r"State:.*(sleeping|running)"
+
+            for task in tasks:
+                grep(
+                    task / "status",
+                    not_paused_pattern,
+                    r"TracerPid:[^\d]*0[^\d]*$",
+                )
+
+            prog = Program()
+            prog.set_pid(pid)
+            tracer_pid_pattern = fr"TracerPid:[^\d]{os.getpid()}[^\d]*$"
+
+            def pause_then_resume(thread, status):
+                grep(status, not_paused_pattern, tracer_pid_pattern)
+                thread.pause()
+                grep(status, r"State:.*tracing stop", tracer_pid_pattern)
+                thread.resume()
+                grep(status, not_paused_pattern, tracer_pid_pattern)
+
+            for task in tasks:
+                pause_then_resume(prog.thread(int(task.name)), task / "status")
+            for thread in prog.threads():
+                pause_then_resume(thread, proc_path / str(thread.tid) / "status")
+        finally:
+            os.kill(pid, signal.SIGINT)
+
+
+class TestPauseResume(TestCase):
+    def setUp(self):
+        self.pid = fork_and_pause()
+        self.prog = Program()
+        self.prog.set_pid(self.pid)
+        self.main_thread = self.prog.thread(self.pid)
+
+    def tearDown(self):
+        try:
+            os.kill(self.pid, signal.SIGINT)
+        except:
+            pass
+
+    def test_double_pause(self):
+        self.main_thread.pause()
+        self.assertRaisesRegex(
+            ValueError,
+            f"{self.main_thread.tid}.*is already paused",
+            self.main_thread.pause,
+        )
+
+    def test_double_resume(self):
+        self.main_thread.pause()
+        self.main_thread.resume()
+        self.assertRaisesRegex(
+            ValueError,
+            f"{self.main_thread.tid}.*has already been resumed or was never paused",
+            self.main_thread.resume,
+        )
+
+    def test_resume_without_pause(self):
+        self.assertRaisesRegex(
+            ValueError,
+            f"{self.main_thread.tid}.*has already been resumed or was never paused",
+            self.main_thread.resume,
+        )
+
+    def test_pause_exited_thread(self):
+        os.kill(self.main_thread.tid, signal.SIGTERM)
+        """
+        PTRACE_INTERRUPT (what `Thread.pause()` uses under the hood) competes
+        with any signals that are sent at the same time, hence we sleep briefly
+        to allow the signal to win the race.
+        """
+        sleep(0.1)
+        self.assertRaisesRegex(
+            ValueError, f"{self.main_thread.tid}.*has exited", self.main_thread.pause
+        )
+
+
+# Enable this for other architectures as they become supported
+@unittest.skipUnless(
+    platform.processor().startswith("x86"),
+    f"stack traces for live processes are not currently supported on {platform.processor()}",
+)
+class TestStackTrace(TestCase):
+    def test_stack_trace(self):
+        with tempfile.NamedTemporaryFile() as executable, tempfile.NamedTemporaryFile(
+            mode="w"
+        ) as program:
+            executable.close()
+            program.write(
+                """
+                      static unsigned int global = 0;
+
+                      void zero() { while(1) global++; }
+
+                      void one() { zero(); }
+
+                      void two() { one(); }
+
+                      int main() { two(); }
+                      """
+            )
+            program.flush()
+            subprocess.check_call(
+                (
+                    "cc",
+                    "-x",
+                    "c",
+                    "-Wall",
+                    "-Werror",
+                    "-g",
+                    "-O0",
+                    "-o",
+                    executable.name,
+                    program.name,
+                )
+            )
+            try:
+                process = subprocess.Popen((executable.name,))
+                prog = Program()
+                prog.set_pid(process.pid)
+                try:
+                    prog.load_default_debug_info()
+                except MissingDebugInfoError:
+                    pass
+                # Hacky way to make sure the program has entered `zero()`
+                while prog["global"].value_() == 0:
+                    sleep(0.1)
+                main_thread = prog.thread(process.pid)
+                main_thread.pause()
+                trace = main_thread.stack_trace()
+                self.assertEqual(len(trace), 4, trace)
+                self.assertEqual(trace[0].name, "zero")
+                self.assertEqual(trace[1].name, "one")
+                self.assertEqual(trace[2].name, "two")
+                self.assertEqual(trace[3].name, "main")
+            finally:
+                process.kill()
+                process.wait()
+
+    def test_stack_trace_requires_pause(self):
+        try:
+            pid = fork_and_pause()
+            prog = Program()
+            prog.set_pid(pid)
+            main_thread = prog.thread(pid)
+            self.assertRaisesRegex(
+                ValueError, "thread must be paused", main_thread.stack_trace
+            )
+        finally:
+            os.kill(pid, signal.SIGTERM)


### PR DESCRIPTION
Building off of the work of #129, this PR (when completed) will implement and extend the Threads API outlined in #92 for live userspace processes. This will bring `drgn` one step closer to fulfilling the traditional role of a userspace debugger, most notably adding the ability to pause and resume threads at will during the execution of the program.

As this is still a work in progress, this PR is in **draft** mode.