### PR TITLE
Fix example for add_memory_segment

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -63,7 +63,7 @@ program "memory":
         file = open(dev, 'rb')
         size = file.seek(0, 2)
 
-        def read_file(address, count, physical, offset):
+        def read_file(address, count, offset, physical):
             file.seek(offset)
             return file.read(count)
 


### PR DESCRIPTION
The parameters of the read_file function in the example are swapped. This matches the parameters order used by py_memory_read_fn.