### PR TITLE
helpers: porting slab allocating debugging tools to drgn helpers

### DIFF
--- a/drgn/helpers/linux/slab.py
+++ b/drgn/helpers/linux/slab.py
@@ -1,0 +1,55 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Slab Allocator
+--------------
+
+The ``drgn.helpers.linux.slab`` module provides helpers for working with the
+Linux slab allocator.
+"""
+
+from typing import Iterator, Optional, Union
+
+from drgn import Object, Program
+from drgn.helpers import escape_ascii_string
+from drgn.helpers.linux.list import list_for_each_entry
+
+__all__ = (
+    "find_slab_cache",
+    "for_each_slab_cache",
+    "print_slab_caches",
+)
+
+
+def for_each_slab_cache(prog: Program) -> Iterator[Object]:
+    """
+    Iterate over all slab caches.
+
+    :return: Iterator of ``struct kmem_cache *`` objects.
+    """
+    return list_for_each_entry(
+        "struct kmem_cache", prog["slab_caches"].address_of_(), "list"
+    )
+
+
+def find_slab_cache(prog: Program, name: Union[str, bytes]) -> Optional[Object]:
+    """
+    Return the slab cache with the given name.
+
+    :param name: Slab cache name.
+    :return: ``struct kmem_cache *``
+    """
+    if isinstance(name, str):
+        name = name.encode()
+    for s in for_each_slab_cache(prog):
+        if s.name.string_() == name:
+            return s
+    return None
+
+
+def print_slab_caches(prog: Program) -> None:
+    """Print the name and ``struct kmem_cache *`` value of all slab caches."""
+    for s in for_each_slab_cache(prog):
+        name = escape_ascii_string(s.name.string_(), escape_backslash=True)
+        print(f"{name} ({s.type_.type_name()})0x{s.value_():x}")

--- a/tests/helpers/linux/test_slab.py
+++ b/tests/helpers/linux/test_slab.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from drgn.helpers.linux.slab import find_slab_cache, for_each_slab_cache
+from tests.linux_kernel import LinuxKernelTestCase
+
+
+def get_proc_slabinfo_names():
+    with open("/proc/slabinfo", "rb") as f:
+        # Skip the version and header.
+        f.readline()
+        f.readline()
+        return [line.split()[0] for line in f]
+
+
+class TestSlab(LinuxKernelTestCase):
+    def test_for_each_slab_cache(self):
+        self.assertCountEqual(
+            get_proc_slabinfo_names(),
+            [s.name.string_() for s in for_each_slab_cache(self.prog)],
+        )
+
+    def test_find_slab_cache(self):
+        for name in get_proc_slabinfo_names():
+            slab = find_slab_cache(self.prog, name)
+            self.assertEqual(name, slab.name.string_())


### PR DESCRIPTION
Adding additional helpers to view slab info for debugging.
Allows for printing slabs, obtainig the struct kmem_cache object
corresponding to a slab and obtaining all slab objects of a given
type.