### PR TITLE
Make iwyu.py respect the `CFLAGS` environment variable

### DIFF
--- a/scripts/iwyu.py
+++ b/scripts/iwyu.py
@@ -169,7 +169,8 @@ def ignore_line(path, state, line):
 
 
 def main():
-    os.environ["CFLAGS"] = "-Wall"
+    if "CFLAGS" not in os.environ:
+        os.environ["CFLAGS"] = "-Wall"
     parser = argparse.ArgumentParser(description="run include-what-you-use on drgn")
     parser.add_argument(
         "source", nargs="*", help="run on given file instead of all source files"


### PR DESCRIPTION
Minor quality of life improvement.

Previously iwyu.py overwrote the value of the `CFLAGS` environment
variable regardless of whether it was already set. This was very
frustrating when trying to set custom `CFLAGS` to be used in the
generation of compile_commands.json, so the script now only sets
`CFLAGS` if it is not already present in the environment.

Signed-off-by: Kevin Svetlitski <svetlitski@fb.com>