### PR TITLE
libdrgn: add s390x pagetable walk support

### DIFF
--- a/drgn/helpers/linux/mm.py
+++ b/drgn/helpers/linux/mm.py
@@ -6,8 +6,8 @@ Memory Management
 -----------------
 
 The ``drgn.helpers.linux.mm`` module provides helpers for working with the
-Linux memory management (MM) subsystem. Only AArch64 and x86-64 are currently
-supported.
+Linux memory management (MM) subsystem. Only AArch64, s390x and x86-64 are
+currently supported.
 """
 
 import operator

--- a/drgn/helpers/linux/mm.py
+++ b/drgn/helpers/linux/mm.py
@@ -6,7 +6,7 @@ Memory Management
 -----------------
 
 The ``drgn.helpers.linux.mm`` module provides helpers for working with the
-Linux memory management (MM) subsystem. Only AArch64, s390x and x86-64 are
+Linux memory management (MM) subsystem. Only AArch64, s390x, and x86-64 are
 currently supported.
 """
 

--- a/libdrgn/arch_s390x.c
+++ b/libdrgn/arch_s390x.c
@@ -297,7 +297,7 @@ linux_kernel_pgtable_iterator_init_s390x(struct drgn_program *prog,
 	struct pgtable_iterator_s390x *it =
 		container_of(_it, struct pgtable_iterator_s390x, it);
 	for (int i = 0; i < 5; i++)
-		it->pagetable[i].addr = UINT64_C(-1);
+		it->pagetable[i].addr = UINT64_MAX;
 	it->levels = 3;
 }
 
@@ -399,12 +399,13 @@ linux_kernel_pgtable_iterator_next_s390x(struct drgn_program *prog,
 	uint64_t entry;
 
 	/*
-	 * Note: we need the ASCE bits to determine the levels of paging in use, but we
-	 * only get the pgd address from drgn. Therefore do the same what the linux kernel
-	 * does: read the first level entry, and deduct the number of levels from the TT bits.
+	 * Note: we need the ASCE bits to determine the levels of paging in use,
+	 * but we only get the pgd address from drgn. Therefore do the same what
+	 * the linux kernel does: read the first level entry, and deduct the
+	 * number of levels from the TT bits.
 	 */
-
-	struct drgn_error *err = drgn_program_read_u64(prog, table, true, &entry);
+	struct drgn_error *err = drgn_program_read_u64(prog, table, true,
+						       &entry);
 	if (err)
 		return err;
 
@@ -425,10 +426,11 @@ linux_kernel_pgtable_iterator_next_s390x(struct drgn_program *prog,
 		    it->pagetable[level].length != length ||
 		    it->pagetable[level].offset != offset) {
 			/*
-			 * It's only marginally more expensive to read 4096 bytes than 8
-			 * bytes, so we always read the full table.
+			 * It's only marginally more expensive to read 4096
+			 * bytes than 8 bytes, so we always read the full table.
 			 */
-			err = drgn_program_read_memory(prog, it->pagetable[level].entries,
+			err = drgn_program_read_memory(prog,
+						       it->pagetable[level].entries,
 						       table, length * 8, true);
 			if (err)
 				return err;
@@ -475,10 +477,14 @@ const struct drgn_architecture_info arch_info_s390x = {
 	.linux_kernel_get_initial_registers =
 		linux_kernel_get_initial_registers_s390x,
 	.apply_elf_reloc = apply_elf_reloc_s390,
-	.linux_kernel_pgtable_iterator_create =  linux_kernel_pgtable_iterator_create_s390x,
-	.linux_kernel_pgtable_iterator_destroy = linux_kernel_pgtable_iterator_destroy_s390x,
-	.linux_kernel_pgtable_iterator_init = linux_kernel_pgtable_iterator_init_s390x,
-	.linux_kernel_pgtable_iterator_next = linux_kernel_pgtable_iterator_next_s390x,
+	.linux_kernel_pgtable_iterator_create =
+		linux_kernel_pgtable_iterator_create_s390x,
+	.linux_kernel_pgtable_iterator_destroy =
+		linux_kernel_pgtable_iterator_destroy_s390x,
+	.linux_kernel_pgtable_iterator_init =
+		linux_kernel_pgtable_iterator_init_s390x,
+	.linux_kernel_pgtable_iterator_next =
+		linux_kernel_pgtable_iterator_next_s390x,
 };
 
 const struct drgn_architecture_info arch_info_s390 = {

--- a/tests/linux_kernel/__init__.py
+++ b/tests/linux_kernel/__init__.py
@@ -91,7 +91,7 @@ skip_unless_have_test_kmod = unittest.skipUnless(
     "DRGN_TEST_KMOD" in os.environ, "test requires drgn_test Linux kernel module"
 )
 
-HAVE_FULL_MM_SUPPORT = NORMALIZED_MACHINE_NAME in ("aarch64", "x86_64")
+HAVE_FULL_MM_SUPPORT = NORMALIZED_MACHINE_NAME in ("aarch64", "s390x", "x86_64")
 
 skip_unless_have_full_mm_support = unittest.skipUnless(
     HAVE_FULL_MM_SUPPORT,


### PR DESCRIPTION
Add support for walking s390x page tables. This supports up to 5 level page table walking and huge/large pages. In order to figure out the level of paging used, we read the first entry of the pgd, which is always mapped for lowcore access and use the level bits of the next page table. This is because drgn passes mm::pgd as pgtable argument to the walker function which doesn't contain the ASCE bits.

Signed-off-by: Sven Schnelle <svens@linux.ibm.com>