### PR TITLE
Add autoconf option to enable ASAN

### DIFF
--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -6,6 +6,8 @@ ACLOCAL_AMFLAGS = -I m4
 .DELETE_ON_ERROR:
 
 AM_CPPFLAGS = -I $(top_srcdir)/include -D_GNU_SOURCE
+AM_CFLAGS = $(SANITIZER_CFLAGS)
+AM_LDFLAGS= $(SANITIZER_LDFLAGS)
 
 noinst_HEADERS = include/dwarf.h \
 		 include/elf.h \
@@ -87,7 +89,8 @@ libdrgnimpl_la_SOURCES = $(ARCH_DEFS:.defs=.c) \
 			 vector.c \
 			 vector.h
 
-libdrgnimpl_la_CFLAGS = -fvisibility=hidden $(OPENMP_CFLAGS) $(elfutils_CFLAGS)
+libdrgnimpl_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden $(OPENMP_CFLAGS) \
+			$(elfutils_CFLAGS)
 libdrgnimpl_la_LIBADD = $(OPENMP_LIBS) $(elfutils_LIBS) -lm
 
 if WITH_LIBKDUMPFILE
@@ -109,7 +112,7 @@ drgn.h: drgn.h.in configure.ac
 lib_LTLIBRARIES = libdrgn.la
 
 libdrgn_la_SOURCES =
-libdrgn_la_LDFLAGS = -version-info 0:0:0
+libdrgn_la_LDFLAGS = $(AM_LDFLAGS) -version-info 0:0:0
 libdrgn_la_LIBADD = libdrgnimpl.la
 
 if WITH_PYTHON
@@ -136,11 +139,11 @@ _drgn_la_SOURCES = python/constants.c \
 		   python/type.c \
 		   python/util.c
 
-_drgn_la_CFLAGS = -fvisibility=hidden
+_drgn_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 _drgn_la_CPPFLAGS = $(AM_CPPFLAGS) $(PYTHON_CPPFLAGS) -iquote $(srcdir)/python \
 		    -iquote python
-_drgn_la_LDFLAGS = -Wl,--exclude-libs,ALL -avoid-version -module -shared \
-		   -rpath $(pkgpyexecdir)
+_drgn_la_LDFLAGS = $(AM_LDFLAGS) -Wl,--exclude-libs,ALL -avoid-version -module \
+		   -shared -rpath $(pkgpyexecdir)
 _drgn_la_LIBADD = libdrgnimpl.la
 
 if WITH_LIBKDUMPFILE

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -92,5 +92,17 @@ AS_CASE(["x$with_libkdumpfile"],
 AM_CONDITIONAL([WITH_LIBKDUMPFILE], [test "x$with_libkdumpfile" = xyes])
 AM_COND_IF([WITH_LIBKDUMPFILE], [AC_DEFINE(WITH_LIBKDUMPFILE)])
 
+AC_ARG_ENABLE([asan],
+	      [AS_HELP_STRING([--enable-asan], [enable AddressSanitizer])],
+	      [], [enable_asan=no])
+
+SANITIZER_CFLAGS=
+SANITIZER_LDFLAGS=
+AS_IF([test "x$enable_asan" != xno],
+      [SANITIZER_CFLAGS="$SANITIZER_CFLAGS -fsanitize=address -fno-omit-frame-pointer"
+       SANITIZER_LDFLAGS="$SANITIZER_LDFLAGS -fsanitize=address"])
+AC_SUBST(SANITIZER_CFLAGS)
+AC_SUBST(SANITIZER_LDFLAGS)
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
[AddressSanitizer (a.k.a ASAN)](https://github.com/google/sanitizers/wiki/AddressSanitizer) is incredibly useful during development, especially when dealing with non-deterministic behavior where re-running the code under a debugger won't necessarily reproduce the bug each time. In order not to break any existing workflows, building with ASAN is opt-in (via `--enable-asan`).

I had originally added this just for myself to make debugging easier, but I figured I may as well upstream it given how useful it's been.