### PR TITLE
Non radix tree idr support rc1

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -2359,16 +2359,7 @@ def _linux_helper_task_cpu(task: Object) -> int:
     """
     ...
 
-def _linux_helper_idr_find(idr: Object, id: IntegerLike) -> Object:
-    """
-    Look up the entry with the given ID in an IDR.
-
-    :param idr: ``struct idr *``
-    :param id: Entry ID.
-    :return: ``void *`` found entry, or ``NULL`` if not found.
-    """
-    ...
-
+def _linux_helper_idr_find(idr: Object, id: IntegerLike) -> Object: ...
 def _linux_helper_find_pid(
     prog_or_ns: Union[Program, Object], pid: IntegerLike
 ) -> Object:

--- a/drgn/helpers/linux/idr.py
+++ b/drgn/helpers/linux/idr.py
@@ -7,20 +7,61 @@ IDR
 
 The ``drgn.helpers.linux.idr`` module provides helpers for working with the IDR
 data structure in :linux:`include/linux/idr.h`. An IDR provides a mapping from
-an ID to a pointer. This currently only supports Linux v4.11+; before this,
-IDRs were not based on radix trees.
+an ID to a pointer.
 """
 
+import operator
 from typing import Iterator, Tuple
 
-from _drgn import _linux_helper_idr_find as idr_find
-from drgn import Object
+from _drgn import _linux_helper_idr_find
+from drgn import NULL, IntegerLike, Object, cast, sizeof
 from drgn.helpers.linux.radixtree import radix_tree_for_each
 
 __all__ = (
     "idr_find",
     "idr_for_each",
 )
+
+_IDR_BITS = 8
+_IDR_MASK = (1 << _IDR_BITS) - 1
+
+
+def idr_find(idr: Object, id: IntegerLike) -> Object:
+    """
+    Look up the entry with the given ID in an IDR.
+
+    :param idr: ``struct idr *``
+    :param id: Entry ID.
+    :return: ``void *`` found entry, or ``NULL`` if not found.
+    """
+    # Since Linux kernel commit 0a835c4f090a ("Reimplement IDR and IDA using
+    # the radix tree") (in v4.11), IDRs are backed by radix trees. Before that,
+    # they are a separate data structure. The helper in libdrgn only handles
+    # the radix tree version.
+    if hasattr(idr, "idr_rt"):
+        return _linux_helper_idr_find(idr, id)
+    else:
+        prog = idr.prog_
+        id = operator.index(id)
+
+        if id < 0:
+            return NULL(prog, "void *")
+
+        p = idr.top.read_()
+        if not p:
+            return NULL(prog, "void *")
+
+        n = (p.layer.value_() + 1) * _IDR_BITS
+        MAX_IDR_SHIFT = sizeof(prog.type("int")) * 8 - 1
+        # Equivalent to id > idr_max(p->layer + 1) in the kernel.
+        if id >= (1 << min(n, MAX_IDR_SHIFT)):
+            return NULL(prog, "void *")
+
+        while n > 0 and p:
+            n -= _IDR_BITS
+            p = p.ary[(id >> n) & _IDR_MASK].read_()
+
+        return cast("void *", p)
 
 
 def idr_for_each(idr: Object) -> Iterator[Tuple[int, Object]]:
@@ -30,9 +71,29 @@ def idr_for_each(idr: Object) -> Iterator[Tuple[int, Object]]:
     :param idr: ``struct idr *``
     :return: Iterator of (index, ``void *``) tuples.
     """
+    # Since Linux kernel commit 0a835c4f090a ("Reimplement IDR and IDA using
+    # the radix tree") (in v4.11), IDRs are backed by radix trees.
     try:
-        base = idr.idr_base.value_()
+        idr_rt = idr.idr_rt
     except AttributeError:
-        base = 0
-    for index, entry in radix_tree_for_each(idr.idr_rt.address_of_()):
-        yield index + base, entry
+        voidp_type = idr.prog_.type("void *")
+
+        def aux(p: Object, id: int, n: int) -> Iterator[Tuple[int, Object]]:
+            p = p.read_()
+            if p:
+                if n == 0:
+                    yield id, cast(voidp_type, p)
+                else:
+                    n -= _IDR_BITS
+                    for child in p.ary:
+                        yield from aux(child, id, n)
+                        id += 1 << n
+
+        yield from aux(idr.top, 0, idr.layers.value_() * _IDR_BITS)
+    else:
+        try:
+            base = idr.idr_base.value_()
+        except AttributeError:
+            base = 0
+        for index, entry in radix_tree_for_each(idr_rt.address_of_()):
+            yield index + base, entry

--- a/libdrgn/linux_kernel_helpers.c
+++ b/libdrgn/linux_kernel_helpers.c
@@ -526,6 +526,11 @@ null:
 #undef is_node
 }
 
+// Note that this only works since Linux kernel commit 0a835c4f090a
+// ("Reimplement IDR and IDA using the radix tree") (in v4.11). We only need
+// this since Linux kernel commit 95846ecf9dac ("pid: replace pid bitmap
+// implementation with IDR API") (in v4.15) (see find_pid_in_pid_hash()), so
+// that's okay.
 struct drgn_error *linux_helper_idr_find(struct drgn_object *res,
 					 const struct drgn_object *idr,
 					 uint64_t id)

--- a/tests/linux_kernel/helpers/test_idr.py
+++ b/tests/linux_kernel/helpers/test_idr.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from drgn import NULL, Object
+from drgn.helpers.linux.idr import idr_find, idr_for_each
+from tests.linux_kernel import LinuxKernelTestCase, skip_unless_have_test_kmod
+
+
+@skip_unless_have_test_kmod
+class TestIDR(LinuxKernelTestCase):
+    def test_idr_find_empty(self):
+        root = self.prog["drgn_test_idr_empty"].address_of_()
+        self.assertIdentical(idr_find(root, 0), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 100), NULL(self.prog, "void *"))
+
+    def test_idr_for_each_empty(self):
+        root = self.prog["drgn_test_idr_empty"].address_of_()
+        self.assertIdentical(list(idr_for_each(root)), [])
+
+    def test_idr_find_one(self):
+        root = self.prog["drgn_test_idr_one"].address_of_()
+        self.assertIdentical(idr_find(root, 0), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 65), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 66), Object(self.prog, "void *", 0xDEADB00))
+        self.assertIdentical(idr_find(root, 67), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 100), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 256 + 66), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 2**24 + 66), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 2**56 + 66), NULL(self.prog, "void *"))
+
+    def test_idr_for_each_one(self):
+        root = self.prog["drgn_test_idr_one"].address_of_()
+        self.assertIdentical(
+            list(idr_for_each(root)),
+            [(66, Object(self.prog, "void *", 0xDEADB00))],
+        )
+
+    def test_idr_lookup_one_at_zero(self):
+        root = self.prog["drgn_test_idr_one_at_zero"].address_of_()
+        self.assertIdentical(idr_find(root, 0), Object(self.prog, "void *", 0x1234))
+        self.assertIdentical(idr_find(root, 1), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 100), NULL(self.prog, "void *"))
+
+    def test_idr_for_each_one_at_zero(self):
+        root = self.prog["drgn_test_idr_one_at_zero"].address_of_()
+        self.assertIdentical(
+            list(idr_for_each(root)), [(0, Object(self.prog, "void *", 0x1234))]
+        )
+
+    def test_idr_find_sparse(self):
+        root = self.prog["drgn_test_idr_sparse"].address_of_()
+        self.assertIdentical(idr_find(root, 0), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 1), Object(self.prog, "void *", 0x1234))
+        self.assertIdentical(idr_find(root, 2), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 0x40), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 0x70), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 0x7F), NULL(self.prog, "void *"))
+        self.assertIdentical(idr_find(root, 0x80), Object(self.prog, "void *", 0x5678))
+        self.assertIdentical(idr_find(root, 0xEE), Object(self.prog, "void *", 0x9ABC))
+        self.assertIdentical(idr_find(root, 0xEF), NULL(self.prog, "void *"))
+
+    def test_idr_for_each_sparse(self):
+        root = self.prog["drgn_test_idr_sparse"].address_of_()
+        self.assertIdentical(
+            list(idr_for_each(root)),
+            [
+                (1, Object(self.prog, "void *", 0x1234)),
+                (0x80, Object(self.prog, "void *", 0x5678)),
+                (0xEE, Object(self.prog, "void *", 0x9ABC)),
+            ],
+        )


### PR DESCRIPTION
This changeset adds support for non-radix tree based idrs in drgn, so that drgn idr helpers can be used with kernels prior tha v4.11.
I have also added idr test cases separately. So far idr test cases were covered by radix tree test cases (since idr helpers were available only for radix-tree base idrs.