### PR TITLE
ppc64: add virtual address translation support

### DIFF
--- a/docs/support_matrix.rst
+++ b/docs/support_matrix.rst
@@ -29,7 +29,7 @@ of this support is:
     * - ppc64
       - ✓
       - ✓
-      -
+      - ✓
     * - i386
       - ✓
       -

--- a/tests/linux_kernel/__init__.py
+++ b/tests/linux_kernel/__init__.py
@@ -91,7 +91,12 @@ skip_unless_have_test_kmod = unittest.skipUnless(
     "DRGN_TEST_KMOD" in os.environ, "test requires drgn_test Linux kernel module"
 )
 
-HAVE_FULL_MM_SUPPORT = NORMALIZED_MACHINE_NAME in ("aarch64", "s390x", "x86_64")
+HAVE_FULL_MM_SUPPORT = NORMALIZED_MACHINE_NAME in (
+    "aarch64",
+    "ppc64",
+    "s390x",
+    "x86_64",
+)
 
 skip_unless_have_full_mm_support = unittest.skipUnless(
     HAVE_FULL_MM_SUPPORT,

--- a/vmtest/__main__.py
+++ b/vmtest/__main__.py
@@ -97,10 +97,8 @@ def _kdump_works(kernel: Kernel) -> bool:
         # bytes...".
         return False
     elif kernel.arch.name == "ppc64":
-        # Without virtual address translation, we can't debug vmcores.
-        return False
         # Before 6.1, sysrq-c hangs.
-        # return KernelVersion(kernel.release) >= KernelVersion("6.1")
+        return KernelVersion(kernel.release) >= KernelVersion("6.1")
     elif kernel.arch.name == "s390x":
         # Before 5.15, sysrq-c hangs.
         return KernelVersion(kernel.release) >= KernelVersion("5.15")


### PR DESCRIPTION
Linux on Power support two MMU, Radix and Hash. Add page table walk to do virtual address translation for Radix MMU on BOOK3S CPU Family. Radix MMU is 4 level page table with two different page sizes to support 64K and 4K. In addition to multiple pages, Radix also supports huge pages. The implementation takes of both page sizes and huge pages.

Tested this patch with live kernel 6.3.0-rc2

drgn script:
------------
import drgn
from drgn.helpers.linux import *

prog = drgn.Program()
prog.set_kernel();
prog.load_debug_info([f'./vmlinux'])
print(cmdline(find_task(prog, 1)))

output:
------
[b'/usr/lib/systemd/systemd', b'--switched-root', b'--system', \
b'--deserialize', b'30']