### PR TITLE
setup.py test: add -smp argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,6 +177,7 @@ class test(Command):
             "d",
             "directory for built artifacts and downloaded kernels for virtual machine tests (default: 'build/vmtest')",
         ),
+        ("smp=", "s", "number of CPUs in qemu"),
     ]
 
     def initialize_options(self):
@@ -184,6 +185,7 @@ class test(Command):
         self.all_kernel_flavors = False
         self.extra_kernels = ""
         self.vmtest_dir = None
+        self.smp = None
 
     def finalize_options(self):
         self.kernels = [kernel for kernel in self.extra_kernels.split(",") if kernel]
@@ -195,6 +197,7 @@ class test(Command):
         if self.vmtest_dir is None:
             build_base = self.get_finalized_command("build").build_base
             self.vmtest_dir = os.path.join(build_base, "vmtest")
+        self.smp = int(self.smp) if self.smp else nproc()
 
     def _run_local(self):
         import unittest
@@ -274,7 +277,7 @@ fi
 """
         try:
             returncode = vmtest.vm.run_in_vm(
-                command, Path("/"), Path(kernel_dir), Path(self.vmtest_dir)
+                command, Path("/"), Path(kernel_dir), Path(self.vmtest_dir), self.smp
             )
         except vmtest.vm.LostVMError as e:
             self.announce(f"error on Linux {kernel_release}: {e}", log.ERROR)

--- a/vmtest/vm.py
+++ b/vmtest/vm.py
@@ -176,7 +176,9 @@ class LostVMError(Exception):
     pass
 
 
-def run_in_vm(command: str, root_dir: Path, kernel_dir: Path, build_dir: Path) -> int:
+def run_in_vm(
+    command: str, root_dir: Path, kernel_dir: Path, build_dir: Path, smp: int = nproc()
+) -> int:
     match = re.search(
         r"QEMU emulator version ([0-9]+(?:\.[0-9]+)*)",
         subprocess.check_output(
@@ -247,7 +249,7 @@ def run_in_vm(command: str, root_dir: Path, kernel_dir: Path, build_dir: Path) -
                 # fmt: off
                 "qemu-system-x86_64", *kvm_args,
 
-                "-smp", str(nproc()), "-m", "2G",
+                "-smp", str(smp), "-m", "2G",
 
                 "-nodefaults", "-display", "none", "-serial", "mon:stdio",
 


### PR DESCRIPTION
When I run qemu on my AMD zen with 32 cores (and 2 GB memory) I sometimes hit:

````
kswapd0: page allocation failure: order:7, mode:0x40c40(GFP_NOFS|__GFP_COMP), nodemask=(null) CPU: 22 PID: 183 Comm: kswapd0 Not tainted 5.16.20-vmtest18.1default #1 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS rel-1.16.0-0-gd239552-rebuilt.opensuse.org 04/01/2014 Call Trace:
 <TASK>
 dump_stack_lvl+0x34/0x44
 warn_alloc+0xf3/0x171
 __alloc_pages_slowpath.constprop.0+0x7e3/0x813
 __alloc_pages+0x100/0x179
 new_slab+0xac/0x23d
 ___slab_alloc+0x436/0x527
 ? p9_fcall_init+0x27/0x66
 ? virtqueue_add+0x7d6/0x8fe
 ? virtqueue_add+0x845/0x8fe
 ? update_cfs_rq_load_avg+0x13d/0x14b
..
```

With the new test argument '-smp 4' it works fine for all flavors.

Signed-off-by: Martin Liska <mliska@suse.cz>