### PR TITLE
Expand DW_AT_upper_bound to include other types of int

### DIFF
--- a/libdrgn/dwarf_info.c
+++ b/libdrgn/dwarf_info.c
@@ -6405,11 +6405,11 @@ static struct drgn_error *subrange_length(Dwarf_Die *die,
 
 	dimension->is_complete = true;
 	/*
-	 * GCC emits a DW_FORM_sdata DW_AT_upper_bound of -1 for empty array
-	 * variables without an explicit size (e.g., `int arr[] = {};`).
+	 * GCC emits a DW_FORM_sdata or DW_FORM_data8 DW_AT_upper_bound of -1
+	 * for empty array variables without an explicit size
+	 * (e.g., `int arr[] = {};`).
 	 */
-	if (attr->code == DW_AT_upper_bound && attr->form == DW_FORM_sdata &&
-	    word == (Dwarf_Word)-1) {
+	if (attr->code == DW_AT_upper_bound && word == (Dwarf_Word)-1) {
 		dimension->length = 0;
 	} else if (attr->code == DW_AT_upper_bound) {
 		if (word >= UINT64_MAX) {

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -2581,6 +2581,32 @@ class TestTypes(TestCase):
             prog.type("TEST").type, prog.array_type(prog.int_type("int", 4, True), 0)
         )
 
+    def test_array_zero_length_upper_bound_cpp(self):
+        prog = dwarf_program(
+            wrap_test_type_dies(
+                DwarfDie(
+                    DW_TAG.array_type,
+                    (DwarfAttrib(DW_AT.type, DW_FORM.ref4, "int_die"),),
+                    (
+                        DwarfDie(
+                            DW_TAG.subrange_type,
+                            (
+                                DwarfAttrib(
+                                    DW_AT.upper_bound,
+                                    DW_FORM.data8,
+                                    18446744073709551615,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                *labeled_int_die,
+            )
+        )
+        self.assertIdentical(
+            prog.type("TEST").type, prog.array_type(prog.int_type("int", 4, True), 0)
+        )
+
     def test_incomplete_array_no_subrange(self):
         prog = dwarf_program(
             wrap_test_type_dies(


### PR DESCRIPTION
GCC appears to use data8 at -1 when reporting zero length arrays, this patch adds support and a test for that behavior.

dwarf_info.c: Remove check for sdata on quirk for array length == 0

I also added a test to avoid this case regressing in the future

See https://github.com/facebookexperimental/object-introspection/pull/77#issuecomment-1439156748