### PR TITLE
tests: limit SMP count to 8 at maximum

### DIFF
--- a/vmtest/vm.py
+++ b/vmtest/vm.py
@@ -256,7 +256,8 @@ def run_in_vm(command: str, kernel: Kernel, root_dir: Path, build_dir: Path) -> 
                 # fmt: off
                 qemu_exe, *kvm_args,
 
-                "-smp", str(nproc()), "-m", "2G",
+                # Limit the number of cores to 8, otherwise we can reach an OOM troubles.
+                "-smp", str(min(nproc(), 8)), "-m", "2G",
 
                 "-display", "none", "-serial", "mon:stdio",
 


### PR DESCRIPTION
Sometimes one can see an OOM with a higher number of SMP count while still having 2G of memory.