### PR TITLE
Fix drgn_test_va KeyError when running test_find_cotaining_slab_cache_invalid()

### DIFF
--- a/tests/linux_kernel/helpers/test_slab.py
+++ b/tests/linux_kernel/helpers/test_slab.py
@@ -147,6 +147,8 @@ class TestSlab(LinuxKernelTestCase):
                 )
                 self.assertEqual(find_containing_slab_cache(obj), cache)
 
+    @skip_unless_have_full_mm_support
+    @skip_unless_have_test_kmod
     def test_find_containing_slab_cache_invalid(self):
         start_addr = pfn_to_virt(self.prog["min_low_pfn"])
         end_addr = pfn_to_virt(self.prog["max_pfn"]) + self.prog["PAGE_SIZE"]


### PR DESCRIPTION
Hi all,

Running `test_find_containing_slab_cache_invalid()` without the `drgn_test` Linux kernel module gives a `KeyError`:

```
  Traceback (most recent call last):
    File ".../tests/linux_kernel/helpers/test_slab.py", line 169, in test_find_containing_slab_cache_invalid
      find_containing_slab_cache(self.prog, self.prog["drgn_test_va"]),
  KeyError: 'drgn_test_va'
```

Use the `@skip_unless_have_test_kmod` tag.  Fixes: 79ea6589c28c ("drgn.helpers.linux.slab: add find_containing_slab_cache helper")

Thanks,
Peilin Ye
