### PR TITLE
fs_inodes: catch proper exception for None path

### DIFF
--- a/contrib/fs_inodes.py
+++ b/contrib/fs_inodes.py
@@ -28,5 +28,5 @@ for inode in list_for_each_entry(
 ):
     try:
         print(os.fsdecode(inode_path(inode)))
-    except ValueError:
+    except (TypeError, ValueError):
         continue


### PR DESCRIPTION
When inode_path returns None and it's passed to fsdecode, I get TypeError exception:

```
  File "/usr/lib64/python3.10/os.py", line 823, in fsdecode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

Thus catch both exception types.

Signed-off-by: Martin Liska <mliska@suse.cz>