### PR TITLE
add vmstat.py script to contrib

### DIFF
--- a/contrib/vmstat.py
+++ b/contrib/vmstat.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env drgn
+# Copyright (c) SUSE Linux.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Dump /proc/vmstat statistics.
+
+   Skip the last enumerator item as it holds the number of enumrator values."""
+
+from drgn.helpers.linux.cpumask import for_each_online_cpu
+from drgn.helpers.linux.percpu import per_cpu
+
+
+def print_event_line(event, counter):
+    print(f"{event.name:<36} {counter.value_():>16}")
+
+
+print(f"{'Event':<36} {'Count':>16}")
+
+# 1) vm_zone_stat statistics are there since v4.8.
+if "vm_zone_stat" in prog:
+    print("VM_ZONE_STAT:")
+    vm_zone_stat = prog["vm_zone_stat"]
+    for event in prog.type("enum zone_stat_item").enumerators[:-1]:
+        print_event_line(event, vm_zone_stat[event.value].counter)
+    print()
+
+# 2) vm_node_stat statistics are there since v4.8.
+if "vm_node_stat" in prog:
+    print("VM_NODE_STAT:")
+    vm_node_stat = prog["vm_node_stat"]
+    for event in prog.type("enum node_stat_item").enumerators[:-1]:
+        print_event_line(event, vm_node_stat[event.value].counter)
+    print()
+
+# 3) vm_numa_event statistics are there since v5.14. They are only populated if
+# CONFIG_NUMA is enabled.
+if "node_subsys" in prog and "vm_numa_event" in prog:
+    print("VM_NUMA_EVENT:")
+    vm_numa_event = prog["vm_numa_event"]
+    for event in prog.type("enum numa_stat_item").enumerators[:-1]:
+        print_event_line(event, vm_numa_event[event.value].counter)
+    print()
+
+# 4) vm_event_states statistics (uses per-CPU counters)
+print("VM_EVENT_STATES:")
+vm_event_states = prog["vm_event_states"]
+cpulist = list(for_each_online_cpu(prog))
+for event in prog.type("enum vm_event_item").enumerators[:-1]:
+    count = sum([per_cpu(vm_event_states, cpu).event[event.value] for cpu in cpulist])
+    print_event_line(event, count)


### PR DESCRIPTION
The script mimics what crash> kmem -V does, the script reports the following:

```
Event                                           Count
VM_ZONE_STAT:
NR_FREE_PAGES                                  512147
NR_ZONE_LRU_BASE                               234271
NR_ZONE_INACTIVE_ANON                          234271
NR_ZONE_ACTIVE_ANON                               196
NR_ZONE_INACTIVE_FILE                           97200
NR_ZONE_ACTIVE_FILE                            110611
NR_ZONE_UNEVICTABLE                              1000
NR_ZONE_WRITE_PENDING                              84
NR_MLOCK                                            0
NR_BOUNCE                                           0
NR_ZSPAGES                                          0
NR_FREE_CMA_PAGES                                   0

VM_NODE_STAT:
NR_LRU_BASE                                    234322
NR_INACTIVE_ANON                               234322
NR_ACTIVE_ANON                                    196
NR_INACTIVE_FILE                                97200
...
```

Signed-off-by: Martin Liska <mliska@suse.cz>