### PR TITLE
add mount.py contrib script

### DIFF
--- a/contrib/mount.py
+++ b/contrib/mount.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env drgn
+# Copyright (c) SUSE Linux.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""A simplified implementation of mount(1) using drgn"""
+
+from drgn.helpers.linux.fs import for_each_mount, mount_dst, mount_fstype, mount_src
+
+print("Mount            Type         Devname      Dirname")
+for mount in for_each_mount(prog):
+    maddr = mount.value_()
+    src = mount_src(mount).decode()
+    dst = mount_dst(mount).decode()
+    type_ = mount_fstype(mount).decode()
+
+    print(f"{maddr:<16x} {type_:<12} {src:<12} {dst}")


### PR DESCRIPTION
Provides crash-like output:

```
Mount            Type         Devname      Dirname
ffff8fed001d8500 rootfs       rootfs       /
ffff8fed06a197c0 proc         proc         /proc
ffff8fed06a192c0 sysfs        sysfs        /sys
ffff8fed06a18c80 devtmpfs     devtmpfs     /dev
ffff8fed06a18b40 securityfs   securityfs   /sys/kernel/security
ffff8fed06a19cc0 tmpfs        tmpfs        /dev/shm
ffff8fed06a18500 devpts       devpts       /dev/pts
ffff8fed06a18dc0 tmpfs        tmpfs        /run
...
```

Signed-off-by: Martin Liska <mliska@suse.cz>