### PR TITLE
Add setter for Program flags

### DIFF
--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -716,6 +716,10 @@ struct drgn_error *drgn_program_from_pid(pid_t pid, struct drgn_program **ret);
 /** Get the set of @ref drgn_program_flags applying to a @ref drgn_program. */
 enum drgn_program_flags drgn_program_flags(struct drgn_program *prog);
 
+/** Set the set of @ref drgn_program_flags applying to a @ref drgn_program. */
+void drgn_program_set_flags(struct drgn_program *prog,
+			    enum drgn_program_flags flags);
+
 /**
  * Get the platform of a @ref drgn_program.
  *

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -65,6 +65,12 @@ drgn_program_flags(struct drgn_program *prog)
 	return prog->flags;
 }
 
+LIBDRGN_PUBLIC void drgn_program_set_flags(struct drgn_program *prog,
+					   enum drgn_program_flags flags)
+{
+	prog->flags = flags;
+}
+
 LIBDRGN_PUBLIC const struct drgn_platform *
 drgn_program_platform(struct drgn_program *prog)
 {

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -972,6 +972,29 @@ static PyObject *Program_get_flags(Program *self, void *arg)
 				     (unsigned long)self->prog.flags);
 }
 
+static int Program_set_flags(Program *self, PyObject *value, void *arg)
+{
+	PyObject *value_attr;
+	unsigned long flags;
+
+	if (!PyObject_IsInstance(value, ProgramFlags_class)) {
+		PyErr_SetString(PyExc_TypeError, "flags must be ProgramFlags");
+		return -1;
+	}
+
+	value_attr = PyObject_GetAttrString(value, "value");
+	if (!value_attr)
+		return -1;
+
+	flags = PyLong_AsUint64Mask(value_attr);
+
+	drgn_program_set_flags(&self->prog, flags);
+
+	Py_DECREF(value_attr);
+
+	return 0;
+}
+
 static PyObject *Program_get_platform(Program *self, void *arg)
 {
 	const struct drgn_platform *platform;
@@ -1089,7 +1112,7 @@ static PyMemberDef Program_members[] = {
 };
 
 static PyGetSetDef Program_getset[] = {
-	{"flags", (getter)Program_get_flags, NULL, drgn_Program_flags_DOC},
+	{"flags", (getter)Program_get_flags, (setter)Program_set_flags, drgn_Program_flags_DOC},
 	{"platform", (getter)Program_get_platform, NULL,
 	 drgn_Program_platform_DOC},
 	{"language", (getter)Program_get_language, (setter)Program_set_language,


### PR DESCRIPTION
The ProgramFlags are set by the `program_from_*` functions, and cannot be modified. This makes several features of drgn unavailable if used as a library.

This patch adds write access to the program flags.

In practice, I use qemu-system and gdb to debug a vmlinux.
Changing the program flags allows me to use a Program created with the default constructor to use Linux specific functions (eg: getting threads).

```Python
import gdb
from drgn import Architecture, Platform, Program, ProgramFlags

def read_mem(address, count, offset, physical):
    return gdb.inferiors()[0].read_memory(address, count)

prog = Program(Platform(Architecture.I386))
prog.flags |= ProgramFlags.IS_LINUX_KERNEL
prog.add_memory_segment(1, (1<<32)-1, read_mem)
prog.load_debug_info(['vmlinux'])

for thread in prog.threads():
    print(thread.object.comm)
```