### PR TITLE
libdrgn: Ensure booleans are treated as primitives in C++

### DIFF
--- a/libdrgn/build-aux/gen_c_keywords_inc_strswitch.py
+++ b/libdrgn/build-aux/gen_c_keywords_inc_strswitch.py
@@ -6,6 +6,7 @@ C_KEYWORDS = (
     "_Atomic",
     "_Bool",
     "_Complex",
+    "bool",
     "char",
     "class",
     "const",
@@ -41,7 +42,7 @@ def main() -> None:
     print("\t@memswitch (s, len)@")
     for token_kind, keyword in keywords:
         print(f'\t@case "{keyword}"@')
-        if keyword == "class":
+        if keyword == "class" or keyword == "bool":
             print(f"\t\treturn cpp ? {token_kind} : C_TOKEN_IDENTIFIER;")
         else:
             print(f"\t\treturn {token_kind};")

--- a/libdrgn/language_c.c
+++ b/libdrgn/language_c.c
@@ -2058,7 +2058,8 @@ static const enum drgn_primitive_type specifier_kind[NUM_SPECIFIER_STATES] = {
 	[SPECIFIER_LONG_DOUBLE] = DRGN_C_TYPE_LONG_DOUBLE,
 };
 
-enum drgn_primitive_type c_parse_specifier_list(const char *s)
+enum drgn_primitive_type
+c_family_parse_specifier_list(const struct drgn_language *lang, const char *s)
 {
 	struct drgn_error *err;
 	struct drgn_c_family_lexer c_family_lexer;
@@ -2066,7 +2067,7 @@ enum drgn_primitive_type c_parse_specifier_list(const char *s)
 	enum c_type_specifier specifier = SPECIFIER_NONE;
 	enum drgn_primitive_type primitive = DRGN_NOT_PRIMITIVE_TYPE;
 
-	c_family_lexer.cpp = false;
+	c_family_lexer.cpp = lang == &drgn_language_cpp;
 	drgn_lexer_init(lexer, drgn_c_family_lexer_func, s);
 
 	for (;;) {

--- a/libdrgn/type.c
+++ b/libdrgn/type.c
@@ -97,7 +97,7 @@ drgn_primitive_type_spellings[DRGN_PRIMITIVE_TYPE_NUM] = {
 		"int unsigned long long", "int long unsigned long",
 		"int long long unsigned", NULL,
 	},
-	[DRGN_C_TYPE_BOOL] = (const char * []){ "_Bool", NULL, },
+	[DRGN_C_TYPE_BOOL] = (const char * []){ "_Bool", "bool", NULL, },
 	[DRGN_C_TYPE_FLOAT] = (const char * []){ "float", NULL, },
 	[DRGN_C_TYPE_DOUBLE] = (const char * []){ "double", NULL, },
 	[DRGN_C_TYPE_LONG_DOUBLE] = (const char * []){
@@ -397,7 +397,8 @@ struct drgn_error *drgn_int_type_create(struct drgn_program *prog,
 {
 	struct drgn_error *err;
 
-	enum drgn_primitive_type primitive = c_parse_specifier_list(name);
+	enum drgn_primitive_type primitive =
+		c_family_parse_specifier_list(lang, name);
 	if (drgn_primitive_type_kind[primitive] == DRGN_TYPE_INT &&
 	    (primitive == DRGN_C_TYPE_CHAR ||
 	     is_signed == drgn_primitive_type_is_signed(primitive)))
@@ -432,9 +433,11 @@ struct drgn_error *drgn_bool_type_create(struct drgn_program *prog,
 {
 	struct drgn_error *err;
 
-	enum drgn_primitive_type primitive = c_parse_specifier_list(name);
+	enum drgn_primitive_type primitive =
+		c_family_parse_specifier_list(lang, name);
 	if (primitive == DRGN_C_TYPE_BOOL)
-		name = drgn_primitive_type_spellings[DRGN_C_TYPE_BOOL][0];
+		name = drgn_primitive_type_spellings[DRGN_C_TYPE_BOOL]
+						    [lang == &drgn_language_cpp];
 	else
 		primitive = DRGN_NOT_PRIMITIVE_TYPE;
 
@@ -464,7 +467,8 @@ struct drgn_error *drgn_float_type_create(struct drgn_program *prog,
 {
 	struct drgn_error *err;
 
-	enum drgn_primitive_type primitive = c_parse_specifier_list(name);
+	enum drgn_primitive_type primitive =
+		c_family_parse_specifier_list(lang, name);
 	if (drgn_primitive_type_kind[primitive] == DRGN_TYPE_FLOAT)
 		name = drgn_primitive_type_spellings[primitive][0];
 	else

--- a/libdrgn/type.h
+++ b/libdrgn/type.h
@@ -477,7 +477,8 @@ extern const char * const drgn_type_kind_spelling[];
  * @return The type, or @ref DRGN_NOT_PRIMITIVE_TYPE if @p s is not the name of
  * a primitive C type.
  */
-enum drgn_primitive_type c_parse_specifier_list(const char *s);
+enum drgn_primitive_type
+c_family_parse_specifier_list(const struct drgn_language *lang, const char *s);
 
 /**
  * Get the type of a @ref drgn_type with all typedefs removed.

--- a/scripts/generate_primitive_type_spellings.py
+++ b/scripts/generate_primitive_type_spellings.py
@@ -24,7 +24,7 @@ SPELLINGS = [
         "DRGN_C_TYPE_UNSIGNED_LONG_LONG",
         ["unsigned long long", "unsigned long long int"],
     ),
-    ("DRGN_C_TYPE_BOOL", ["_Bool"]),
+    ("DRGN_C_TYPE_BOOL", ["_Bool", "bool"]),
     ("DRGN_C_TYPE_FLOAT", ["float"]),
     ("DRGN_C_TYPE_DOUBLE", ["double"]),
     ("DRGN_C_TYPE_LONG_DOUBLE", ["long double"]),

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -65,19 +65,23 @@ class TestType(MockProgramTestCase):
         self.assertRaises(ValueError, self.prog.int_type, "int", 4, True, "middle")
 
     def test_bool(self):
-        t = self.prog.bool_type("_Bool", 1)
-        self.assertEqual(t.kind, TypeKind.BOOL)
-        self.assertEqual(t.primitive, PrimitiveType.C_BOOL)
-        self.assertEqual(t.language, DEFAULT_LANGUAGE)
-        self.assertEqual(t.name, "_Bool")
-        self.assertEqual(t.size, 1)
-        self.assertEqual(t.byteorder, "little")
-        self.assertTrue(t.is_complete())
+        for language, name in ((Language.C, "_Bool"), (Language.CPP, "bool")):
+            t = self.prog.bool_type(name, 1, language=language)
+            self.assertEqual(t.kind, TypeKind.BOOL)
+            self.assertEqual(t.primitive, PrimitiveType.C_BOOL)
+            self.assertEqual(t.language, language)
+            self.assertEqual(t.name, name)
+            self.assertEqual(t.size, 1)
+            self.assertEqual(t.byteorder, "little")
+            self.assertTrue(t.is_complete())
 
-        self.assertEqual(repr(t), "prog.bool_type(name='_Bool', size=1)")
-        self.assertEqual(sizeof(t), 1)
+            self.assertEqual(
+                repr(t),
+                f"prog.bool_type(name='{name}', size=1{', language=Language.CPP' if language is Language.CPP else ''})",
+            )
+            self.assertEqual(sizeof(t), 1)
 
-        self.assertRaises(TypeError, self.prog.bool_type, None, 1)
+            self.assertRaises(TypeError, self.prog.bool_type, None, 1)
 
     def test_bool_byteorder(self):
         self.assertIdentical(


### PR DESCRIPTION
Booleans in C++ programs were not registering as primitives (i.e. `.primitive` was `None` on a boolean type). This has been remedied by treating `bool` as a keyword in C++, in much the same fashion that #158 added support for classes in C++.

Signed-off-by: Kevin Svetlitski <svetlitski@meta.com>