### PR TITLE
Add name to drgn.Thread

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -847,6 +847,19 @@ class FindObjectFlags(enum.Flag):
 class Thread:
     """A thread in a program."""
 
+    name: Optional[str]
+    """
+    Thread name, or ``None`` if unknown.
+
+    See `PR_SET_NAME
+    <https://man7.org/linux/man-pages/man2/prctl.2.html#:~:text=PR_SET_NAME>`_
+    and `/proc/[pid]/comm
+    <https://man7.org/linux/man-pages/man5/proc.5.html#:~:text=%2Fproc%2F%5Bpid%5D%2Fcomm>`_.
+
+    .. note::
+        Linux userspace core dumps only save the name of the main thread, so
+        :attr:`name` will be ``None`` for other threads.
+    """
     tid: int
     """
     Thread ID (as defined by `gettid(2)

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -46,6 +46,7 @@ struct drgn_symbol;
 
 struct drgn_thread {
 	struct drgn_program *prog;
+	char name[64];
 	uint32_t tid;
 	struct nstring prstatus;
 	struct drgn_object object;


### PR DESCRIPTION
This PR aims to resolve #143 

First off, my apologies for the delay. Had to step away for a bit and didn't have access to my personal laptop.

This is also my first time working in a project that interfaces Python with C, exciting stuff! I wrote some stuff to try out fetching the name of the thread for userspace programs. I think it should work, or outright crash if there are some errors while opening the file or using string functions but instead I get this:
![image](https://user-images.githubusercontent.com/105760760/183782521-47fd5388-14c8-4edf-9d2e-01aed7f3c526.png)

The other functions and attributes of threads check out for a userspace program (stack unwinding not being available, `thread.object` not available outside the kernel) but  I don't get why `name` isn't recognized as a valid attribute after i added it to the interface. This may actually be a naive question but I am quite confused by this.

Learning a lot through this project though! 

@osandov 