### PR TITLE
Add Python 3.12 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,20 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+    inputs:
+      test_all_python_versions:
+        description: "Run tests on all Python versions"
+        type: boolean
+        default: false
+        required: true
+  workflow_call:
+    inputs:
+      test_all_python_versions:
+        description: "Run tests on all Python versions"
+        type: boolean
+        default: false
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -13,7 +27,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7', '3.6']
+        python-version: ${{ inputs.test_all_python_versions
+                            && fromJSON('["3.12", "3.11", "3.10", "3.9", "3.8", "3.7", "3.6"]')
+                            || fromJSON('["3.11", "3.6"]')}}
         cc: [gcc, clang]
       fail-fast: false
     env:
@@ -25,6 +41,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,16 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'test-all-python-versions' }}
+    with:
+      test_all_python_versions: ${{ contains(github.event.pull_request.labels.*.name, 'test-all-python-versions') }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,12 @@
+name: Main Branch Push CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+    with:
+      test_all_python_versions: true

--- a/.github/workflows/vmtest-build.yml
+++ b/.github/workflows/vmtest-build.yml
@@ -36,3 +36,8 @@ jobs:
           name: kernel-build-logs
           path: build/vmtest/kbuild/*.log
           if-no-files-found: ignore
+  test:
+    needs: build
+    uses: ./.github/workflows/ci.yml
+    with:
+      test_all_python_versions: true


### PR DESCRIPTION
Use the "hyphen release" syntax to specify the latest version between 3.12.0-beta.1 and 3.12. It's unclear whether this will actually work to bring in the real releases of 3.12 when they happen, but I think the only way to find out would be to try it out.