### PR TITLE
libdrgn: Zero fill excluded pages in kernel core dumps rather than FaultError

### DIFF
--- a/libdrgn/memory_reader.h
+++ b/libdrgn/memory_reader.h
@@ -100,7 +100,8 @@ struct drgn_memory_file_segment {
 	 * Size of the segment in the file. This may be less than the size of
 	 * the segment in memory, which means that the remaining bytes were in
 	 * the program's memory but were not saved in the core dump. Attempting
-	 * to read these bytes is treated as a fault.
+	 * to read these bytes will be zero filled or a fault depending on
+	 * zerofill below.
 	 */
 	uint64_t file_size;
 	/** File descriptor. */
@@ -110,6 +111,11 @@ struct drgn_memory_file_segment {
 	 * OS error.
 	 */
 	bool eio_is_fault;
+	/**
+	 * If @c true, attempts to read between file_size and memory_size
+	 * will be zero filled, otherwise it is treated as a memory fault.
+	 */
+	bool zerofill;
 };
 
 /** @ref drgn_memory_read_fn which reads from a file. */


### PR DESCRIPTION
makecoredump will exclude zero pages. We found a core file where a
structure straddled a page boundary and the end of the structure
was all zeros so the page was excluded and we were generating a
FaultError trying to access the structure.

This change reverts a portion of that behaviour such that when we are
debugging a kernel core we go back to the zero fill behaviour. To do this
we go back to creating segments based on memsz instead of filesz and
handling the filesz->memsz gap in drgn_read_memory_file.

Fixes: 02912ca7d073 ("libdrgn: fix handling of p_filesz < p_memsz in core dumps")
Signed-off-by: Glen McCready <gkm@mysteryinc.ca>