### PR TITLE
packit: temporarily work around examples directory

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,8 +10,10 @@ upstream_package_name: drgn
 downstream_package_name: python-drgn
 actions:
   get-current-version: "python3 setup.py --version"
-  # Fetch the specfile from Rawhide, drop any patches and disable rpmautospec
-  post-upstream-clone: "bash -c \"curl -s https://src.fedoraproject.org/rpms/python-drgn/raw/main/f/python-drgn.spec | sed -e '/^Patch[0-9]/d' -e '/^%autochangelog$/d' > python-drgn.spec\""
+  # Fetch the specfile from Rawhide, drop any patches, disable rpmautospec, and
+  # copy the contrib directory instead of the (now non-existent) examples
+  # directory until the next release.
+  post-upstream-clone: "bash -c \"curl -s https://src.fedoraproject.org/rpms/python-drgn/raw/main/f/python-drgn.spec | sed -e '/^Patch[0-9]/d' -e '/^%autochangelog$/d' -e 's/cp -PR examples /cp -PR contrib /'> python-drgn.spec\""
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
Packit is failing because the examples directory doesn't exist since commit a0a54edc1f1d ("Create contrib directory"). Let's work around it in our post-upstream-clone step until we cut the next release and update the RPM spec.

Signed-off-by: Omar Sandoval <osandov@osandov.com>