### PR TITLE
Add drgn.Program.main_thread()

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -321,6 +321,15 @@ class Program:
         :raises ValueError: if the program is live (i.e., not a core dump)
         """
         ...
+    def main_thread(self) -> Thread:
+        """
+        Get the main thread of the program.
+
+        Only works for the crash dump of user-space applications.
+
+        :raises ValueError: if the program is the Linux kernel or running user-space application
+        """
+        ...
     def read(
         self, address: IntegerLike, size: IntegerLike, physical: bool = False
     ) -> bytes:

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2882,6 +2882,16 @@ struct drgn_error *drgn_program_crashed_thread(struct drgn_program *prog,
 					       struct drgn_thread **ret);
 
 /**
+ * Get the main program thread
+ * *
+ * @param[out] ret Main thread handle. This is valid for the lifetime of @p
+ * prog. This must NOT be destroyed with @ref drgn_thread_destroy().
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_main_thread(struct drgn_program *prog,
+					       struct drgn_thread **ret);
+
+/**
  * Get the object for the given thread. This is currently only defined for the
  * Linux kernel.
  *

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -210,7 +210,7 @@ struct drgn_error *drgn_program_cache_kdump_notes(struct drgn_program *prog)
 		prstatus_size = kdump_blob_size(prstatus_attr.val.blob);
 		uint32_t _;
 		err = drgn_program_cache_prstatus_entry(prog, prstatus_data,
-							prstatus_size, &_);
+							prstatus_size, &_, &_);
 		if (err)
 			return err;
 	}

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -155,6 +155,7 @@ struct drgn_program {
 		struct drgn_thread_set thread_set;
 	};
 	struct drgn_thread *crashed_thread;
+	struct drgn_thread *main_thread;
 	bool core_dump_notes_cached;
 	bool prefer_orc_unwinder;
 
@@ -303,11 +304,13 @@ struct drgn_error *drgn_program_find_prstatus_by_tid(struct drgn_program *prog,
  * @param[in] data The pointer to the note data.
  * @param[in] size Size of data in note.
  * @param[out] ret Thread ID from note.
+ * @param[out] ret Process Group ID from note.
  */
 struct drgn_error *drgn_program_cache_prstatus_entry(struct drgn_program *prog,
 						     const char *data,
 						     size_t size,
-						     uint32_t *ret);
+						     uint32_t *tid,
+						     uint32_t *pgrp);
 
 /*
  * Like @ref drgn_program_find_symbol_by_address(), but @p ret is already

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -880,6 +880,16 @@ static PyObject *Program_crashed_thread(Program *self)
 	return Thread_wrap(thread);
 }
 
+static PyObject *Program_main_thread(Program *self)
+{
+	struct drgn_error *err;
+	struct drgn_thread *thread;
+	err = drgn_program_main_thread(&self->prog, &thread);
+	if (err)
+		return set_drgn_error(err);
+	return Thread_wrap(thread);
+}
+
 static DrgnObject *Program_subscript(Program *self, PyObject *key)
 {
 	struct drgn_error *err;
@@ -1030,6 +1040,8 @@ static PyMethodDef Program_methods[] = {
 	 METH_VARARGS | METH_KEYWORDS, drgn_Program_thread_DOC},
 	{"crashed_thread", (PyCFunction)Program_crashed_thread, METH_NOARGS,
 	 drgn_Program_crashed_thread_DOC},
+	{"main_thread", (PyCFunction)Program_main_thread, METH_NOARGS,
+	 drgn_Program_main_thread_DOC},
 	{"void_type", (PyCFunction)Program_void_type,
 	 METH_VARARGS | METH_KEYWORDS, drgn_Program_void_type_DOC},
 	{"int_type", (PyCFunction)Program_int_type,

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -29,6 +29,7 @@ class TestCoreDump(TestCase):
     )
 
     CRASHED_TID = 2265419
+    MAIN_TID = 2265413
 
     @classmethod
     def setUpClass(cls):
@@ -63,3 +64,6 @@ class TestCoreDump(TestCase):
 
     def test_crashed_thread(self):
         self.assertEqual(self.prog.crashed_thread().tid, self.CRASHED_TID)
+
+    def test_main_thread(self):
+        self.assertEqual(self.prog.main_thread().tid, self.MAIN_TID)


### PR DESCRIPTION
Currently only supported for user-space crash dumps. E.g. no support
for live user-space application debugging of kernel debugging

Closes #144

Signed-off-by: Mykola Lysenko <mykolal@fb.com>