### PR TITLE
Correctly interpret template parameters in the C++ lexer

### DIFF
--- a/tests/libdrgn.py
+++ b/tests/libdrgn.py
@@ -192,6 +192,7 @@ class C_TOKEN(enum.IntEnum):
     DOT = auto()
     NUMBER = auto()
     IDENTIFIER = auto()
+    TEMPLATE_ARGUMENTS = auto()
 
 
 class Token:


### PR DESCRIPTION
Previously, attempting to lookup a type with template parameters via `prog.type()` would result in an "invalid character" error message. This has been remedied by properly handling template parameters in the C++ lexer, enabling type lookups as desired.

Signed-off-by: Kevin Svetlitski <svetlitski@meta.com>