### PR TITLE
Debug a given executable without immediately starting a new process

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -443,6 +443,17 @@ class Program:
             return an :class:`Object`.
         """
         ...
+    def set_argv(self, executable_path: Path, argv: Sequence[str]) -> None:
+        """
+        Set the program to a yet to be created process with the given executable
+        and arguments.
+
+        :param executable_path: Path to the executable file to be used for the
+            new process.
+        :param argv: argv Arguments supplied to the new process
+            (interpreted as by `execvp(3)`).
+        """
+        ...
     def set_core_dump(self, path: Path) -> None:
         """
         Set the program to a core dump.
@@ -513,6 +524,12 @@ class Program:
         the program.
 
         This is equivalent to ``load_debug_info(None, True)``.
+        """
+        ...
+    def run(self) -> None:
+        """
+        Launch a new process using the executable and arguments previously
+        supplied in a call to  :meth:`set_argv`, and begin debugging it.
         """
         ...
     cache: Dict[Any, Any]

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -624,6 +624,22 @@ drgn_program_add_object_finder(struct drgn_program *prog,
 			       drgn_object_find_fn fn, void *arg);
 
 /**
+ * Set a @ref drgn_program to use the given executable and arguments.
+ *
+ * To launch a process using the given executable and arguments, call
+ * @ref drgn_program_run.
+ *
+ * @param[in] executable_path Path to the executable file to be used for the
+ * new process.
+ * @param[in] argv Arguments supplied to the new process
+ * (interpreted as by `execvp(3)`).
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_set_argv(struct drgn_program *prog,
+					 const char *executable_path,
+					 char *const argv[]);
+
+/**
  * Set a @ref drgn_program to a core dump.
  *
  * @sa drgn_program_from_core_dump()
@@ -663,6 +679,34 @@ struct drgn_error *drgn_program_load_debug_info(struct drgn_program *prog,
 						const char **paths, size_t n,
 						bool load_default,
 						bool load_main);
+
+/**
+ * Launch a new process using the executable and arguments previously supplied
+ * in a call to @ref drgn_program_set_argv, and begin debugging it.
+ *
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_run(struct drgn_program *prog);
+
+/**
+ * Create a @ref drgn_program from a given executable and arguments.
+ *
+ * The types present in the program and other information contained within its
+ * debug information can be queried immediately after calling this function.
+ *
+ * Values can be inspected only after launching a process with the given
+ * executable and arguments by calling @ref drgn_program_run.
+ *
+ * @param[in] executable_path Path to the executable file to be used for the
+ * new process.
+ * @param[in] argv Arguments supplied to the new process
+ * (interpreted as by `execvp(3)`).
+ * @param[out] ret Returned program.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_from_argv(const char *executable_path,
+					  char *const argv[],
+					  struct drgn_program **ret);
 
 /**
  * Create a @ref drgn_program from a core dump file.

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -84,6 +84,9 @@ struct drgn_program {
 	struct drgn_memory_reader reader;
 	/* Elf core dump or /proc/pid/mem file segments. */
 	struct drgn_memory_file_segment *file_segments;
+	/* Executable and arguments for a userspace program. */
+	const char * executable_path;
+	char * const* argv;
 	/* Elf core dump. Not valid for live programs or kdump files. */
 	Elf *core;
 	/* File descriptor for ELF core dump, kdump file, or /proc/pid/mem. */


### PR DESCRIPTION
See the commit messages for a more detailed description of this new feature.

This is something that previously could be halfway achieved via the hack:
```sh
drgn -p 0 -s executable --no-default-symbols
```

But while that was sufficient for querying the types in a binary, it didn't provide any way to subsequently run the binary.

This addition changes this on the C API, Python bindings, and CLI fronts by providing easy mechanisms for specifying a binary (and arguments to be passed to it) to debug without immediately running it, as well as facilities for later launching a new process with the given binary and arguments. So now you can do the following, which is quite convenient:

```
drgn -a executable arg0 arg1 arg2
>>> prog.type('struct foo') # Can query debug info before running program
>>> prog.run() # Launch the program with the pre-specified arguments at your leisure
>>> prog['my_foo'] # Debug the program as normal 
```