### PR TITLE
contrib: add timer listing script

### DIFF
--- a/contrib/timer.py
+++ b/contrib/timer.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env drgn
+# Copyright (c) SUSE Linux.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""List system timers   """
+
+from drgn.helpers.linux.cpumask import for_each_online_cpu
+from drgn.helpers.linux.kconfig import get_kconfig
+from drgn.helpers.linux.list import hlist_for_each_entry
+from drgn.helpers.linux.percpu import per_cpu
+from drgn.helpers.linux.rbtree import rbtree_inorder_for_each_entry
+
+hrtimer_base = prog["hrtimer_bases"]
+jiffies = int(prog["jiffies"])
+hz = int(get_kconfig(prog)['CONFIG_HZ'])
+adjusted_jiffies = jiffies - (0x100000000 - 300 * hz)
+
+
+def get_fname(function):
+    try:
+        return "<" + prog.symbol(function).name + ">"
+    except LookupError:
+        return ""
+
+
+print("=== timers ===")
+print(f"Jiffies: {int(jiffies)}\n")
+
+for cpu in for_each_online_cpu(prog):
+    print(f"CPU {cpu}")
+    timer_bases = per_cpu(prog["timer_bases"], cpu)
+
+    for i in range(timer_bases.type_.length):
+        print(f"TIMER_BASES[{i}]")
+        print(f"  {'Expires':>16} {'TTE':>16} Function")
+        for j in range(timer_bases[i].vectors.type_.length):
+            timers = list(hlist_for_each_entry("struct timer_list", timer_bases[i].vectors[j], "entry"))
+            for item in timers:
+                expires = int(item.expires)
+                print(f"  {expires:>16} {expires - jiffies:>16} {get_fname(item.function)}")
+    print()
+
+print("=== hrtimers ===")
+
+for cpu in for_each_online_cpu(prog):
+    print(f"CPU {cpu}")
+
+    clock_base = per_cpu(hrtimer_base, cpu).clock_base
+    for clockid in range(clock_base.type_.length):
+        clock = clock_base[clockid]
+        now = adjusted_jiffies * 1000000000 // hz + int(clock.offset)
+        print(f"  Clock: {clockid} (current: {now:>22}) {hex(clock.get_time)} "
+              f"{get_fname(clock.get_time)}")
+        timer_tree = clock.active.rb_root.rb_root
+        try:
+            # Use list(...) instead of the lazy iteration as the data structure is very volatile
+            # and changing quite ofter.
+            timers = list(rbtree_inorder_for_each_entry("struct hrtimer", timer_tree, "node"))
+            if timers:
+                print(f"    {'Softexpires':>22} {'Expires':>22} {'TTE':>22}  Function")
+                for timer in timers:
+                    fname = get_fname(timer.function)
+                    tte = int(timer.node.expires) - now
+                    print(f"    {int(timer._softexpires):>22} {int(timer.node.expires):>22} "
+                          f"{tte:>22}  {hex(timer.function)} {fname}")
+                print()
+        except Exception as e:
+            print(f"    [skipped: {e}]")
+    print()


### PR DESCRIPTION
The script mimics crash tool command 'timer' where it prints both normal and high-resolution timers. It has been tested with 5.4+.

```
=== timers ===
Jiffies: 4316158600

CPU 0
TIMER_BASES[0]
           Expires              TTE Function
        4316158601                1 <process_timeout>
        4316158603                3 <process_timeout>
        4316158632               32 <delayed_work_timer_fn>
        4316160900             2300 <process_timeout>
        4316159750             1150 <commit_timeout>
        4316214500            55900 <mce_timer_fn>
        4316192445            33845 <tsc_sync_check_timer_fn>
TIMER_BASES[1]
           Expires              TTE Function
        4316158613               13 <tcp_orphan_update>
        4316158750              150 <delayed_work_timer_fn>
        4316158750              150 <delayed_work_timer_fn>
        4316162279             3679 <delayed_work_timer_fn>
        4316159171              571 <writeout_period>
        4316165965             7365 <wq_watchdog_timer_fn>
...

=== hrtimers ===
CPU 0
  Clock: 0 (current:         85065216000000) 0xffffffffb9d60d30 <ktime_get>
               Softexpires                Expires                    TTE  Function
            85065385636443         85065385636443              169636443  0xffffffffb9d6ffa0 <tick_sched_timer>
            85068041636443         85068041636443             2825636443  0xffffffffb9dbbe80 <watchdog_timer_fn>
            85112597085000         85112597085000            47381085000  0xffffffffb9fb5d90 <timerfd_tmrproc>
            85412597085000         85412597085000           347381085000  0xffffffffb9fb5d90 <timerfd_tmrproc>
            86419414192906         86419514192906          1354298192906  0xffffffffb9d5d8d0 <hrtimer_wakeup>

  Clock: 1 (current:    1676553192878685670) 0xffffffffb9d5d760 <ktime_get_real>
               Softexpires                Expires                    TTE  Function
       9223372036854775807    9223372036854775807    7546818843976090137  0xffffffffb9fb5d90 <timerfd_tmrproc>

  Clock: 2 (current:         85065216000000) 0xffffffffb9d5d750 <ktime_get_boottime>
  Clock: 3 (current:    1676553192878685670) 0xffffffffb9d5d740 <ktime_get_clocktai>
  Clock: 4 (current:         85065216000000) 0xffffffffb9d60d30 <ktime_get>
  Clock: 5 (current:    1676553192878685670) 0xffffffffb9d5d760 <ktime_get_real>
  Clock: 6 (current:         85065216000000) 0xffffffffb9d5d750 <ktime_get_boottime>
  Clock: 7 (current:    1676553192878685670) 0xffffffffb9d5d740 <ktime_get_clocktai>
...
```