### PR TITLE
Add DRGN_PROGRAM_IS_LOCAL flag

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -837,6 +837,11 @@ class ProgramFlags(enum.Flag):
     kernel or a running process).
     """
 
+    IS_LOCAL = ...
+    """
+    The program is running on the local machine.
+    """
+
 class FindObjectFlags(enum.Flag):
     """
     ``FindObjectFlags`` are flags for :meth:`Program.object()`. These can be

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -490,6 +490,8 @@ enum drgn_program_flags {
 	DRGN_PROGRAM_IS_LINUX_KERNEL = (1 << 0),
 	/** The program is currently running. */
 	DRGN_PROGRAM_IS_LIVE = (1 << 1),
+	/** The program is running on the local machine. */
+	DRGN_PROGRAM_IS_LOCAL = (1 << 2),
 };
 
 /**

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -1557,7 +1557,7 @@ report_kernel_modules(struct drgn_debug_info_load_state *load,
 	 * can be disabled via an environment variable for testing.
 	 */
 	bool use_sys_module = false;
-	if (prog->flags & DRGN_PROGRAM_IS_LIVE) {
+	if (prog->flags & DRGN_PROGRAM_IS_LOCAL) {
 		char *env = getenv("DRGN_USE_SYS_MODULE");
 		use_sys_module = !env || atoi(env);
 	}

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -535,7 +535,8 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 				goto out_segments;
 		}
 		prog->flags |= (DRGN_PROGRAM_IS_LINUX_KERNEL |
-				DRGN_PROGRAM_IS_LIVE);
+				DRGN_PROGRAM_IS_LIVE |
+		                DRGN_PROGRAM_IS_LOCAL);
 		elf_end(prog->core);
 		prog->core = NULL;
 	} else if (vmcoreinfo_note) {
@@ -625,7 +626,7 @@ drgn_program_set_pid(struct drgn_program *prog, pid_t pid)
 		goto out_segments;
 
 	prog->pid = pid;
-	prog->flags |= DRGN_PROGRAM_IS_LIVE;
+	prog->flags |= DRGN_PROGRAM_IS_LIVE | DRGN_PROGRAM_IS_LOCAL;
 	return NULL;
 
 out_segments:


### PR DESCRIPTION
Currently, when drgn is used to debug a running program, we assume it to be running on the local machine. However, with remote debugging, this will no longer be the case. To accommodate remote debugging, introduce a flag DRGN_PROGRAM_IS_LOCAL, and use it to decide whether to use /sys/module.