### PR TITLE
Implement kallsyms for vmlinux only

### DIFF
--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -49,6 +49,10 @@ libdrgnimpl_la_SOURCES = $(ARCH_DEFS:.defs=.c) \
 			 hash_table.c \
 			 hash_table.h \
 			 helpers.h \
+			 kallsyms.c \
+			 kallsyms.h \
+			 kernel_info.c \
+			 kernel_info.h \
 			 language.c \
 			 language.h \
 			 language_c.c \

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -630,6 +630,77 @@ struct drgn_error *
 drgn_program_add_object_finder(struct drgn_program *prog,
 			       drgn_object_find_fn fn, void *arg);
 
+/** Flags for @ref drgn_program_find_symbols() */
+enum drgn_find_symbol_flags {
+	/** Find symbols whose name matches the name argument */
+	DRGN_FIND_SYM_NAME = 1 << 0,
+	/** Find symbols whose address matches the addr argument */
+	DRGN_FIND_SYM_ADDR = 1 << 1,
+	/** Find only one symbol */
+	DRGN_FIND_SYM_ONE = 1 << 2,
+};
+
+/** Result type for @ref drgn_program_find_symbols() */
+union drgn_find_symbol_result {
+	/** When @ref DRGN_FIND_SYM_ONE is set, return the symbol here */
+	struct drgn_symbol *symbol;
+	struct {
+		/** When @ref DRGN_FIND_SYM_ONE is unset, store array here */
+		struct drgn_symbol **symbol_arr;
+		/** When @ref DRGN_FIND_SYM_ONE is unset, store array length */
+		size_t count;
+	};
+};
+
+/**
+ * Callback for finding one or more symbols.
+ *
+ * The callback should perform a symbol lookup based on the flags given in @a
+ * flags. When multiple flags are provided, the effect should be treated as a
+ * logical AND. When @ref DRGN_FIND_SYM_ONE is set, a single symbol should be
+ * returned, otherwise, an array should be returned.
+ *
+ * When no symbol is found, the proper pointer in @ref drgn_find_symbol_result
+ * should be set to NULL (and if applicable, count should be set to 0). No error
+ * should be returned in this case.
+ *
+ * @param[in] name Name of the symbol to match
+ * @param[in] addr Address of the symbol to match
+ * @param[in] flags Flags indicating the desired behavior of the search
+ * @param[in] arg Argument passed to @ref drgn_program_add_symbol_finder().
+ * @param[out] ret Returned result
+ */
+typedef struct drgn_error *
+(*drgn_find_symbol_fn)(const char *name, uint64_t addr,
+		       enum drgn_find_symbol_flags flags, void *arg,
+		       union drgn_find_symbol_result *ret);
+
+/**
+ * Register a symbol finding callback.
+ *
+ * Callbacks are called in reverse order that they were originally added. In
+ * case of a search for multiple symbols, then the results of all callbacks are
+ * concatenated. If the search is for a single symbol, then the first callback
+ * which finds a symbol will short-circuit the search.
+ *
+ * @param[in] fn Symbol search function
+ * @param[in] arg Argument to pass to the callback
+ */
+struct drgn_error *
+drgn_program_add_symbol_finder(struct drgn_program *prog,
+			       drgn_find_symbol_fn fn, void *arg);
+
+/**
+ * Unregister a symbol finding callback
+ *
+ * If a symbol finder is found with the given @a fn and @a arg, removes it.
+ * Otherwise, does nothing.
+ *
+ * @param[in] fn Symbol search function
+ * @param[in] arg Callback argument
+ */
+void drgn_program_remove_symbol_finder(struct drgn_program *prog,
+				       drgn_find_symbol_fn fn, void *arg);
 /**
  * Set a @ref drgn_program to a core dump.
  *

--- a/libdrgn/kallsyms.c
+++ b/libdrgn/kallsyms.c
@@ -1,0 +1,461 @@
+// Copyright (c) 2022 Oracle and/or its affiliates
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <stddef.h>
+
+#include "kallsyms.h"
+#include "program.h"
+#include "drgn.h"
+
+/**
+ * This struct contains the tables necessary to reconstruct kallsyms names.
+ *
+ * vmlinux (core kernel) kallsyms names are compressed using table compression.
+ * There is some description of it in the kernel's "scripts/kallsyms.c", but
+ * this is a brief overview that should make the code below comprehensible.
+ *
+ * Table compression uses the remaining 128 characters not defined by ASCII and
+ * maps them to common substrings (e.g. the prefix "write_"). Each name is
+ * represented as a sequence of bytes which refers to strings in this table.
+ * The two arrays below comprise this table:
+ *
+ *   - token_table: this is one long string with all of the tokens concatenated
+ *     together, e.g. "a\0b\0c\0...z\0write_\0read_\0..."
+ *   - token_index: this is a 256-entry long array containing the index into
+ *     token_table where you'll find that token's string.
+ *
+ * To decode a string, for each byte you simply index into token_index, then use
+ * that to index into token_table, and copy that string into your buffer.
+ *
+ * The actual kallsyms symbol names are concatenated into a buffer called
+ * "names". The first byte in a name is the length (in tokens, not decoded
+ * bytes) of the symbol name. The remaining "length" bytes are decoded via the
+ * table as described above. The first decoded byte is a character representing
+ * what type of symbol this is (e.g. text, data structure, etc).
+ */
+struct kallsyms_reader {
+	uint32_t num_syms;
+	uint8_t *names;
+	char *token_table;
+	uint16_t *token_index;
+};
+
+/**
+ * Copy the kallsyms names tables from the program into host memory.
+ * @param prog Program to read from
+ * @param kr kallsyms_reader to populate
+ * @param vi vmcoreinfo for the program
+ */
+static struct drgn_error *
+kallsyms_copy_tables(struct drgn_program *prog, struct kallsyms_reader *kr,
+		     struct vmcoreinfo *vi)
+{
+	struct drgn_error *err;
+	const size_t token_index_size = (UINT8_MAX + 1) * sizeof(uint16_t);
+	uint64_t last_token;
+	size_t token_table_size, names_idx;
+	char data;
+	uint8_t len;
+	bool bswap;
+
+	err = drgn_program_bswap(prog, &bswap);
+	if (err)
+		return err;
+
+	/* Read num_syms from vmcore */
+	err = drgn_program_read_u32(prog,
+				    vi->kallsyms_num_syms,
+				    false, &kr->num_syms);
+	if (err)
+		return err;
+	if (bswap)
+		kr->num_syms = bswap_32(kr->num_syms);
+
+	/* Read the constant-sized token_index table (256 entries) */
+	kr->token_index = malloc(token_index_size);
+	if (!kr->token_index)
+		return &drgn_enomem;
+	err = drgn_program_read_memory(prog, kr->token_index,
+				       vi->kallsyms_token_index,
+				       token_index_size, false);
+	if (err)
+		return err;
+	if (bswap) {
+		for (size_t i = 0; i < kr->num_syms; i++) {
+			kr->token_index[i] = bswap_16(kr->token_index[i]);
+		}
+	}
+
+	/*
+	 * Find the end of the last token, so we get the overall length of
+	 * token_table. Then copy the token_table into host memory.
+	 */
+	last_token = vi->kallsyms_token_table + kr->token_index[UINT8_MAX];
+	do {
+		err = drgn_program_read_u8(prog, last_token, false,
+					   (uint8_t *)&data);
+		if (err)
+			return err;
+
+		last_token++;
+	} while (data);
+	token_table_size = last_token - vi->kallsyms_token_table + 1;
+	kr->token_table = malloc(token_table_size);
+	if (!kr->token_table)
+		return &drgn_enomem;
+	err = drgn_program_read_memory(prog, kr->token_table,
+				       vi->kallsyms_token_table,
+				       token_table_size, false);
+	if (err)
+		return err;
+
+	/* Now find the end of the names array by skipping through it, then copy
+	 * that into host memory. */
+	names_idx = 0;
+	for (size_t i = 0; i < kr->num_syms; i++) {
+		err = drgn_program_read_u8(prog,
+					   vi->kallsyms_names + names_idx,
+					   false, &len);
+		if (err)
+			return err;
+		names_idx += len + 1;
+	}
+	kr->names = malloc(names_idx);
+	if (!kr->names)
+		return &drgn_enomem;
+	err = drgn_program_read_memory(prog, kr->names,
+				       vi->kallsyms_names,
+				       names_idx, false);
+	if (err)
+		return err;
+
+	return NULL;
+}
+
+/**
+ * Write the symbol starting at @a offset into @a result.
+ * @param kr Registry containing kallsyms data
+ * @param offset Starting index within "names" array for this symbol
+ * @param result Buffer to write output symbol to
+ * @param maxlen Size of output buffer, to avoid overruns
+ * @param[out] kind_ret Where to write the symbol kind data
+ * @param[out] bytes_ret How many bytes were output (incl. NUL)
+ * @returns The offset of the next symbol
+ */
+static unsigned int
+kallsyms_expand_symbol(struct kallsyms_reader *kr, unsigned int offset,
+		       char *result, size_t maxlen, char *kind_ret,
+		       size_t *bytes_ret)
+{
+	uint8_t *data = &kr->names[offset];
+	unsigned int len = *data;
+	bool skipped_first = false;
+	size_t bytes = 0;
+
+	offset += len + 1;
+	data += 1;
+	while (len) {
+		char *token_ptr = &kr->token_table[kr->token_index[*data]];
+		while (*token_ptr) {
+			if (skipped_first) {
+				if (maxlen <= 1)
+					goto tail;
+				*result = *token_ptr;
+				result++;
+				maxlen--;
+				bytes++;
+			} else {
+				if (kind_ret)
+					*kind_ret = *token_ptr;
+				skipped_first = true;
+			}
+			token_ptr++;
+		}
+
+		data++;
+		len--;
+	}
+
+tail:
+	*result = '\0';
+	bytes++;
+	*bytes_ret = bytes;
+	return offset;
+}
+
+/** Decode all symbol names from @a kr and place them into @a reg */
+static struct drgn_error *
+kallsyms_create_symbol_array(struct kallsyms_registry *reg, struct kallsyms_reader *kr)
+{
+	uint8_t token_lengths[UINT8_MAX+1];
+
+	/* Compute the length of each token */
+	for (int i = 0; i <= UINT8_MAX; i++) {
+		token_lengths[i] = strlen(&kr->token_table[kr->token_index[i]]);
+	}
+
+	/* Now compute the length of all symbols together */
+	size_t names_idx = 0;
+	size_t length = 0;
+	for (int i = 0; i < kr->num_syms; i++) {
+		uint8_t num_tokens = kr->names[names_idx];
+		for (int j = names_idx + 1; j < names_idx + num_tokens + 1; j++)
+			length += token_lengths[kr->names[j]];
+		length++; /* nul terminator */
+		names_idx += num_tokens + 1;
+	}
+
+	reg->symbol_buffer = malloc(length);
+	reg->symbols = calloc(kr->num_syms, sizeof(*reg->symbols));
+	reg->types = malloc(kr->num_syms);
+	reg->num_syms = kr->num_syms;
+	if (!reg->symbol_buffer || !reg->symbols || !reg->types)
+		return &drgn_enomem;
+
+	names_idx = 0;
+	size_t symbols_idx = 0;
+	for (int i = 0; i < kr->num_syms; i++) {
+		size_t bytes = 0;
+		names_idx = kallsyms_expand_symbol(kr, names_idx,
+						   reg->symbol_buffer + symbols_idx,
+						   length - symbols_idx, &reg->types[i],
+						   &bytes);
+		reg->symbols[i] = &reg->symbol_buffer[symbols_idx];
+		symbols_idx += bytes;
+	}
+	return NULL;
+}
+
+/** Copies and decodes symbol names from the program. */
+static struct drgn_error *
+kallsyms_load_names(struct kallsyms_registry *reg, struct vmcoreinfo *vi)
+{
+	struct drgn_error *err;
+	struct kallsyms_reader reader = {0};
+
+	err = kallsyms_copy_tables(reg->prog, &reader, vi);
+	if (err)
+		goto out;
+
+	err = kallsyms_create_symbol_array(reg, &reader);
+out:
+	free(reader.names);
+	free(reader.token_index);
+	free(reader.token_table);
+	return err;
+}
+
+/** Lookup @a name in the registry @a kr, and return the index of the symbol */
+int drgn_kallsyms_lookup(struct kallsyms_registry *kr, const char *name)
+{
+	for (int i = 0; i < kr->num_syms; i++)
+		if (strcmp(kr->symbols[i], name) == 0)
+			return i;
+	return -1;
+}
+
+/** Return the address of symbol at @a index*/
+static uint64_t
+kallsyms_address(struct kallsyms_registry *kr, unsigned int index)
+{
+	return kr->addresses[index];
+}
+
+/** Compute an address via the CONFIG_KALLSYMS_ABSOLUTE_PERCPU method*/
+static uint64_t absolute_percpu(uint64_t base, int32_t val)
+{
+	if (val >= 0)
+		return (uint64_t) val;
+	else
+		return base - 1 - val;
+}
+
+/**
+ * Load the kallsyms address information from @a prog
+ *
+ * Just as symbol name loading is complex, so is address loading. Addresses may
+ * be stored directly as an array of pointers, but more commonly, they are
+ * stored as an array of 32-bit integers which are related to an offset. This
+ * function decodes the addresses into a plain array of 64-bit addresses.
+ *
+ * @param prog The program to read from
+ * @param kr The symbol registry to fill
+ * @param vi vmcoreinfo containing necessary symbols
+ * @returns NULL on success, or error
+ */
+static struct drgn_error *
+kallsyms_load_addresses(struct drgn_program *prog, struct kallsyms_registry *kr, struct vmcoreinfo *vi)
+{
+	struct drgn_error *err = NULL;
+	bool bswap, bits64;
+	uint32_t *addr32;
+
+	err = drgn_program_bswap(prog, &bswap);
+	if (err)
+		return err;
+	err = drgn_program_is_64_bit(prog, &bits64);
+	if (err)
+		return err;
+
+	kr->addresses = malloc(kr->num_syms * sizeof(uint64_t));
+	if (!kr->addresses)
+		return &drgn_enomem;
+
+	if (vi->kallsyms_addresses) {
+		/*
+		 * The kallsyms addresses are stored as plain addresses in an
+		 * array of unsigned long! Read the appropriate size array and
+		 * do any necessary byte swaps.
+		 */
+		if (!bits64) {
+			addr32 = malloc(kr->num_syms * sizeof(uint32_t));
+			if (!addr32)
+				return &drgn_enomem;
+
+			err = drgn_program_read_memory(prog, addr32,
+						vi->kallsyms_addresses,
+						kr->num_syms * sizeof(uint32_t),
+						false);
+			if (err) {
+				free(addr32);
+				return err;
+			}
+			for (int i = 0; i < kr->num_syms; i++) {
+				if (bswap)
+					kr->addresses[i] = bswap_32(addr32[i]);
+				else
+					kr->addresses[i] = addr32[i];
+			}
+			free(addr32);
+		} else {
+			err = drgn_program_read_memory(prog, kr->addresses,
+						vi->kallsyms_addresses,
+						kr->num_syms * sizeof(uint32_t),
+						false);
+			if (err)
+				return err;
+			if (bswap)
+				for (int i = 0; i < kr->num_syms; i++)
+					kr->addresses[i] = bswap_64(kr->addresses[i]);
+		}
+	} else {
+		/*
+		 * The kallsyms addresses are stored in an array of 4-byte
+		 * values, which can be interpreted in two ways:
+		 * (1) if CONFIG_KALLSYMS_ABSOLUTE_PERCPU is enabled, then
+		 *     positive values are addresses, and negative values are
+		 *     offsets from a base address.
+		 * (2) otherwise, the 4-byte values are directly used as
+		 *     addresses
+		 * First, read the values, then figure out which way to
+		 * interpret them.
+		 */
+		uint64_t relative_base;
+		if (bits64) {
+			err = drgn_program_read_u64(prog, vi->kallsyms_relative_base,
+						false, &relative_base);
+			if (err)
+				return err;
+			if (bswap)
+				relative_base = bswap_64(relative_base);
+		} else {
+			uint32_t rel32;
+			err = drgn_program_read_u32(prog, vi->kallsyms_relative_base,
+						    false, &rel32);
+			if (err)
+				return err;
+			if (bswap)
+				rel32 = bswap_32(rel32);
+			relative_base = rel32;
+		}
+		addr32 = malloc(kr->num_syms * sizeof(uint32_t));
+		if (!addr32)
+			return &drgn_enomem;
+
+		err = drgn_program_read_memory(prog, addr32,
+					vi->kallsyms_offsets,
+					kr->num_syms * sizeof(uint32_t),
+					false);
+		if (err) {
+			free(addr32);
+			return err;
+		}
+		if (bswap)
+			for (int i = 0; i < kr->num_syms; i++)
+				addr32[i] = bswap_32(addr32[i]);
+
+		/*
+		 * Now that we've read the offsets data, we need to determine
+		 * how to interpret them. To do this, use the _stext symbol. We
+		 * have the correct value from vmcoreinfo. Compute it both ways
+		 * and pick the correct interpretation.
+		 */
+		int stext_idx = drgn_kallsyms_lookup(kr,"_stext");
+		if (stext_idx < 0) {
+			free(addr32);
+			return drgn_error_create(
+				DRGN_ERROR_OTHER,
+				"Could not find _stext symbol in kallsyms");
+		}
+
+		uint64_t stext_abs = relative_base + addr32[stext_idx];
+		uint64_t stext_pcpu = absolute_percpu(relative_base, (int32_t)addr32[stext_idx]);
+		if (stext_abs == vi->_stext) {
+			for (int i = 0; i < kr->num_syms; i++)
+				kr->addresses[i] = relative_base + addr32[i];
+		} else if (stext_pcpu == vi->_stext) {
+			for (int i = 0; i < kr->num_syms; i++)
+				kr->addresses[i] = absolute_percpu(relative_base, (int32_t)addr32[i]);
+		} else {
+			err = drgn_error_create(
+				DRGN_ERROR_OTHER,
+				"Unable to interpret kallsyms address data");
+		}
+		free(addr32);
+	}
+	return err;
+}
+
+/** Free all data held by @a kr */
+void drgn_kallsyms_destroy(struct kallsyms_registry *kr)
+{
+	if (kr) {
+		free(kr->addresses);
+		free(kr->symbol_buffer);
+		free(kr->symbols);
+		free(kr->types);
+		free(kr);
+	}
+}
+
+struct drgn_error *drgn_kallsyms_create(struct drgn_program *prog,
+				        struct vmcoreinfo *vi,
+					struct kallsyms_registry **kr_out)
+{
+	struct drgn_error *err;
+	struct kallsyms_registry *kr;
+
+	if (!(vi->kallsyms_names && vi->kallsyms_token_table
+	      && vi->kallsyms_token_index && vi->kallsyms_num_syms)) {
+		return NULL;
+	}
+
+	kr = calloc(1, sizeof(*kr));
+	if (!kr)
+		return &drgn_enomem;
+
+	kr->prog = prog;
+	err = kallsyms_load_names(kr, vi);
+	if (err)
+		goto out;
+
+	err = kallsyms_load_addresses(prog, kr, vi);
+	if (err)
+		goto out;
+
+	*kr_out = kr;
+	return NULL;
+out:
+	drgn_kallsyms_destroy(kr);
+	return err;
+}

--- a/libdrgn/kallsyms.h
+++ b/libdrgn/kallsyms.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 Oracle and/or its affiliates
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file
+ *
+ * Kallsyms data handling
+ *
+ * See @ref Kallsyms
+ */
+
+#ifndef DRGN_KALLSYMS_H
+#define DRGN_KALLSYMS_H
+
+#include <stdint.h>
+
+struct drgn_program;
+struct vmcoreinfo;
+
+/**
+ * @ingroup KernelInfo
+ *
+ * @defgroup Kallsyms Kallsyms symbol table
+ *
+ * Using the kallsyms data from within the program as a symbol table.
+ *
+ * @{
+ */
+
+/** Holds kallsyms data copied from the kernel */
+struct kallsyms_registry {
+	/** Program owning this registry */
+	struct drgn_program *prog;
+	/** Number of symbols contained */
+	uint32_t num_syms;
+	/** Array of symbol names */
+	char **symbols;
+	/** Buffer backing the symbols array, all point into here */
+	char *symbol_buffer;
+	/** Array of symbol addresses */
+	uint64_t *addresses;
+	/** Array of one-character type codes*/
+	char *types;
+};
+
+
+/**
+ * Initialize kallsyms data
+ *
+ * Search for a kallsyms symbol table, and if found, attempt to load it. On
+ * success, a kallsyms registry is returned in @a ret. If the kallsyms data is
+ * not found (a common failure mode), NULL will be returned to indicate no
+ * error, but @a ret will not be set. This indicates that initialization should
+ * continue. If an error occurs parsing the kallsyms data once it is found, the
+ * error will be returned.
+ *
+ * @param prog Program to search
+ * @param vi vmcoreinfo from the crash dump
+ * @param[out] ret Created registry
+ * @returns NULL on success, or when kallsyms data is not found
+ */
+struct drgn_error *drgn_kallsyms_create(struct drgn_program *prog,
+				        struct vmcoreinfo *vi,
+					struct kallsyms_registry **kr_out);
+
+/** @} */
+
+#endif // DRGN_KALLSYMS_H

--- a/libdrgn/kernel_info.c
+++ b/libdrgn/kernel_info.c
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Oracle and/or its affiliates
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "drgn.h"
+#include "kallsyms.h"
+#include "kernel_info.h"
+#include "program.h"
+
+struct drgn_error *
+drgn_program_load_kernel_info(struct drgn_program *prog)
+{
+	struct drgn_error *err;
+	struct kernel_info *kinfo = calloc(1, sizeof(*kinfo));
+
+	if (!kinfo)
+		return &drgn_enomem;
+
+	err = drgn_kallsyms_create(prog, &prog->vmcoreinfo, &kinfo->kallsyms);
+	if (err || !kinfo)
+		goto out_free_kinfo;
+
+	prog->kinfo = kinfo;
+	printf("Loaded symbols from kallsyms\n");
+	return NULL;
+
+out_free_kinfo:
+	free(kinfo);
+	return err;
+}

--- a/libdrgn/kernel_info.h
+++ b/libdrgn/kernel_info.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2022 Oracle and/or its affiliates
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DRGN_KERNEL_INFO_H
+#define DRGN_KERNEL_INFO_H
+
+struct kallsyms_registry;
+struct drgn_program;
+
+/**
+ * @ingroup Internals
+ *
+ * @defgroup KernelInfo Linux Kernel specific debug info
+ *
+ * @{
+ */
+
+/**
+ * Holds kernel internal debug information
+ *
+ * This structure contains any internal information for the Linux kernel which
+ * can be used to provide similar information as DWARF info. It can be used when
+ * no DWARF info is available to provide symbol information.
+ */
+struct kernel_info {
+	struct kallsyms_registry *kallsyms;
+};
+
+/**
+ * Load debugging information from within the program itself (Linux only)
+ *
+ * The Linux kernel can contain enough information to do some simple debugging
+ * tasks. If other sources of debug info fail, we can try to find this info
+ * and load it.
+ */
+struct drgn_error *drgn_program_load_kernel_info(struct drgn_program *prog);
+
+/** @} */
+
+#endif // DRGN_KERNEL_INFO_H

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -29,6 +29,7 @@
 #include "vector.h"
 
 struct drgn_symbol;
+struct kernel_info;
 
 /**
  * @defgroup Internals Internals
@@ -140,6 +141,7 @@ struct drgn_program {
 	 */
 	struct drgn_object_index oindex;
 	struct drgn_debug_info *dbinfo;
+	struct kernel_info *kinfo;
 
 	/*
 	 * Program information.

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -25,6 +25,7 @@
 #include "memory_reader.h"
 #include "object_index.h"
 #include "platform.h"
+#include "symbol.h"
 #include "type.h"
 #include "vector.h"
 
@@ -142,6 +143,7 @@ struct drgn_program {
 	struct drgn_object_index oindex;
 	struct drgn_debug_info *dbinfo;
 	struct kernel_info *kinfo;
+	struct drgn_symbol_finder *symbol_finders;
 
 	/*
 	 * Program information.

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -62,6 +62,17 @@ struct vmcoreinfo {
 	uint64_t swapper_pg_dir;
 	/** Whether 5-level paging was enabled. */
 	bool pgtable_l5_enabled;
+	/**
+	 * Kallsyms related symbols
+	 */
+	uint64_t kallsyms_names;
+	uint64_t kallsyms_token_table;
+	uint64_t kallsyms_token_index;
+	uint64_t kallsyms_num_syms;
+	uint64_t kallsyms_offsets;
+	uint64_t kallsyms_relative_base;
+	uint64_t kallsyms_addresses;
+	uint64_t _stext;
 };
 
 struct drgn_thread {

--- a/libdrgn/symbol.h
+++ b/libdrgn/symbol.h
@@ -7,6 +7,7 @@
 #include <gelf.h>
 
 #include "drgn.h"
+#include "vector.h"
 
 struct drgn_symbol {
 	const char *name;
@@ -16,8 +17,16 @@ struct drgn_symbol {
 	enum drgn_symbol_kind kind;
 };
 
+struct drgn_symbol_finder {
+	drgn_find_symbol_fn function;
+	void *arg;
+	struct drgn_symbol_finder *next;
+};
+
 /** Initialize a @ref drgn_symbol from an ELF symbol. */
 void drgn_symbol_from_elf(const char *name, uint64_t address,
 			  const GElf_Sym *elf_sym, struct drgn_symbol *ret);
+
+DEFINE_VECTOR_TYPE(symbolp_vector, struct drgn_symbol *)
 
 #endif /* DRGN_SYMBOL_H */


### PR DESCRIPTION
Hi Omar,

I've been reworking my _very_ work-in-progress branch for BTF & kallsyms, and I sketched out my approach in #176. This pull request implements step 1 - kallsyms parsing for vmlinux only. Using symbols from vmcoreinfo ([patches](https://lore.kernel.org/lkml/YoTIMEPAxLF9t2eo@MiWiFi-R3L-srv/) for that look to be accepted), this parses and reads the compressed kallsyms data and extracts it to some easily-queried arrays.

To make this patch have a functional, testable result, I've refactored the ELF symbol code which I had earlier worked on -- it is now modular. Then, I implemented the new symbol API for kallsyms. I'm not absolutely wedded to the particular API design I chose, but I wanted to start somewhere. I don't have a ton of work building off of this patch series yet, so we can iterate on the API if you have better ideas.

So now, we're able to load a vmcore without any debuginfo or ELF symbol table, and do the following:

```
$ venv/bin/drgn -c test3/vmcore
drgn 0.0.19+6.gf753cf7 (using Python 3.9.5, elfutils 0.180, with libkdumpfile)
Loaded symbols from kallsyms
For help, type help(drgn).
>>> import drgn
>>> from drgn import NULL, Object, cast, container_of, execscript, offsetof, reinterpret, sizeof
>>> from drgn.helpers.linux import *
>>> len(prog.symbols())
107551
>>> prog.symbol(0xffffffffb96203f0 + 20)
Symbol(name='cstate_pmu_event_init', address=0xffffffffb96203f0, size=0x180, binding=<SymbolBinding.UNKNOWN: 0>, kind=<SymbolKind.FUNC: 2>)
```