### PR TITLE
Add StackFrame.locals() method

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -1704,6 +1704,16 @@ class StackFrame:
         :param name: Object name.
         """
         ...
+    def locals(self) -> List[str]:
+        """
+        Get a list of the names of all local objects (local variables, function
+        parameters, local constants, and nested functions) in the scope of this
+        frame.
+
+        Not all names may have present values, but they can be used with the
+        :meth:`[] <.__getitem__>` operator to check.
+        """
+        ...
     def source(self) -> Tuple[str, int, int]:
         """
         Get the source code location of this frame.

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -2790,6 +2790,31 @@ struct drgn_error *drgn_stack_frame_symbol(struct drgn_stack_trace *trace,
 					   struct drgn_symbol **ret);
 
 /**
+ * Get the names of local objects in the scope of this frame.
+ *
+ * The array of names must be freed with @ref drgn_stack_frame_locals_destroy().
+ *
+ * @param[out] names_ret Returned array of names. On success, must be freed with
+ * @ref drgn_stack_frame_locals_destroy().
+ * @param[out] count_ret Returned number of names in @p names_ret.
+ * @return @c NULL on success, non-@c NULL on error
+ */
+struct drgn_error *
+drgn_stack_frame_locals(struct drgn_stack_trace *trace, size_t frame,
+			const char ***names_ret, size_t *count_ret);
+
+/**
+ * Free an array of names returned by @ref drgn_stack_frame_locals().
+ *
+ * The individual names from this array are invalid once this function is
+ * called. Any string which will be used later should be copied.
+ *
+ * @param names Array of names returned by @ref drgn_stack_frame_locals().
+ * @param count Count returned by @ref drgn_stack_frame_locals().
+ */
+void drgn_stack_frame_locals_destroy(const char **names, size_t count);
+
+/**
  * Find an object in the scope of a stack frame.
  *
  * @param[in] name Object name.

--- a/libdrgn/dwarf_info.h
+++ b/libdrgn/dwarf_info.h
@@ -232,6 +232,19 @@ struct drgn_error *drgn_find_die_ancestors(Dwarf_Die *die, Dwarf_Die **dies_ret,
 	__attribute__((__nonnull__(2, 3)));
 
 /**
+ * Get an array of names of `DW_TAG_variable` and `DW_TAG_formal_parameter` DIEs
+ * in local scopes.
+ *
+ * @param[out] names_ret Returned array of names. On success, must be freed with
+ * @c free(). The individual strings should not be freed.
+ * @param[out] count_ret Returned number of names in @p names_ret.
+ */
+struct drgn_error *drgn_dwarf_scopes_names(Dwarf_Die *scopes,
+					   size_t num_scopes,
+					   const char ***names_ret,
+					   size_t *count_ret);
+
+/**
  * Find an object DIE in an array of DWARF scopes.
  *
  * @param[in] scopes Array of scopes, from outermost to innermost.

--- a/libdrgn/stack_trace.c
+++ b/libdrgn/stack_trace.c
@@ -378,6 +378,27 @@ drgn_stack_frame_symbol(struct drgn_stack_trace *trace, size_t frame,
 }
 
 LIBDRGN_PUBLIC struct drgn_error *
+drgn_stack_frame_locals(struct drgn_stack_trace *trace, size_t frame_i,
+			const char ***names_ret, size_t *count_ret)
+{
+	struct drgn_stack_frame *frame = &trace->frames[frame_i];
+	if (frame->function_scope >= frame->num_scopes) {
+		*names_ret = NULL;
+		*count_ret = 0;
+		return NULL;
+	}
+	return drgn_dwarf_scopes_names(frame->scopes + frame->function_scope,
+				       frame->num_scopes - frame->function_scope,
+				       names_ret, count_ret);
+}
+
+LIBDRGN_PUBLIC
+void drgn_stack_frame_locals_destroy(const char **names, size_t count)
+{
+	free(names);
+}
+
+LIBDRGN_PUBLIC struct drgn_error *
 drgn_stack_frame_find_object(struct drgn_stack_trace *trace, size_t frame_i,
 			     const char *name, struct drgn_object *ret)
 {


### PR DESCRIPTION
I know you mentioned in #134 that listing variables in a stack frame would be something that is made part of the Scopes API (#123). That makes sense, but given that the Scopes API may be a long time coming, and it will need to cover a lot of complexity, I wanted to share this small implementation of this idea. No expectations here (even of review, let alone merging :smile: ). I'm starting to play around with debugger code built on top of this, so I'm personally finding it useful.