### PR TITLE
Fix find_containing_slab_cache's behavior when the page does not exist

### DIFF
--- a/drgn/helpers/linux/slab.py
+++ b/drgn/helpers/linux/slab.py
@@ -300,12 +300,12 @@ def find_containing_slab_cache(  # type: ignore  # Need positional-only argument
     page = virt_to_page(prog, addr)
 
     try:
-        PG_slab_mask = 1 << prog.constant("PG_slab")
+        page_flags = page.flags
     except FaultError:
         # Page does not exist
         return NULL(prog, "struct kmem_cache *")
 
-    if not page.flags & PG_slab_mask:
+    if not page_flags & (1 << prog.constant("PG_slab")):
         # Not a slab page
         return NULL(prog, "struct kmem_cache *")
 


### PR DESCRIPTION
`find_containing_slab_cache` is supposed to returns NULL when encountered a page which does not exist. This is detected when accessing page flags gives us a fault error. However, this is not checked correctly in the current implementation. This commit fixes this issue.