### PR TITLE
drgn.helpers.linux.mm: Incorporate the use of pfn_mapped[] in for_each_page()

### DIFF
--- a/drgn/helpers/linux/mm.py
+++ b/drgn/helpers/linux/mm.py
@@ -690,13 +690,17 @@ def decode_page_flags(page: Object) -> str:
 
 def for_each_page(prog: Program) -> Iterator[Object]:
     """
-    Iterate over all pages in the system.
+    Iterate over all present/or mapped kernel pages.
 
     :return: Iterator of ``struct page *`` objects.
     """
     vmemmap = prog["vmemmap"]
-    for i in range(prog["min_low_pfn"], prog["max_pfn"]):
-        yield vmemmap + i
+    pfn_mapped = prog["pfn_mapped"]
+    nr_pfn_mapped = prog["nr_pfn_mapped"]
+    for i in range(nr_pfn_mapped.value_()):
+        page = vmemmap + pfn_mapped[i].start.value_()
+        for j in range(pfn_mapped[i].start.value_(), pfn_mapped[i].end.value_() - pfn_mapped[i].start.value_()):
+            yield page + j
 
 
 @overload


### PR DESCRIPTION
Modify the for_each_page() helper to consider both pfn_mapped[] and nr_pfn_mapped respectively. Therefore only valid kernel mapped pages are returned.

Signed-off-by: Aaron Tomlin <atomlin@atomlin.com>