### PR TITLE
Llist helpers v2

### DIFF
--- a/drgn/helpers/linux/llist.py
+++ b/drgn/helpers/linux/llist.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Lockless Lists
+------------
+
+The ``drgn.helpers.linux.llist`` module provides helpers for working with the
+lockless, ``NULL``-terminated, singly-linked list implementation in
+:linux:`include/linux/llist.h` (``struct llist_head`` and ``struct
+llist_node``).
+"""
+
+from typing import Iterator, Union
+
+from drgn import NULL, Object, Type, container_of
+
+__all__ = (
+    "llist_empty",
+    "llist_first_entry",
+    "llist_first_entry_or_null",
+    "llist_for_each",
+    "llist_for_each_entry",
+    "llist_is_singular",
+    "llist_next_entry",
+)
+
+
+def llist_empty(head: Object) -> bool:
+    """
+    Return whether an llist is empty.
+
+    :param head: ``struct llist_head *``
+    """
+    return not head.first
+
+
+def llist_is_singular(head: Object) -> bool:
+    """
+    Return whether an llist has only one element.
+
+    :param head: ``struct llist_head *``
+    """
+    first = head.first.read_()
+    return bool(first) and not first.next
+
+
+def llist_first_entry(head: Object, type: Union[str, Type], member: str) -> Object:
+    """
+    Return the first entry in an llist.
+
+    The list is assumed to be non-empty.
+
+    See also :func:`llist_first_entry_or_null()`.
+
+    :param head: ``struct llist_head *``
+    :param type: Entry type.
+    :param member: Name of ``struct llist_node`` member in entry type.
+    :return: ``type *``
+    """
+    return container_of(head.first, type, member)
+
+
+def llist_first_entry_or_null(
+    head: Object, type: Union[str, Type], member: str
+) -> Object:
+    """
+    Return the first entry in an llist or ``NULL`` if the llist is empty.
+
+    See also :func:`llist_first_entry()`.
+
+    :param head: ``struct llist_head *``
+    :param type: Entry type.
+    :param member: Name of ``struct llist_node`` member in entry type.
+    :return: ``type *``
+    """
+    first = head.first.read_()
+    if first:
+        return container_of(first, type, member)
+    else:
+        return NULL(head.prog_, head.prog_.pointer_type(head.prog_.type(type)))
+
+
+def llist_next_entry(pos: Object, member: str) -> Object:
+    """
+    Return the next entry in an llist.
+
+    :param pos: ``type*``
+    :param member: Name of ``struct llist_node`` member in entry type.
+    :return: ``type *``
+    """
+    return container_of(getattr(pos, member).next, pos.type_.type, member)
+
+
+def llist_for_each(node: Object) -> Iterator[Object]:
+    """
+    Iterate over all of the nodes in an llist starting from a given node.
+
+    :param node: ``struct llist_node *``
+    :return: Iterator of ``struct llist_node *`` objects.
+    """
+    pos = node.read_()
+    while pos:
+        yield pos
+        pos = pos.next.read_()
+
+
+def llist_for_each_entry(
+    type: Union[str, Type], node: Object, member: str
+) -> Iterator[Object]:
+    """
+    Iterate over all of the entries in an llist starting from a given node.
+
+    :param type: Entry type.
+    :param node: ``struct llist_node *``
+    :param member: Name of ``struct llist_node`` member in entry type.
+    :return: Iterator of ``type *`` objects.
+    """
+    type = node.prog_.type(type)
+    for pos in llist_for_each(node):
+        yield container_of(pos, type, member)

--- a/tests/linux_kernel/helpers/test_llist.py
+++ b/tests/linux_kernel/helpers/test_llist.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from drgn import NULL
+from drgn.helpers.linux.llist import (
+    llist_empty,
+    llist_first_entry,
+    llist_first_entry_or_null,
+    llist_for_each,
+    llist_for_each_entry,
+    llist_is_singular,
+    llist_next_entry,
+)
+from tests.linux_kernel import LinuxKernelTestCase, skip_unless_have_test_kmod
+
+
+@skip_unless_have_test_kmod
+class TestLlist(LinuxKernelTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.empty = cls.prog["drgn_test_empty_llist"].address_of_()
+        cls.full = cls.prog["drgn_test_full_llist"].address_of_()
+        cls.entries = cls.prog["drgn_test_llist_entries"]
+        cls.num_entries = 3
+        cls.singular = cls.prog["drgn_test_singular_llist"].address_of_()
+        cls.singular_entry = cls.prog["drgn_test_singular_llist_entry"].address_of_()
+        cls.singular_node = cls.singular_entry.node.address_of_()
+
+    def node(self, n):
+        return self.entries[n].node.address_of_()
+
+    def entry(self, n):
+        return self.entries[n].address_of_()
+
+    def test_llist_empty(self):
+        self.assertTrue(llist_empty(self.empty))
+        self.assertFalse(llist_empty(self.full))
+        self.assertFalse(llist_empty(self.singular))
+
+    def test_llist_is_singular(self):
+        self.assertFalse(llist_is_singular(self.empty))
+        self.assertFalse(llist_is_singular(self.full))
+        self.assertTrue(llist_is_singular(self.singular))
+
+    def test_llist_first_entry(self):
+        self.assertEqual(
+            llist_first_entry(self.full, "struct drgn_test_llist_entry", "node"),
+            self.entry(2),
+        )
+        self.assertEqual(
+            llist_first_entry(self.singular, "struct drgn_test_llist_entry", "node"),
+            self.singular_entry,
+        )
+
+    def test_llist_first_entry_or_null(self):
+        self.assertEqual(
+            llist_first_entry_or_null(
+                self.empty, "struct drgn_test_llist_entry", "node"
+            ),
+            NULL(self.prog, "struct drgn_test_llist_entry *"),
+        )
+        self.assertEqual(
+            llist_first_entry_or_null(
+                self.full, "struct drgn_test_llist_entry", "node"
+            ),
+            self.entry(2),
+        )
+        self.assertEqual(
+            llist_first_entry_or_null(
+                self.singular, "struct drgn_test_llist_entry", "node"
+            ),
+            self.singular_entry,
+        )
+
+    def test_llist_next_entry(self):
+        for i in reversed(range(1, self.num_entries)):
+            self.assertEqual(llist_next_entry(self.entry(i), "node"), self.entry(i - 1))
+
+    def test_llist_for_each(self):
+        self.assertEqual(list(llist_for_each(self.empty.first)), [])
+        self.assertEqual(
+            list(llist_for_each(self.full.first)),
+            [self.node(i) for i in reversed(range(self.num_entries))],
+        )
+        self.assertEqual(
+            list(llist_for_each(self.singular.first)), [self.singular_node]
+        )
+
+    def test_llist_for_each_entry(self):
+        self.assertEqual(
+            list(
+                llist_for_each_entry(
+                    "struct drgn_test_llist_entry", self.empty.first, "node"
+                )
+            ),
+            [],
+        )
+        self.assertEqual(
+            list(
+                llist_for_each_entry(
+                    "struct drgn_test_llist_entry", self.full.first, "node"
+                )
+            ),
+            [self.entry(i) for i in reversed(range(self.num_entries))],
+        )
+        self.assertEqual(
+            list(
+                llist_for_each_entry(
+                    "struct drgn_test_llist_entry", self.singular.first, "node"
+                )
+            ),
+            [self.singular_entry],
+        )

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -11,6 +11,7 @@
 #include <linux/io.h>
 #include <linux/kernel.h>
 #include <linux/list.h>
+#include <linux/llist.h>
 #include <linux/mm.h>
 #include <linux/module.h>
 #include <linux/rbtree.h>
@@ -83,6 +84,32 @@ static void drgn_test_list_init(void)
 	}
 
 	init_corrupted_list();
+}
+
+// llist
+
+LLIST_HEAD(drgn_test_empty_llist);
+LLIST_HEAD(drgn_test_full_llist);
+LLIST_HEAD(drgn_test_singular_llist);
+
+struct drgn_test_llist_entry {
+	struct llist_node node;
+	int value;
+};
+
+struct drgn_test_llist_entry drgn_test_llist_entries[3];
+struct drgn_test_llist_entry drgn_test_singular_llist_entry;
+
+static void drgn_test_llist_init(void)
+{
+	size_t i;
+
+	for (i = 0; i < ARRAY_SIZE(drgn_test_llist_entries); i++) {
+		llist_add(&drgn_test_llist_entries[i].node,
+			      &drgn_test_full_llist);
+	}
+
+	llist_add(&drgn_test_singular_llist_entry.node, &drgn_test_singular_llist);
 }
 
 // mm
@@ -305,6 +332,7 @@ static int __init drgn_test_init(void)
 	int ret;
 
 	drgn_test_list_init();
+	drgn_test_llist_init();
 	ret = drgn_test_mm_init();
 	if (ret)
 		goto out;


### PR DESCRIPTION
There was one merging mistake in PR: https://github.com/osandov/drgn/pull/194. This is new version of same PR with review comments addressed.
It has been tested with test cases added as part of this PR:
`test_llist_empty (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
test_llist_first_entry (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
test_llist_first_entry_or_null (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
test_llist_for_each (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
test_llist_for_each_entry (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
test_llist_is_singular (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
test_llist_next_entry (tests.linux_kernel.helpers.test_llist.TestLlist) ... ok
`
