### PR TITLE
Add drgn.Program.main_thread()

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -308,6 +308,15 @@ class Program:
         :raises LookupError: if no thread has the given thread ID
         """
         ...
+    def main_thread(self) -> Thread:
+        """
+        Get the main thread of the program.
+
+        This is only defined for userspace programs.
+
+        :raises ValueError: if the program is the Linux kernel
+        """
+        ...
     def crashed_thread(self) -> Thread:
         """
         Get the thread that caused the program to crash.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -203,14 +203,17 @@ Threads
 ^^^^^^^
 
 The :class:`drgn.Thread` class represents a thread.
-:meth:`drgn.Program.threads()`, :meth:`drgn.Program.thread()`, and
-:meth:`drgn.Program.crashed_thread()` can be used to find threads::
+:meth:`drgn.Program.threads()`, :meth:`drgn.Program.thread()`,
+:meth:`drgn.Program.main_thread()`, and :meth:`drgn.Program.crashed_thread()`
+can be used to find threads::
 
     >>> for thread in prog.threads():
     ...     print(thread.tid)
     ...
     39143
     39144
+    >>> print(prog.main_thread().tid)
+    39143
     >>> print(prog.crashed_thread().tid)
     39144
 

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2872,6 +2872,16 @@ struct drgn_error *drgn_program_find_thread(struct drgn_program *prog,
 					    struct drgn_thread **ret);
 
 /**
+ * Get the main program thread.
+ *
+ * @param[out] ret Borrowed thread handle. This is valid for the lifetime of @p
+ * prog. This must NOT be destroyed with @ref drgn_thread_destroy().
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_main_thread(struct drgn_program *prog,
+					    struct drgn_thread **ret);
+
+/**
  * Get the thread that caused the program to crash.
  *
  * @param[out] ret Borrowed thread handle. This is valid for the lifetime of @p

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -154,6 +154,7 @@ struct drgn_program {
 		/* For userspace programs, threads indexed by PID. */
 		struct drgn_thread_set thread_set;
 	};
+	struct drgn_thread *main_thread;
 	struct drgn_thread *crashed_thread;
 	bool core_dump_notes_cached;
 	bool prefer_orc_unwinder;

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -870,6 +870,16 @@ static PyObject *Program_thread(Program *self, PyObject *args, PyObject *kwds)
 	return ret;
 }
 
+static PyObject *Program_main_thread(Program *self)
+{
+	struct drgn_error *err;
+	struct drgn_thread *thread;
+	err = drgn_program_main_thread(&self->prog, &thread);
+	if (err)
+		return set_drgn_error(err);
+	return Thread_wrap(thread);
+}
+
 static PyObject *Program_crashed_thread(Program *self)
 {
 	struct drgn_error *err;
@@ -1028,6 +1038,8 @@ static PyMethodDef Program_methods[] = {
 	 drgn_Program_threads_DOC},
 	{"thread", (PyCFunction)Program_thread,
 	 METH_VARARGS | METH_KEYWORDS, drgn_Program_thread_DOC},
+	{"main_thread", (PyCFunction)Program_main_thread, METH_NOARGS,
+	 drgn_Program_main_thread_DOC},
 	{"crashed_thread", (PyCFunction)Program_crashed_thread, METH_NOARGS,
 	 drgn_Program_crashed_thread_DOC},
 	{"void_type", (PyCFunction)Program_void_type,

--- a/tests/helpers/linux/test_threads.py
+++ b/tests/helpers/linux/test_threads.py
@@ -37,6 +37,13 @@ class TestThreads(LinuxHelperTestCase):
         self.assertEqual(thread.tid, pid)
         self.assertEqual(thread.object, find_task(self.prog, pid))
 
+    def test_main_thread(self):
+        self.assertRaisesRegex(
+            ValueError,
+            "main thread is not defined for the Linux kernel",
+            self.prog.main_thread,
+        )
+
     def test_crashed_thread(self):
         self.assertRaisesRegex(
             ValueError,

--- a/tests/linux_kernel/vmcore/test_vmcore.py
+++ b/tests/linux_kernel/vmcore/test_vmcore.py
@@ -24,6 +24,13 @@ class TestVMCore(LinuxVMCoreTestCase):
         crashed_thread_tid = self.prog.crashed_thread().tid
         self.assertEqual(self.prog.thread(crashed_thread_tid).tid, crashed_thread_tid)
 
+    def test_main_thread(self):
+        self.assertRaisesRegex(
+            ValueError,
+            "main thread is not defined for the Linux kernel",
+            self.prog.main_thread,
+        )
+
     def test_crashed_thread(self):
         crashed_thread = self.prog.crashed_thread()
         self.assertGreater(crashed_thread.tid, 0)

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -28,6 +28,7 @@ class TestCoreDump(TestCase):
         2265425,
     )
 
+    MAIN_TID = 2265413
     CRASHED_TID = 2265419
 
     @classmethod
@@ -60,6 +61,9 @@ class TestCoreDump(TestCase):
         for tid in self.TIDS:
             self.assertEqual(self.prog.thread(tid).tid, tid)
         self.assertRaises(LookupError, self.prog.thread, 99)
+
+    def test_main_thread(self):
+        self.assertEqual(self.prog.main_thread().tid, self.MAIN_TID)
 
     def test_crashed_thread(self):
         self.assertEqual(self.prog.crashed_thread().tid, self.CRASHED_TID)


### PR DESCRIPTION
Currently only supported for user-space crash dumps. E.g. no support
for live user-space application debugging of kernel debugging

Closes #144

Signed-off-by: Mykola Lysenko <mykolal@fb.com>