### PR TITLE
python: Make Type.name and Type.tag always exist

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -1815,16 +1815,16 @@ class Type:
     language: Final[Language]
     """Programming language of this type."""
 
-    name: Final[str]
+    name: Final[Optional[str]]
     """
-    Name of this type. This is present for integer, boolean, floating-point,
-    and typedef types.
+    Name of this type. This exists for integer, boolean, floating-point,
+    and typedef types, and is ``None`` otherwise.
     """
 
     tag: Final[Optional[str]]
     """
-    Tag of this type, or ``None`` if this is an anonymous type. This is present
-    for structure, union, class, and enumerated types.
+    Tag of this type, or ``None`` if this is an anonymous type. This is also
+    ``None`` for structure, union, class, and enumerated types.
     """
 
     size: Final[Optional[int]]

--- a/libdrgn/python/type.c
+++ b/libdrgn/python/type.c
@@ -83,23 +83,18 @@ static PyObject *DrgnType_get_language(DrgnType *self, void *arg)
 
 static PyObject *DrgnType_get_name(DrgnType *self)
 {
-	if (!drgn_type_has_name(self->type)) {
-		return PyErr_Format(PyExc_AttributeError,
-				    "%s type does not have a name",
-				    drgn_type_kind_str(self->type));
-	}
-	return PyUnicode_FromString(drgn_type_name(self->type));
+	if (!drgn_type_has_name(self->type))
+		Py_RETURN_NONE;
+	else
+		return PyUnicode_FromString(drgn_type_name(self->type));
 }
 
 static PyObject *DrgnType_get_tag(DrgnType *self)
 {
 	const char *tag;
 
-	if (!drgn_type_has_tag(self->type)) {
-		return PyErr_Format(PyExc_AttributeError,
-				    "%s type does not have a tag",
-				    drgn_type_kind_str(self->type));
-	}
+	if (!drgn_type_has_tag(self->type))
+		Py_RETURN_NONE;
 
 	tag = drgn_type_tag(self->type);
 	if (tag)


### PR DESCRIPTION
This is a quick drive-by commit to raise a discussion. One incredibly common use case of Types in Linux helpers is to distinguish between the different versions of structures in different kernel versions. It's quite frustrating to write perfectly good code like this (taken from an in-development helper):

    if obj.type_.name == "int":
        pass
    elif obj.type_.type_name() == "atomic_t *":
        pass

And find that even though the intent of this code is clear, it would raise "AttributeError: pointer type does not have a name". Of course, the code could be reordered to avoid this issue. But it seems confusing that type presence or absence is used in this way. Further, some Type fields have a strange "tristate" property, where they could be either absent, present but None, or have a value -- all depending on what kind of Type it is.

In my opinion, that sort of subtlety is probably more correct, but in reality is a difficult API to work with. The Type class already exposes the necessary information to infer the details of some of these tristate properties (e.g. Type.is_complete(), or Type.kind). Consumer code which wants to know those things should directly query those attributes, and not have to tiptoe around unexpected AttributeErrors which could pop up at any time.

This commit only touches the name and tag fields, but the pattern exists for the size, length, is_signed, byteorder fields. I didn't update all fields because I really just want to have the discussion first. Also, I feel that some of these fields (length, is_signed, byteorder) are pretty justifiable to be absent: if you're accessing the byteorder field of a structure type, you're clearly doing something wrong. However, with the name-related fields, it seems less clear.

---

As I wrote this commit message I did realize that `type_name()` is probably the correct API for doing these sorts of type checks. It's just quite unclear. I think it would be worth discussing this more, but I don't necessarily think this change is the only correct answer.