### PR TITLE
Add BTF type finder

### DIFF
--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -32,6 +32,8 @@ libdrgnimpl_la_SOURCES = $(ARCH_DEFS:.defs=.c) \
 			 binary_buffer.h \
 			 binary_search_tree.h \
 			 bitops.h \
+			 btf.h \
+			 btf.c \
 			 c_keywords.inc \
 			 cfi.c \
 			 cfi.h \

--- a/libdrgn/btf.c
+++ b/libdrgn/btf.c
@@ -1,0 +1,249 @@
+// Copyright (c) 2022 Oracle and/or its affiliates.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "drgn.h"
+#include "program.h"
+#include "memory_reader.h"
+#include "btf.h"
+
+DEFINE_VECTOR(type_vector, struct btf_type *);
+
+struct drgn_prog_btf {
+	struct drgn_program *prog;
+
+	/**
+	 * Length of the BTF buffer in bytes.
+	 */
+	size_t len;
+
+	/**
+	 * BTF buffer.
+	 */
+	union {
+		void *ptr;
+		struct btf_header *hdr;
+	};
+
+	/**
+	 * Pointer within the buffer to the "type" section.
+	 */
+	union {
+		void *type;
+		struct btf_type *tp;
+	};
+
+	/**
+	 * Pointer within the buffer to the "strings" section.
+	 */
+	char *str;
+
+	/**
+	 * Array allowing us to map BTF type_id indexes to their location within
+	 * the "type" section. This could certainly be compressed or optimized,
+	 * but for now it is fine.
+	 */
+	struct type_vector index;
+};
+
+const size_t DRGN_BTF_INDEX_INIT = 4096;
+
+static inline uint32_t btf_kind(uint32_t info)
+{
+	return (info & 0x1F000000) >> 24;
+}
+
+static inline uint16_t btf_vlen(uint32_t info)
+{
+	return info & 0xFFFF;
+}
+
+static inline uint32_t btf_kind_flag(uint32_t info)
+{
+	return info & (1 << 31);
+}
+
+/**
+ * Return the next btf_type entry after this one. In order to do this we must
+ * add the offset of any supplemental data which follows this entry.
+ */
+static struct btf_type *btf_next(struct btf_type *tp)
+{
+	void *next = (void *)tp + sizeof(struct btf_type);
+
+	switch (btf_kind(tp->info)) {
+	case BTF_KIND_INT:
+		return next + sizeof(uint32_t);
+
+	case BTF_KIND_ARRAY:
+		return next + sizeof(struct btf_array);
+
+	case BTF_KIND_STRUCT:
+	case BTF_KIND_UNION:
+		return next + btf_vlen(tp->info) * sizeof(struct btf_member);
+
+	case BTF_KIND_ENUM:
+		return next + btf_vlen(tp->info) * sizeof(struct btf_enum);
+
+	case BTF_KIND_FUNC_PROTO:
+		return next + btf_vlen(tp->info) * sizeof(struct btf_param);
+
+	case BTF_KIND_VAR:
+		return next + sizeof(struct btf_var);
+
+	case BTF_KIND_DATASEC:
+		return next + btf_vlen(tp->info) * sizeof(struct btf_var_secinfo);
+
+	case BTF_KIND_DECL_TAG:
+		return next + sizeof(struct btf_decl_tag);
+
+	case BTF_KIND_PTR:
+	case BTF_KIND_FWD:
+	case BTF_KIND_TYPEDEF:
+	case BTF_KIND_VOLATILE:
+	case BTF_KIND_CONST:
+	case BTF_KIND_RESTRICT:
+	case BTF_KIND_FUNC:
+	case BTF_KIND_FLOAT:
+	case BTF_KIND_TYPE_TAG:
+		return next;
+
+	default:
+		UNREACHABLE();
+	}
+}
+
+/**
+ * Return true if this type pointer is past the end of the BTF type buffer.
+ */
+static inline bool btf_type_end(struct drgn_prog_btf *bf, struct btf_type *tp)
+{
+	return ((void *)tp - bf->type) >= bf->hdr->type_len;
+}
+
+/**
+ * Index the BTF data for quick access.
+ */
+static struct drgn_error *drgn_btf_index(struct drgn_prog_btf *bf)
+{
+	struct btf_type *tp;
+	for (tp = bf->tp; !btf_type_end(bf, tp); tp = btf_next(tp))
+		if (!type_vector_append(&bf->index, &tp))
+			return &drgn_enomem;
+	return NULL;
+}
+
+static struct btf_type *drgn_btf_lookup(struct drgn_prog_btf *bf, const char *name,
+					int desired_btf_kind)
+{
+	for (size_t i = 1; i < bf->index.size; i++)
+		if (btf_kind(bf->index.data[i]->info) == desired_btf_kind)
+			return bf->index.data[i];
+	return NULL;
+}
+
+static struct drgn_error *
+drgn_int_type_from_btf(struct drgn_prog_btf *bf, const char *name, size_t name_len,
+		       struct drgn_qualified_type *ret)
+{
+	struct btf_type *tp = drgn_btf_lookup(bf, name, BTF_KIND_INT);
+	uint32_t encoding;
+	if (!tp) {
+		printf("drgn_int_type_from_btf: not found\n");
+		return &drgn_not_found;
+	}
+	encoding = *(uint32_t *)&tp[1];
+	if (BTF_INT_BITS(encoding) % 8)
+		return drgn_error_create(DRGN_ERROR_OTHER, "int encoding of non-byte size not supported");
+	int bytes = BTF_INT_BITS(encoding) / 8;
+	if (BTF_INT_OFFSET(encoding))
+		return drgn_error_create(DRGN_ERROR_OTHER, "int encoding at non-zero offset not supported");
+	bool _signed = BTF_INT_SIGNED & encoding;
+	return drgn_int_type_create(bf->prog, name, bytes, _signed, DRGN_LITTLE_ENDIAN, &drgn_language_c, &ret->type);
+}
+
+static struct drgn_error *
+drgn_type_from_btf(enum drgn_type_kind kind, const char *name,
+		   size_t name_len, const char *filename,
+		   void *arg, struct drgn_qualified_type *ret)
+{
+	struct btf_type *tp;
+	struct drgn_prog_btf *bf = arg;
+
+	printf("drgn_type_from_btf: %d, \"%s\", %p\n", kind, name, ret);
+	fflush(stdout);
+
+	switch (kind) {
+	case DRGN_TYPE_INT:
+		return drgn_int_type_from_btf(bf, name, name_len, ret);
+	case DRGN_TYPE_BOOL:
+	case DRGN_TYPE_STRUCT:
+	case DRGN_TYPE_UNION:
+		break;
+	default:
+		break;
+	}
+	printf("drgn_type_from_btf: not found\n");
+	return &drgn_not_found;
+}
+
+struct drgn_error *drgn_btf_init(struct drgn_program *prog, uint64_t start, uint64_t bytes)
+{
+	struct drgn_prog_btf *pbtf;
+	struct drgn_error *err = NULL;
+	struct btf_type *tp = NULL;
+
+	pbtf = calloc(1, sizeof(*pbtf));
+	if (!pbtf) {
+		err = &drgn_enomem;
+		goto out_free;
+	}
+
+	type_vector_init(&pbtf->index);
+
+	/* Insert NULL entry at index 0 for the void type */
+	if (!type_vector_append(&pbtf->index, &tp)) {
+		err = &drgn_enomem;
+		goto out_free;
+	}
+
+	pbtf->ptr = malloc(bytes);
+	if (!pbtf->ptr) {
+		err = &drgn_enomem;
+		goto out_free;
+	}
+
+	err = drgn_memory_reader_read(&prog->reader, pbtf->ptr, start, bytes, false);
+	if (err)
+		goto out_free;
+
+
+	if (pbtf->hdr->magic != BTF_MAGIC) {
+		err = drgn_error_create(DRGN_ERROR_OTHER, "BTF header magic incorrect");
+		goto out_free;
+	}
+	if (pbtf->hdr->hdr_len != sizeof(*pbtf->hdr)) {
+		err = drgn_error_create(DRGN_ERROR_OTHER, "BTF header size mismatch");
+		goto out_free;
+	}
+	if (pbtf->hdr->str_off + pbtf->hdr->str_len > bytes ||
+	    pbtf->hdr->type_off + pbtf->hdr->type_len > bytes) {
+		err = drgn_error_create(DRGN_ERROR_OTHER, "BTF offsets out of bounds");
+		goto out_free;
+	}
+	pbtf->type = pbtf->ptr + pbtf->hdr->hdr_len + pbtf->hdr->type_off;
+	pbtf->str = pbtf->ptr + pbtf->hdr->hdr_len + pbtf->hdr->str_off;
+	pbtf->prog = prog;
+	err = drgn_btf_index(pbtf);
+	if (err)
+		goto out_free;
+
+	err = drgn_program_add_type_finder(prog, drgn_type_from_btf, pbtf);
+	if (err)
+		goto out_free;
+	return err;
+out_free:
+	free(pbtf->ptr);
+	type_vector_deinit(&pbtf->index);
+	free(pbtf);
+	return err;
+}

--- a/libdrgn/btf.c
+++ b/libdrgn/btf.c
@@ -1,10 +1,11 @@
 // Copyright (c) 2022 Oracle and/or its affiliates.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "drgn.h"
-#include "program.h"
-#include "memory_reader.h"
 #include "btf.h"
+#include "drgn.h"
+#include "lazy_object.h"
+#include "memory_reader.h"
+#include "program.h"
 
 DEFINE_VECTOR(type_vector, struct btf_type *);
 
@@ -43,6 +44,8 @@ struct drgn_prog_btf {
 	 * but for now it is fine.
 	 */
 	struct type_vector index;
+
+	struct drgn_type **cache;
 };
 
 const size_t DRGN_BTF_INDEX_INIT = 4096;
@@ -141,33 +144,58 @@ const char *btf_str(struct drgn_prog_btf *bf, uint32_t off)
 	return (const char *)&bf->str[off];
 }
 
-static struct btf_type *drgn_btf_lookup(struct drgn_prog_btf *bf, const char *name,
-					size_t name_len, int desired_btf_kind)
+static uint32_t drgn_btf_lookup(struct drgn_prog_btf *bf, const char *name,
+				size_t name_len, int desired_btf_kind)
 {
 	struct btf_type *tp;
-	for (size_t i = 1; i < bf->index.size; i++) {
+	for (uint32_t i = 1; i < bf->index.size; i++) {
 		tp = bf->index.data[i];
 		if (btf_kind(tp->info) == desired_btf_kind &&
 		    tp->name_off &&
-		    strncmp(btf_str(bf, tp->name_off), name, name_len) == 0) {
-			return bf->index.data[i];
+		    strncmp(btf_str(bf, tp->name_off), name, name_len+1) == 0) {
+			return i;
 		}
 	}
-	return NULL;
+	return 0; /* void anyway */
+}
+
+static enum drgn_qualifiers
+drgn_btf_resolve_qualifiers(struct drgn_prog_btf *bf, uint32_t idx, uint32_t *ret)
+{
+	enum drgn_qualifiers qual = 0;
+
+	for (;;) {
+		struct btf_type *tp = bf->index.data[idx];
+		switch (btf_kind(tp->info)) {
+		case BTF_KIND_CONST:
+			qual |= DRGN_QUALIFIER_CONST;
+			break;
+		case BTF_KIND_RESTRICT:
+			qual |= DRGN_QUALIFIER_RESTRICT;
+			break;
+		case BTF_KIND_VOLATILE:
+			qual |= DRGN_QUALIFIER_VOLATILE;
+			break;
+		default:
+			*ret = idx;
+			return qual;
+		}
+		idx = tp->type;
+	}
 }
 
 static struct drgn_error *
-drgn_int_type_from_btf(struct drgn_prog_btf *bf, const char *name, size_t name_len,
-		       struct drgn_qualified_type *ret)
+drgn_btf_type_create(struct drgn_prog_btf *bf, uint32_t idx,
+		     struct drgn_qualified_type *ret);
+
+static struct drgn_error *
+drgn_int_type_from_btf(struct drgn_prog_btf *bf, struct btf_type *tp,
+		       struct drgn_type **ret)
 {
-	struct btf_type *tp = drgn_btf_lookup(bf, name, name_len, BTF_KIND_INT);
 	uint32_t info;
 	bool _signed, is_bool;
-
-	if (!tp) {
-		printf("drgn_int_type_from_btf: not found\n");
-		return &drgn_not_found;
-	}
+	struct drgn_error *rv;
+	const char *name = btf_str(bf, tp->name_off);
 
 	info = *(uint32_t *)(tp + 1);
 	if (BTF_INT_OFFSET(info))
@@ -175,9 +203,200 @@ drgn_int_type_from_btf(struct drgn_prog_btf *bf, const char *name, size_t name_l
 	_signed = BTF_INT_SIGNED & BTF_INT_ENCODING(info);
 	is_bool = BTF_INT_BOOL & BTF_INT_ENCODING(info);
 	if (is_bool)
-		return drgn_bool_type_create(bf->prog, name, tp->size, DRGN_PROGRAM_ENDIAN, &drgn_language_c, &ret->type);
+		return drgn_bool_type_create(bf->prog, name, tp->size, DRGN_PROGRAM_ENDIAN, &drgn_language_c, ret);
 	else
-		return drgn_int_type_create(bf->prog, name, tp->size, _signed, DRGN_PROGRAM_ENDIAN, &drgn_language_c, &ret->type);
+		return drgn_int_type_create(bf->prog, name, tp->size, _signed, DRGN_PROGRAM_ENDIAN, &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_pointer_type_from_btf(struct drgn_prog_btf *bf, struct btf_type *tp,
+			   struct drgn_type **ret)
+{
+	struct drgn_qualified_type pointed;
+	struct drgn_error *err = NULL;
+
+	if (!tp->type)
+		pointed.type = drgn_void_type(bf->prog, &drgn_language_c);
+	else
+		err = drgn_btf_type_create(bf, tp->type, &pointed);
+
+	if (err)
+		return err;
+
+	// TODO can't hardcode 8
+	return drgn_pointer_type_create(bf->prog, pointed, 8, DRGN_PROGRAM_ENDIAN, &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_typedef_type_from_btf(struct drgn_prog_btf *bf, struct btf_type *tp,
+			   struct drgn_type **ret)
+{
+	struct drgn_qualified_type aliased;
+	struct drgn_error *err;
+	const char *name = btf_str(bf, tp->name_off);
+
+	err = drgn_btf_type_create(bf, tp->type, &aliased);
+	if (err)
+		return err;
+
+	return drgn_typedef_type_create(bf->prog, name, aliased, &drgn_language_c, ret);
+}
+
+struct drgn_btf_member_thunk_arg {
+	struct btf_member *member;
+	struct drgn_prog_btf *bf;
+	uint64_t bit_field_size;
+};
+
+static uint64_t drgn_btf_lookup_bit_size(struct drgn_prog_btf *bf, uint32_t idx, uint64_t *offset)
+{
+	drgn_btf_resolve_qualifiers(bf, idx, &idx);
+	struct btf_type *tp = bf->index.data[idx];
+	uint32_t val;
+	if (btf_kind(tp->info) != BTF_KIND_INT)
+		return 0;
+
+	// Integers themselves may encode bit size and offset
+	val = *(uint32_t *)&tp[1];
+	if (BTF_INT_OFFSET(val))
+		*offset += BTF_INT_OFFSET(val);
+	return BTF_INT_BITS(val);
+}
+
+static struct drgn_error *
+drgn_btf_member_thunk_fn(struct drgn_object *res, void *arg_)
+{
+	struct drgn_btf_member_thunk_arg *arg = arg_;
+	struct drgn_error *err;
+
+	if (res) {
+		struct drgn_qualified_type qualified_type;
+		printf("THUNK: create type %d\n", arg->member->type);
+		err = drgn_btf_type_create(arg->bf, arg->member->type, &qualified_type);
+		if (err)
+			return err;
+		if (!arg->bit_field_size) {
+			arg->bit_field_size = 8 * drgn_type_size(qualified_type.type);
+		}
+		err = drgn_object_set_absent(res, qualified_type, arg->bit_field_size);
+		if (err)
+			return err;
+	}
+	free(arg);
+	return NULL;
+}
+
+static struct drgn_error *
+drgn_compound_type_from_btf(struct drgn_prog_btf *bf, struct btf_type *tp,
+			    struct drgn_type **ret)
+{
+	struct drgn_compound_type_builder builder;
+	struct btf_member *members = (struct btf_member *)&tp[1];
+	size_t vlen = btf_vlen(tp->info);
+	enum drgn_type_kind kind = DRGN_TYPE_STRUCT;
+	bool flag_bitfield_size_in_offset = btf_kind_flag(tp->info);
+	struct drgn_error *err;
+	const char *tag = NULL;
+
+	if (btf_kind(tp->info) == BTF_KIND_UNION)
+		kind = DRGN_TYPE_UNION;
+
+	if (tp->name_off)
+		tag = btf_str(bf, tp->name_off);
+
+	drgn_compound_type_builder_init(&builder, bf->prog, kind);
+	for (size_t i = 0; i < vlen; i++) {
+		struct drgn_btf_member_thunk_arg *thunk_arg =
+			malloc(sizeof(*thunk_arg));
+		uint64_t bit_offset;
+		const char *name = NULL;
+		if (!thunk_arg)
+			return &drgn_enomem;
+		thunk_arg->member = &members[i];
+		thunk_arg->bf = bf;
+		if (flag_bitfield_size_in_offset) {
+			bit_offset = BTF_MEMBER_BIT_OFFSET(members[i].offset);
+			thunk_arg->bit_field_size = BTF_MEMBER_BITFIELD_SIZE(members[i].offset);
+		} else {
+			bit_offset = members[i].offset;
+			thunk_arg->bit_field_size = drgn_btf_lookup_bit_size(bf, members[i].type, &bit_offset);
+		}
+		if (members[i].name_off)
+			name = btf_str(bf, members[i].name_off);
+
+		union drgn_lazy_object member_object;
+		drgn_lazy_object_init_thunk(&member_object, bf->prog,
+					    drgn_btf_member_thunk_fn, thunk_arg);
+
+		err = drgn_compound_type_builder_add_member(&builder, &member_object,
+							    name, bit_offset);
+		if (err) {
+			drgn_lazy_object_deinit(&member_object);
+			return err;
+		}
+		printf(" added struct member %s ofset %lu!\n", name ? name : "(anonymous)", bit_offset);
+	}
+	return drgn_compound_type_create(&builder, tag, tp->size, true, &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_btf_type_create(struct drgn_prog_btf *bf, uint32_t idx,
+		     struct drgn_qualified_type *ret)
+{
+	struct drgn_error *err;
+	enum drgn_qualifiers qual = drgn_btf_resolve_qualifiers(bf, idx, &idx);
+	struct btf_type *tp = bf->index.data[idx];
+
+	printf("drgn_btf_type_create: %d\n", idx);
+
+	if (bf->cache[idx]) {
+		ret->qualifiers = qual;
+		ret->type = bf->cache[idx];
+		return NULL;
+	}
+
+	switch (btf_kind(tp->info)) {
+	case BTF_KIND_INT:
+		err = drgn_int_type_from_btf(bf, tp, &ret->type);
+		break;
+	case BTF_KIND_PTR:
+		err = drgn_pointer_type_from_btf(bf, tp, &ret->type);
+		break;
+	case BTF_KIND_TYPEDEF:
+		err = drgn_typedef_type_from_btf(bf, tp, &ret->type);
+		break;
+	case BTF_KIND_STRUCT:
+	case BTF_KIND_UNION:
+		err = drgn_compound_type_from_btf(bf, tp, &ret->type);
+		break;
+
+	default:
+		return &drgn_not_found;
+	}
+	if (!err) {
+		ret->qualifiers = qual;
+		bf->cache[idx] = ret->type;
+	}
+	return err;
+}
+
+static int drgn_btf_kind(enum drgn_type_kind kind)
+{
+	switch (kind) {
+	case DRGN_TYPE_INT:
+	case DRGN_TYPE_BOOL:
+		return BTF_KIND_INT;
+	case DRGN_TYPE_TYPEDEF:
+		return BTF_KIND_TYPEDEF;
+	case DRGN_TYPE_STRUCT:
+		return BTF_KIND_STRUCT;
+	case DRGN_TYPE_UNION:
+		return BTF_KIND_UNION;
+	case DRGN_TYPE_POINTER:
+		return BTF_KIND_PTR;
+	default:
+		return -1;
+	}
 }
 
 static struct drgn_error *
@@ -185,23 +404,22 @@ drgn_type_from_btf(enum drgn_type_kind kind, const char *name,
 		   size_t name_len, const char *filename,
 		   void *arg, struct drgn_qualified_type *ret)
 {
-	struct btf_type *tp;
+	uint32_t idx;
 	struct drgn_prog_btf *bf = arg;
+	int btf_kind = drgn_btf_kind(kind);
 
-	printf("drgn_type_from_btf: %d, \"%s\", %p\n", kind, name, ret);
+	if (btf_kind < 0)
+		return &drgn_not_found;
 
-	switch (kind) {
-	case DRGN_TYPE_INT:
-	case DRGN_TYPE_BOOL:
-		return drgn_int_type_from_btf(bf, name, name_len, ret);
-	case DRGN_TYPE_STRUCT:
-	case DRGN_TYPE_UNION:
-		break;
-	default:
-		break;
-	}
-	printf("drgn_type_from_btf: not found\n");
-	return &drgn_not_found;
+	printf("drgn_type_from_btf: kind: %d name: %s\n", kind, name);
+	idx = drgn_btf_lookup(bf, name, name_len, btf_kind);
+	if (!idx)
+		return &drgn_not_found;
+
+	struct drgn_error *err = drgn_btf_type_create(bf, idx, ret);
+	if (!err)
+		printf("drgn_type_from_btf: return kind %d\n", ret->type->_private.kind);
+	return err;
 }
 
 struct drgn_error *drgn_btf_init(struct drgn_program *prog, uint64_t start, uint64_t bytes)
@@ -255,11 +473,18 @@ struct drgn_error *drgn_btf_init(struct drgn_program *prog, uint64_t start, uint
 	if (err)
 		goto out_free;
 
+	pbtf->cache = calloc(pbtf->index.size, sizeof(pbtf->cache));
+	if (!pbtf->cache) {
+		err = &drgn_enomem;
+		goto out_free;
+	}
+
 	err = drgn_program_add_type_finder(prog, drgn_type_from_btf, pbtf);
 	if (err)
 		goto out_free;
 	return err;
 out_free:
+	free(pbtf->cache);
 	free(pbtf->ptr);
 	type_vector_deinit(&pbtf->index);
 	free(pbtf);

--- a/libdrgn/btf.h
+++ b/libdrgn/btf.h
@@ -1,0 +1,207 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/* Copyright (c) 2018 Facebook */
+
+/**
+ * @file
+ *
+ * BPF Type Format. This header is copied from linux 5.17. We can't rely on the
+ * system having an up-to-date copy of <linux/btf.h>, since we may debug a more
+ * recent kernel than the system drgn was built on.
+ */
+
+#ifndef DRGN_BTF_H
+#define DRGN_BTF_H
+
+#include <stdint.h>
+
+#include "program.h"
+
+typedef uint8_t  __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef int32_t __s32;
+
+#define BTF_MAGIC	0xeB9F
+#define BTF_VERSION	1
+
+struct btf_header {
+	__u16	magic;
+	__u8	version;
+	__u8	flags;
+	__u32	hdr_len;
+
+	/* All offsets are in bytes relative to the end of this header */
+	__u32	type_off;	/* offset of type section	*/
+	__u32	type_len;	/* length of type section	*/
+	__u32	str_off;	/* offset of string section	*/
+	__u32	str_len;	/* length of string section	*/
+};
+
+/* Max # of type identifier */
+#define BTF_MAX_TYPE	0x000fffff
+/* Max offset into the string section */
+#define BTF_MAX_NAME_OFFSET	0x00ffffff
+/* Max # of struct/union/enum members or func args */
+#define BTF_MAX_VLEN	0xffff
+
+struct btf_type {
+	__u32 name_off;
+	/* "info" bits arrangement
+	 * bits  0-15: vlen (e.g. # of struct's members)
+	 * bits 16-23: unused
+	 * bits 24-27: kind (e.g. int, ptr, array...etc)
+	 * bits 28-30: unused
+	 * bit     31: kind_flag, currently used by
+	 *             struct, union and fwd
+	 */
+	__u32 info;
+	/* "size" is used by INT, ENUM, STRUCT, UNION and DATASEC.
+	 * "size" tells the size of the type it is describing.
+	 *
+	 * "type" is used by PTR, TYPEDEF, VOLATILE, CONST, RESTRICT,
+	 * FUNC, FUNC_PROTO, VAR, DECL_TAG and TYPE_TAG.
+	 * "type" is a type_id referring to another type.
+	 */
+	union {
+		__u32 size;
+		__u32 type;
+	};
+};
+
+#define BTF_INFO_KIND(info)	(((info) >> 24) & 0x1f)
+#define BTF_INFO_VLEN(info)	((info) & 0xffff)
+#define BTF_INFO_KFLAG(info)	((info) >> 31)
+
+enum {
+	BTF_KIND_UNKN		= 0,	/* Unknown	*/
+	BTF_KIND_INT		= 1,	/* Integer	*/
+	BTF_KIND_PTR		= 2,	/* Pointer	*/
+	BTF_KIND_ARRAY		= 3,	/* Array	*/
+	BTF_KIND_STRUCT		= 4,	/* Struct	*/
+	BTF_KIND_UNION		= 5,	/* Union	*/
+	BTF_KIND_ENUM		= 6,	/* Enumeration	*/
+	BTF_KIND_FWD		= 7,	/* Forward	*/
+	BTF_KIND_TYPEDEF	= 8,	/* Typedef	*/
+	BTF_KIND_VOLATILE	= 9,	/* Volatile	*/
+	BTF_KIND_CONST		= 10,	/* Const	*/
+	BTF_KIND_RESTRICT	= 11,	/* Restrict	*/
+	BTF_KIND_FUNC		= 12,	/* Function	*/
+	BTF_KIND_FUNC_PROTO	= 13,	/* Function Proto	*/
+	BTF_KIND_VAR		= 14,	/* Variable	*/
+	BTF_KIND_DATASEC	= 15,	/* Section	*/
+	BTF_KIND_FLOAT		= 16,	/* Floating point	*/
+	BTF_KIND_DECL_TAG	= 17,	/* Decl Tag */
+	BTF_KIND_TYPE_TAG	= 18,	/* Type Tag */
+
+	NR_BTF_KINDS,
+	BTF_KIND_MAX		= NR_BTF_KINDS - 1,
+};
+
+/* For some specific BTF_KIND, "struct btf_type" is immediately
+ * followed by extra data.
+ */
+
+/* BTF_KIND_INT is followed by a u32 and the following
+ * is the 32 bits arrangement:
+ */
+#define BTF_INT_ENCODING(VAL)	(((VAL) & 0x0f000000) >> 24)
+#define BTF_INT_OFFSET(VAL)	(((VAL) & 0x00ff0000) >> 16)
+#define BTF_INT_BITS(VAL)	((VAL)  & 0x000000ff)
+
+/* Attributes stored in the BTF_INT_ENCODING */
+#define BTF_INT_SIGNED	(1 << 0)
+#define BTF_INT_CHAR	(1 << 1)
+#define BTF_INT_BOOL	(1 << 2)
+
+/* BTF_KIND_ENUM is followed by multiple "struct btf_enum".
+ * The exact number of btf_enum is stored in the vlen (of the
+ * info in "struct btf_type").
+ */
+struct btf_enum {
+	__u32	name_off;
+	__s32	val;
+};
+
+/* BTF_KIND_ARRAY is followed by one "struct btf_array" */
+struct btf_array {
+	__u32	type;
+	__u32	index_type;
+	__u32	nelems;
+};
+
+/* BTF_KIND_STRUCT and BTF_KIND_UNION are followed
+ * by multiple "struct btf_member".  The exact number
+ * of btf_member is stored in the vlen (of the info in
+ * "struct btf_type").
+ */
+struct btf_member {
+	__u32	name_off;
+	__u32	type;
+	/* If the type info kind_flag is set, the btf_member offset
+	 * contains both member bitfield size and bit offset. The
+	 * bitfield size is set for bitfield members. If the type
+	 * info kind_flag is not set, the offset contains only bit
+	 * offset.
+	 */
+	__u32	offset;
+};
+
+/* If the struct/union type info kind_flag is set, the
+ * following two macros are used to access bitfield_size
+ * and bit_offset from btf_member.offset.
+ */
+#define BTF_MEMBER_BITFIELD_SIZE(val)	((val) >> 24)
+#define BTF_MEMBER_BIT_OFFSET(val)	((val) & 0xffffff)
+
+/* BTF_KIND_FUNC_PROTO is followed by multiple "struct btf_param".
+ * The exact number of btf_param is stored in the vlen (of the
+ * info in "struct btf_type").
+ */
+struct btf_param {
+	__u32	name_off;
+	__u32	type;
+};
+
+enum {
+	BTF_VAR_STATIC = 0,
+	BTF_VAR_GLOBAL_ALLOCATED = 1,
+	BTF_VAR_GLOBAL_EXTERN = 2,
+};
+
+enum btf_func_linkage {
+	BTF_FUNC_STATIC = 0,
+	BTF_FUNC_GLOBAL = 1,
+	BTF_FUNC_EXTERN = 2,
+};
+
+/* BTF_KIND_VAR is followed by a single "struct btf_var" to describe
+ * additional information related to the variable such as its linkage.
+ */
+struct btf_var {
+	__u32	linkage;
+};
+
+/* BTF_KIND_DATASEC is followed by multiple "struct btf_var_secinfo"
+ * to describe all BTF_KIND_VAR types it contains along with it's
+ * in-section offset as well as size.
+ */
+struct btf_var_secinfo {
+	__u32	type;
+	__u32	offset;
+	__u32	size;
+};
+
+/* BTF_KIND_DECL_TAG is followed by a single "struct btf_decl_tag" to describe
+ * additional information related to the tag applied location.
+ * If component_idx == -1, the tag is applied to a struct, union,
+ * variable or function. Otherwise, it is applied to a struct/union
+ * member or a func argument, and component_idx indicates which member
+ * or argument (0 ... vlen-1).
+ */
+struct btf_decl_tag {
+       __s32   component_idx;
+};
+
+struct drgn_error *drgn_btf_init(struct drgn_program *prog, uint64_t start, uint64_t bytes);
+
+#endif /* DRGN_BTF_H */

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -664,6 +664,10 @@ struct drgn_error *drgn_program_load_debug_info(struct drgn_program *prog,
 						bool load_default,
 						bool load_main);
 
+/** Load BTF at a specified address. Here to allow Python bindings to use. */
+struct drgn_error *
+drgn_program_load_btf(struct drgn_program *prog, uint64_t addr, uint64_t size);
+
 /**
  * Create a @ref drgn_program from a core dump file.
  *

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "btf.h"
 #include "debug_info.h"
 #include "error.h"
 #include "helpers.h"
@@ -674,6 +675,12 @@ drgn_program_load_debug_info(struct drgn_program *prog, const char **paths,
 		}
 	}
 	return err;
+}
+
+LIBDRGN_PUBLIC struct drgn_error *
+drgn_program_load_btf(struct drgn_program *prog, uint64_t addr, uint64_t size)
+{
+	return drgn_btf_init(prog, addr, size);
 }
 
 static struct drgn_error *get_prstatus_pid(struct drgn_program *prog, const char *data,

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -745,6 +745,19 @@ static PyObject *Program_stack_trace(Program *self, PyObject *args,
 	return ret;
 }
 
+static PyObject *Program_add_btf_info(Program *self, PyObject *args)
+{
+	struct drgn_error *err;
+	uint64_t addr, size;
+
+	if (!PyArg_ParseTuple(args, "KK:symbols", &addr, &size))
+		return NULL;
+
+	err = drgn_program_load_btf(&self->prog, addr, size);
+	if (err)
+		return set_drgn_error(err);
+	return Py_None;
+}
 static PyObject *Program_symbols(Program *self, PyObject *args)
 {
 	struct drgn_error *err;
@@ -1041,6 +1054,8 @@ static PyMethodDef Program_methods[] = {
 	{"stack_trace", (PyCFunction)Program_stack_trace,
 	 METH_VARARGS | METH_KEYWORDS, drgn_Program_stack_trace_DOC},
 	{"symbols", (PyCFunction)Program_symbols, METH_VARARGS,
+	 drgn_Program_symbols_DOC},
+	{"add_btf_info", (PyCFunction)Program_add_btf_info, METH_VARARGS,
 	 drgn_Program_symbols_DOC},
 	{"symbol", (PyCFunction)Program_symbol, METH_O,
 	 drgn_Program_symbol_DOC},


### PR DESCRIPTION
This is an early (ugly) draft of a type finder based on BTF! I'm hoping to get some advice on direction if possible, and once we have an idea of where to take this, I can clean up the branch into logical changes and we can move it out of the draft state.

Currently, this supports the basics: 
- typedefs, integers, enums, arrays, structs, unions, function signatures. 

It is missing:
- float, mostly because my vmcore doesn't have any floating point values to test on, but it should be trivial to implement. 
- tags - e.g. attribute tags. I haven't run into these yet but I'm sure it will need implementing before this gets merged.
- function / variable declarations. This isn't strictly type name information, but instead it's the type information associated with the symbol table. It will need to be there for BTF to be really useful, but it's not necessarily within scope for the "type finder" API.
- Support for module BTF. This should be 100% feasible, but I need to get a more mature implementation before I start dabbling there.

The way I've been able to exercise the functionality is by adding `prog.add_btf_info(address, bytes)`, which will read the data from the program memory and interpret it as BTF, registering the type finder. So right now, I'm able to load a normal vmcore with debuginfo, get the addresses of `__start_BTF` and `__stop_BTF` symbols, and then run drgn again without the debuginfo, calling `prog.add_btf_info(__start_BTF, __stop_BTF - __start_BTF)`.

I've tested it on some large/interesting structs within the kernel (`task_struct`, `dentry`, `dentry_operations`, `inode`), by running `print(prog.type("..."))`. They all look correct to me.

I have a few specific questions (corresponding with TODOs or other outlined issues in comments):

1. Licensing: we shouldn't rely on the system-provided <linux/btf.h> because it
   may not be fully up-to-date. So I grabbed a copy from linux 5.17. The license
   identifier on <linux/btf.h> is GPLv2, is this an issue for inclusion?
2. BTF does not encode the architecture pointer size, is there a good way to get
   that in drgn?
3. BTF seems to specify that all enums are encoded as 4-byte signed integers. Is
   there any good way to create such a type without relying on the language's
   name? This is for inclusion in the "compatible_type" field of the enum.
   
However, the biggest question I have is if you can recommend a direction for
me to go next? For the most part, this has been an "automatic" process of
reading and implementing the BTF spec, while also learning the drgn type system.
Now that a large chunk of this is complete, I'm unsure how to integrate this
module with the rest of drgn. Should the BTF registry have a pointer in
`prog.dbinfo`?

Using the BTF integration automatically seems to be a ways off. After all, we
still need kallsyms support, and at least a few new symbols in the vmcoreinfo
note to help us find the kallsyms in the vmcore. Without both pieces, the BTF
code is pretty unhelpful. To find the BTF information, you need a symbol table,
and if you have that you probably have DWARF info too. Plus, even if you find
the BTF information, you'll still want the symbol table so you can find data
structures to analyze with the BTF types. So would the best way forward right
now be to expose this as some sort of Python interface (cleaned up from what I
have here)?
