### PR TITLE
packit: disable rpmautospec

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,8 +10,8 @@ upstream_package_name: drgn
 downstream_package_name: python-drgn
 actions:
   get-current-version: "python3 setup.py --version"
-  # Fetch the specfile from Rawhide and drop any patches
-  post-upstream-clone: "bash -c \"curl -s https://src.fedoraproject.org/rpms/python-drgn/raw/main/f/python-drgn.spec | sed '/^Patch[0-9]/d' > python-drgn.spec\""
+  # Fetch the specfile from Rawhide, drop any patches and disable rpmautospec
+  post-upstream-clone: "bash -c \"curl -s https://src.fedoraproject.org/rpms/python-drgn/raw/main/f/python-drgn.spec | sed -e '/^Patch[0-9]/d' -e '/^%autochangelog$/d' > python-drgn.spec\""
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
Something changed recently in PackIt and it no longer generates a
changelog if the rpmautospec macro is present. This ends up breaking
EPEL 8 builds, which apparently don't support rpmautospec properly yet
(see https://pagure.io/fedora-infra/rpmautospec/issue/204).

Signed-off-by: Davide Cavalca <dcavalca@fb.com>