### PR TITLE
pre-commit: Update isort version to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.2
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)


### PR DESCRIPTION
Currently on Ubuntu 22.04 LTS, pre-commit hook installation is broken for isort, with an error that can be seen at [1]. The solution is to update isort to 5.12.0.

[1]: https://github.com/PyCQA/isort/issues/2077