### PR TITLE
libdrgn: linux_kernel: Fix compiler warning

### DIFF
--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -358,7 +358,9 @@ static struct drgn_error *linux_kernel_get_vmemmap(struct drgn_program *prog,
 {
 	struct drgn_error *err;
 	if (prog->vmemmap.kind == DRGN_OBJECT_ABSENT) {
-		uint64_t address;
+		// Silence -Wmaybe-uninitialized false positive last seen with
+		// GCC 13 by initializing to zero.
+		uint64_t address = 0;
 		err = linux_kernel_get_vmemmap_address(prog, &address);
 		if (err)
 			return err;


### PR DESCRIPTION
With GCC 13.1.1 and the recommended build
setup (`CONFIGURE_FLAGS="--enable-compiler-warnings=error"`), I get the following failure:

```
In function 'linux_kernel_get_vmemmap',
    inlined from 'linux_kernel_object_find' at ../../libdrgn/linux_kernel_object_find.inc.strswitch:34:12:
../../libdrgn/linux_kernel.c:370:23: error: 'address' may be used uninitialized [-Werror=maybe-uninitialized]
  370 |                 err = drgn_object_set_unsigned(&prog->vmemmap, qualified_type,
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  371 |                                                address, 0);
      |                                                ~~~~~~~~~~~
../../libdrgn/linux_kernel.c: In function 'linux_kernel_object_find':
../../libdrgn/linux_kernel.c:361:26: note: 'address' was declared here
  361 |                 uint64_t address;
      |                          ^~~~~~~
cc1: all warnings being treated as errors
```

While linux_kernel_get_vmemmap_address should always update address in a non-error case, the compiler seems to disagree. It's easy enough to shut up the compiler by initializing address to 0. What's more, if there is an actual issue where the linux_kernel_get_vmemmap_address does NOT update the address variable, a 0 value will be easier to debug than garbage from an uninitialized variable.