### PR TITLE
Fix TCP listing contrib script

### DIFF
--- a/contrib/tcp_sock.py
+++ b/contrib/tcp_sock.py
@@ -8,12 +8,12 @@ import ipaddress
 import socket
 import struct
 
-from drgn import cast, container_of
+from drgn import cast
 from drgn.helpers.common.type import enum_type_to_class
 from drgn.helpers.linux import (
     cgroup_path,
-    hlist_for_each,
     hlist_nulls_empty,
+    hlist_nulls_for_each_entry,
     sk_fullsock,
     sk_nulls_for_each,
     sk_tcpstate,
@@ -99,8 +99,9 @@ tcp_hashinfo = prog.object("tcp_hashinfo")
 
 try:
     for ilb in tcp_hashinfo.listening_hash:
-        for pos in hlist_for_each(ilb.head):
-            sk = container_of(pos, "struct sock", "__sk_common.skc_node")
+        for sk in hlist_nulls_for_each_entry(
+            "struct sock", ilb.nulls_head, "__sk_common.skc_node"
+        ):
             _print_sk(sk)
 except AttributeError:
     for i in range(tcp_hashinfo.lhash2_mask + 1):


### PR DESCRIPTION
In v5.18, it's actually hlist_nulls_head what is used for items of inet_hashinfo::listening_hash. With the change it works for all releases starting with v4.9. The version 4.4 is not supported right now (nulls head list is probably not known at the time).

Fixes: #268

Signed-off-by: Martin Liska <mliska@suse.cz>