### PR TITLE
[RFC] libdrgn: Handle --only-keep-debug Linux modules

### DIFF
--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -1659,17 +1659,17 @@ static struct drgn_error *relocate_elf_file(Elf *elf)
 
 	Elf_Scn *reloc_scn = NULL;
 	while ((reloc_scn = elf_nextscn(elf, reloc_scn))) {
-		GElf_Shdr *shdr, shdr_mem;
-		shdr = gelf_getshdr(reloc_scn, &shdr_mem);
-		if (!shdr) {
+		GElf_Shdr *reloc_shdr, reloc_shdr_mem;
+		reloc_shdr = gelf_getshdr(reloc_scn, &reloc_shdr_mem);
+		if (!reloc_shdr) {
 			err = drgn_error_libelf();
 			goto out;
 		}
 		/* We don't support any architectures that use SHT_REL yet. */
-		if (shdr->sh_type != SHT_RELA)
+		if (reloc_shdr->sh_type != SHT_RELA)
 			continue;
 
-		const char *scnname = elf_strptr(elf, shstrndx, shdr->sh_name);
+		const char *scnname = elf_strptr(elf, shstrndx, reloc_shdr->sh_name);
 		if (!scnname) {
 			err = drgn_error_libelf();
 			goto out;
@@ -1677,13 +1677,22 @@ static struct drgn_error *relocate_elf_file(Elf *elf)
 
 		if (strstartswith(scnname, ".rela.debug_") ||
 		    strstartswith(scnname, ".rela.orc_")) {
-			Elf_Scn *scn = elf_getscn(elf, shdr->sh_info);
+			Elf_Scn *scn = elf_getscn(elf, reloc_shdr->sh_info);
 			if (!scn) {
 				err = drgn_error_libelf();
 				goto out;
 			}
 
-			Elf_Scn *symtab_scn = elf_getscn(elf, shdr->sh_link);
+			GElf_Shdr *shdr, shdr_mem;
+			shdr = gelf_getshdr(scn, &shdr_mem);
+			if (!shdr) {
+				err = drgn_error_libelf();
+				goto out;
+			}
+			if (shdr->sh_type == SHT_NOBITS)
+				continue;
+
+			Elf_Scn *symtab_scn = elf_getscn(elf, reloc_shdr->sh_link);
 			if (!symtab_scn) {
 				err = drgn_error_libelf();
 				goto out;

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -925,9 +925,16 @@ static struct drgn_error *identify_kernel_elf(Elf *elf,
 static struct drgn_error *
 get_kernel_module_name_from_modinfo(Elf_Scn *modinfo_scn, const char **ret)
 {
+	GElf_Shdr *modinfo_shdr, modinfo_shdr_mem;
 	struct drgn_error *err;
 	Elf_Data *data;
 	const char *p, *end, *nul;
+
+	modinfo_shdr = gelf_getshdr(modinfo_scn, &modinfo_shdr_mem);
+	if (!modinfo_shdr)
+		return drgn_error_libelf();
+	if (modinfo_shdr->sh_type == SHT_NOBITS)
+		goto out;
 
 	if (modinfo_scn) {
 		err = read_elf_section(modinfo_scn, &data);
@@ -946,6 +953,7 @@ get_kernel_module_name_from_modinfo(Elf_Scn *modinfo_scn, const char **ret)
 			p = nul + 1;
 		}
 	}
+out:
 	*ret = NULL;
 	return NULL;
 }
@@ -959,9 +967,16 @@ static struct drgn_error *
 get_kernel_module_name_from_this_module(Elf_Scn *this_module_scn,
 					size_t name_offset, const char **ret)
 {
+	GElf_Shdr *this_module_shdr, this_module_shdr_mem;
 	struct drgn_error *err;
 	Elf_Data *data;
 	const char *p, *nul;
+
+	this_module_shdr = gelf_getshdr(this_module_scn, &this_module_shdr_mem);
+	if (!this_module_shdr)
+		return drgn_error_libelf();
+	if (this_module_shdr->sh_type == SHT_NOBITS)
+		goto out;
 
 	if (this_module_scn) {
 		err = read_elf_section(this_module_scn, &data);
@@ -976,6 +991,7 @@ get_kernel_module_name_from_this_module(Elf_Scn *this_module_scn,
 			}
 		}
 	}
+out:
 	*ret = NULL;
 	return NULL;
 }


### PR DESCRIPTION
Hi Omar,

When trying to load .ko modules under `/usr/lib/debug/lib/modules/` from `linux-image-$VERSION-dbg` packages built by kernel `scripts/package/builddeb`, I ran into the following segfault:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  apply_elf_rela_x86_64 (relocating=0x7fddf7ca4da0, r_offset=0, r_type=2, r_addend=0, sym_value=<optimized out>)
    at ../../libdrgn/arch_x86_64.c:517
517                        memcpy(dst, &value, sizeof(value));
[Current thread is 1 (Thread 0x7fddf7ca5700 (LWP 3945980))]
(gdb) bt
#0  apply_elf_rela_x86_64 (relocating=0x7fddf7ca4da0, r_offset=0, r_type=2, r_addend=0, sym_value=<optimized out>)
    at ../../libdrgn/arch_x86_64.c:517
#1  0x00007fde4a78721d in relocate_elf_section (platform=0x7fddf7ca4d90, shdrnum=49, sh_addrs=0x7fdddc000b20, symtab_scn=<optimized out>,
    reloc_scn=0xe6ee28, scn=<optimized out>) at ../../libdrgn/debug_info.c:1588
#2  relocate_elf_file (elf=<optimized out>) at ../../libdrgn/debug_info.c:1692
#3  drgn_debug_info_find_sections (module=<optimized out>) at ../../libdrgn/debug_info.c:1711
#4  drgn_debug_info_read_module (head=0xd52050, index=0x7ffd280675f0, load=0x7ffd28067810) at ../../libdrgn/debug_info.c:1861
#5  drgn_debug_info_update_index._omp_fn.0 () at ../../libdrgn/debug_info.c:1926
#6  0x00007fde4a6d779e in ?? () from /usr/lib/x86_64-linux-gnu/libgomp.so.1
#7  0x00007fde4bb7dfa3 in start_thread (arg=<optimized out>) at pthread_create.c:486
#8  0x00007fde4b6c44cf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
It turns out that `scripts/package/builddeb` uses `objcopy  --only-keep-debug` [1] to generate `-dbg` kernel modules, which removes all contents of non-debug ELF sections, including `.orc_unwind_ip`, then mark [2] them as `SHT_NOBITS`.

This caused drgn to segfault (NULL dereference) when trying to apply relocation for `.orc_unwind_ip`.

Similar things happen when loading such "--only-keep-debug" modules using `drgn -s` or `>>> prog.load_debug_info()`, since `.modinfo` and `.gnu.linkonce.this_module` are not present, too, causing drgn to again segfault.

This commit tries to handle such Linux modules by checking `shdr->sh_type` against `SHT_NOBITS` in advance.  I've tested this and it seems to work for my use case, but I'm very new to libelf, libdrgn etc.  What do you think?

thanks,
ypl

[1] https://github.com/torvalds/linux/blob/master/scripts/package/builddeb#L172
[2] https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=binutils/objcopy.c;h=d16d8ee67e4dfe550eaa553671552b2300fbf2e0;hb=HEAD#l4089