### PR TITLE
contrib: add script to dump irq stats. 

### DIFF
--- a/contrib/irq.py
+++ b/contrib/irq.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env drgn
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+""" Script to dump irq stats using drgn"""
+
+from typing import Iterator
+
+from drgn import NULL
+from drgn import Object
+from drgn import Program
+from drgn.helpers.common.format import escape_ascii_string
+from drgn.helpers.linux.cpumask import for_each_present_cpu
+from drgn.helpers.linux.cpumask import cpumask_to_cpulist
+from drgn.helpers.linux.percpu import per_cpu_ptr
+from drgn.helpers.linux.radixtree import radix_tree_for_each
+from drgn.helpers.linux.radixtree import radix_tree_lookup
+
+
+def _sparse_irq_supported(prog: Program) -> bool:
+    try:
+        _ = prog["irq_desc_tree"]
+        return True
+    except KeyError:
+        return False
+
+
+def _kstat_irqs_cpu(prog: Program, irq: int, cpu: int) -> int:
+    desc = irq_to_desc(prog, irq)
+    if not desc:
+        return 0
+
+    addr = per_cpu_ptr(desc.kstat_irqs, cpu)
+    return Object(prog, "int", address=addr).value_()
+
+
+def irq_in_use(prog: Program, irq: int) -> bool:
+    """
+    Check if a given irq number is in use or not.
+    An irq number is considered to be in use by the kernel, if the kernel
+    has allocated a irq descriptor for it. The irq may not yet have any
+    registered irq handlers.
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: True if irq is in use, False otherwise
+    """
+    desc = irq_to_desc(prog, irq)
+    # An irq number is in use if irq_desc object has been allocated for it
+    return bool(desc)
+
+
+def irq_has_action(prog: Program, irq: int) -> bool:
+    """
+    Check if a given irq has handler(s) registered or not.
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: True if irq has registered handler(s), False otherwise
+    """
+
+    desc = irq_to_desc(prog, irq)
+    return bool(desc and desc.action)
+
+
+def for_each_irq(prog: Program) -> Iterator[int]:
+    """
+    Iterate through all allocated irq numbers.
+
+    :param prog: drgn program
+
+    :return: Iterator of irq numbers
+    """
+    if _sparse_irq_supported(prog):
+        irq_desc_tree = prog["irq_desc_tree"].address_of_()
+        for irq, _ in radix_tree_for_each(irq_desc_tree):
+            yield irq
+    else:
+        count = len(prog["irq_desc"])
+        for irq_num in range(count):
+            yield irq_num
+
+
+def for_each_irq_desc(prog: Program) -> Iterator[Object]:
+    """
+    Iterate through all allocated irq descriptors.
+
+    :param prog: drgn program
+
+    :return: Iterator of ``struct irq_desc *`` objects.
+    """
+    if _sparse_irq_supported(prog):
+        irq_desc_tree = prog["irq_desc_tree"].address_of_()
+        for _, addr in radix_tree_for_each(irq_desc_tree):
+            irq_desc = Object(
+                prog, "struct irq_desc", address=addr
+            ).address_of_()
+            yield irq_desc
+    else:
+        count = len(prog["irq_desc"])
+        for irq_num in range(count):
+            yield (prog["irq_desc"][irq_num]).address_of_()
+
+
+def irq_name_to_desc(prog: Program, name: str) -> Object:
+    """
+    Get ``struct irq_desc *`` for irq handler of given name
+
+    :param prog: drgn program
+    :param name: name of irq handler
+
+    :return: ``struct irq_desc *`` object if irq descriptor is found.
+             NULL otherwise
+    """
+    for desc in for_each_irq_desc(prog):
+        if desc.action and desc.action.name == name:
+            return desc
+
+    return NULL(prog, "void *")
+
+
+def irq_to_desc(prog: Program, irq: int) -> Object:
+    """
+    Get ``struct irq_desc *`` for given irq number
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: ``struct irq_desc *`` object if irq descriptor is found.
+             NULL otherwise
+    """
+    if _sparse_irq_supported(prog):
+        addr = radix_tree_lookup(prog["irq_desc_tree"].address_of_(), irq)
+        if addr:
+            return Object(prog, "struct irq_desc", address=addr).address_of_()
+        else:
+            return NULL(prog, "void *")
+    else:
+        return (prog["irq_desc"][irq]).address_of_()
+
+
+def get_irq_affinity(prog: Program, irq: int) -> Object:
+    """
+    Get ``struct cpumask`` for given irq's cpu affinity
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: ``struct cpumask`` object if irq descriptor is found.
+             NULL otherwise
+    """
+
+    if not irq_in_use(prog, irq):
+        print("IRQ not in use so affinity data is not reliable")
+
+    irq_desc = irq_to_desc(prog, irq)
+
+    # if CONFIG_CPUMASK_OFFSTACK is enabled then affinity is an array
+    # of cpumask objects otherwise it is pointer to a cpumask object
+    if hasattr(irq_desc, "irq_common_data"):
+        try:
+            _ = len(irq_desc.irq_common_data.affinity)
+            addr = irq_desc.irq_common_data.affinity.address_
+        except TypeError:
+            addr = irq_desc.irq_common_data.affinity.value_()
+    elif hasattr(irq_desc, "irq_data"):
+        try:
+            _ = len(irq_desc.irq_data.affinity)
+            addr = irq_desc.irq_data.affinity.address_
+        except TypeError:
+            addr = irq_desc.irq_data.affinity.value_()
+    else:
+        return None
+
+    return Object(prog, "struct cpumask", address=addr)
+
+
+def get_irq_affinity_list(prog: Program, irq: int) -> Object:
+    """
+    Get affinity of a given cpu.
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: range of cpus to which irq is affined to
+    """
+
+    affinity = get_irq_affinity(prog, irq)
+    if affinity is not None:
+        return cpumask_to_cpulist(affinity)
+    else:
+        return None
+
+def show_irq_num_stats(prog: Program, irq: int) -> None:
+    """
+    Show stats for a given irq number
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: None
+    """
+
+    if not irq_in_use(prog, irq):
+        print(f"irq: {irq} is not in use")
+        return
+
+    if not irq_has_action(prog, irq):
+        print(f"irq: {irq} has no handlers registered")
+        return
+    print_header = True
+    total_count = 0
+    for cpu in for_each_present_cpu(prog):
+        kstat_irqs = _kstat_irqs_cpu(prog, irq, cpu)
+        if not kstat_irqs:
+            continue
+        desc = irq_to_desc(prog, irq)
+        name = escape_ascii_string(
+            desc.action.name.string_(), escape_backslash=True
+        )
+        if print_header:
+            print(
+                f"irq: {irq} name: {name} ({desc.type_.type_name()})0x{desc.value_():x}"
+            )
+            print_header = False
+
+        total_count += kstat_irqs
+        print(f"    CPU: {cpu}  \t count: {kstat_irqs}")
+
+    print(f"    Total: {total_count}")
+
+
+def show_irq_name_stats(prog: Program, irq_name: str) -> None:
+    """
+    Show irq stats for irqs whose handler have specified name or
+    for irqs whose handler names begin with specified string.
+
+    :param prog: drgn program
+    :param irq_name: name or beginning of name of irq handler
+
+    :return: None
+    """
+
+    found = False
+    for irq in for_each_irq(prog):
+        if irq_in_use(prog, irq) and irq_has_action(prog, irq):
+            desc = irq_to_desc(prog, irq)
+            name = escape_ascii_string(
+                desc.action.name.string_(), escape_backslash=True
+            )
+            if name.startswith(irq_name):
+                found = True
+                show_irq_num_stats(prog, irq)
+
+    if not found:
+        print(
+            f"Found no irq with name: {irq_name} or with name starting with: {irq_name}"
+        )
+
+
+def show_irq_stats(prog: Program) -> None:
+    """
+    Show stats for all irqs.
+    :param prog: drgn program
+
+    :return: None
+    """
+    for irq in for_each_irq(prog):
+        if irq_in_use(prog, irq) and irq_has_action(prog, irq):
+            show_irq_num_stats(prog, irq)
+
+
+def show_cpu_irq_num_stats(prog: Program, cpu: int, irq: int) -> None:
+    """
+    Show irq stats of a cpu for a given irq number
+
+    :param prog: drgn program
+    :param cpu: cpu index
+    :param irq: irq number
+
+    :return: None
+    """
+
+    if not irq_in_use(prog, irq):
+        print(f"irq: {irq} is not in use")
+        return
+
+    if not irq_has_action(prog, irq):
+        print(f"irq: {irq} has no handlers registered")
+        return
+
+    print(f"IRQ stats for cpu: {cpu}")
+    desc = irq_to_desc(prog, irq)
+    name = escape_ascii_string(
+        desc.action.name.string_(), escape_backslash=True
+    )
+    kstat_irqs = _kstat_irqs_cpu(prog, irq, cpu)
+    print(
+        f"    irq: {irq} name: {name} ({desc.type_.type_name()})0x{desc.value_():x} count: {kstat_irqs}"
+    )
+
+
+def show_cpu_irq_name_stats(prog: Program, cpu: int, irq_name: str) -> None:
+    """
+    Show irq stats of a cpu for irqs whose handler have specified name or
+    for irqs whose handler names begin with specified string.
+
+    :param prog: drgn program
+    :param cpu: cpu index
+    :param irq_name: name or beginning of name of irq handler
+
+    :return: None
+    """
+
+    found = False
+    total_irqs_on_cpu = 0
+    print(f"IRQ stats for cpu: {cpu}")
+    for irq in for_each_irq(prog):
+        if irq_in_use(prog, irq) and irq_has_action(prog, irq):
+            desc = irq_to_desc(prog, irq)
+            name = escape_ascii_string(
+                desc.action.name.string_(), escape_backslash=True
+            )
+            if name.startswith(irq_name):
+                found = True
+                kstat_irqs = _kstat_irqs_cpu(prog, irq, cpu)
+                if not kstat_irqs:
+                    continue
+                total_irqs_on_cpu += kstat_irqs
+                print(
+                    f"    irq: {irq} name: {name} ({desc.type_.type_name()})0x{desc.value_():x} count: {kstat_irqs}"
+                )
+
+    if not found:
+        print(
+            f"Found no irq with name: {irq_name} or with name starting with: {irq_name}"
+        )
+    else:
+        print(f"Total: {total_irqs_on_cpu}")
+
+
+def show_cpu_irq_stats(prog: Program, cpu: int) -> None:
+    """
+    Show irq stats for specified cpu.
+
+    :param prog: drgn program
+    :param cpu: cpu index
+
+    :return: None
+    """
+    total_irqs_on_cpu = 0
+    print(f"IRQ stats for cpu: {cpu}")
+    for irq in for_each_irq(prog):
+        if irq_in_use(prog, irq) and irq_has_action(prog, irq):
+            kstat_irqs = _kstat_irqs_cpu(prog, irq, cpu)
+            if not kstat_irqs:
+                continue
+
+            desc = irq_to_desc(prog, irq)
+            name = escape_ascii_string(
+                desc.action.name.string_(), escape_backslash=True
+            )
+            print(
+                f"    irq: {irq} name: {name} ({desc.type_.type_name()})0x{desc.value_():x} count: {kstat_irqs}"
+            )
+            total_irqs_on_cpu += kstat_irqs
+
+    print(f"Total: {total_irqs_on_cpu}")
+
+
+def show_each_cpu_irq_stats(prog: Program) -> None:
+    """
+    Show irq stats for each cpu.
+
+    :param prog: drgn program
+
+    :return: None
+    """
+    for cpu in for_each_present_cpu(prog):
+        show_cpu_irq_stats(prog, cpu)
+        print("\n")
+
+
+def print_irq_affinity(prog: Program, irq: int) -> None:
+    """
+    Print cpu affinity of specified irq.
+
+    :param prog: drgn program
+    :param irq: irq number
+
+    :return: None
+    """
+
+    if not irq_in_use(prog, irq):
+        print(f"irq: {irq} is not in use")
+        return
+
+    if not irq_has_action(prog, irq):
+        print(f"irq: {irq} has no handlers registered")
+        return
+
+    desc = irq_to_desc(prog, irq)
+    name = escape_ascii_string(
+        desc.action.name.string_(), escape_backslash=True
+    )
+    affinity = get_irq_affinity_list(prog, irq)
+    print(f"irq: {irq} name: {name} affinity: {affinity}")
+
+
+def print_irqs_affinities(prog: Program) -> None:
+    """
+    Print cpu affinities for all irqs in use.
+
+    :param prog: drgn program
+
+    :return: None
+    """
+    for irq in for_each_irq(prog):
+        if irq_in_use(prog, irq) and irq_has_action(prog, irq):
+            print_irq_affinity(prog, irq)
+
+
+def print_all_irqs(prog: Program) -> None:
+    """
+    Print number, name, ``struct irq_desc *`` and ``struct irqaction *`` for all irqs in use.
+
+    :param prog: drgn program
+
+    :return: None
+    """
+    for irq in for_each_irq(prog):
+        if irq_in_use(prog, irq) and irq_has_action(prog, irq):
+            desc = irq_to_desc(prog, irq)
+            name = escape_ascii_string(
+                desc.action.name.string_(), escape_backslash=True
+            )
+            print(
+                f"irq: {irq} name: {name} ({desc.type_.type_name()})0x{desc.value_():x}  ({desc.action.type_.type_name()})0x{desc.action.value_():x}"
+            )
+
+
+print("###################################################")
+print("List of IRQs")
+print("###################################################")
+print_all_irqs(prog)
+print("\n")
+
+print("###################################################")
+print("IRQ affinities")
+print("###################################################")
+print_irqs_affinities(prog)
+print("\n")
+
+print("###################################################")
+print("IRQ stats")
+print("###################################################")
+show_irq_stats(prog)
+print("\n")
+
+print("###################################################")
+print("cpuwise IRQ stats")
+print("###################################################")
+show_each_cpu_irq_stats(prog)
+print("\n")

--- a/drgn/helpers/linux/cpumask.py
+++ b/drgn/helpers/linux/cpumask.py
@@ -19,6 +19,7 @@ __all__ = (
     "for_each_online_cpu",
     "for_each_possible_cpu",
     "for_each_present_cpu",
+    "cpumask_to_cpulist",
 )
 
 
@@ -60,3 +61,30 @@ def for_each_possible_cpu(prog: Program) -> Iterator[int]:
 def for_each_present_cpu(prog: Program) -> Iterator[int]:
     """Iterate over all present CPUs."""
     return _for_each_cpu_mask(prog, "__cpu_present_mask")
+
+
+def cpumask_to_cpulist(mask: Object) -> str:
+    """
+    Return a CPU mask as a CPU list string.
+
+    >>> cpumask_to_cpulist(mask)
+    0-3,8-11
+
+    :param mask: ``struct cpumask *``
+    :return: String in the `CPU list format
+    <https://man7.org/linux/man-pages/man7/cpuset.7.html#:~:text=List%20format>`
+    """
+    cpulist = [cpu for cpu in for_each_cpu(mask)]
+
+    start = end = -2
+    parts = []
+    for cpu in cpulist:
+        if cpu == end + 1:
+            end = cpu
+        else:
+            if start >= 0:
+                parts.append(str(start) if start == end else f"{start}-{end}")
+            start = end = cpu
+    if start >= 0:
+        parts.append(str(start) if start == end else f"{start}-{end}")
+    return ",".join(parts)

--- a/drgn/helpers/linux/cpumask.py
+++ b/drgn/helpers/linux/cpumask.py
@@ -15,11 +15,11 @@ from drgn import Object, Program
 from drgn.helpers.linux.bitops import for_each_set_bit
 
 __all__ = (
+    "cpumask_to_cpulist",
     "for_each_cpu",
     "for_each_online_cpu",
     "for_each_possible_cpu",
     "for_each_present_cpu",
-    "cpumask_to_cpulist",
 )
 
 
@@ -72,13 +72,11 @@ def cpumask_to_cpulist(mask: Object) -> str:
 
     :param mask: ``struct cpumask *``
     :return: String in the `CPU list format
-    <https://man7.org/linux/man-pages/man7/cpuset.7.html#:~:text=List%20format>`
+        <https://man7.org/linux/man-pages/man7/cpuset.7.html#FORMATS>`_.
     """
-    cpulist = [cpu for cpu in for_each_cpu(mask)]
-
     start = end = -2
     parts = []
-    for cpu in cpulist:
+    for cpu in for_each_cpu(mask):
         if cpu == end + 1:
             end = cpu
         else:


### PR DESCRIPTION
script to dump irq stats.

A sample output:

python3 -m drgn -s ~/Local-vmcores/sched-study/v4.14/vmlinux -c ~/Local-vmcores/sched-study/v4.14/vmcore contrib/irq.py 
warning: could not get debugging information for:
kernel modules (could not read depmod: open: /lib/modules/4.14.307/modules.dep.bin: No such file or directory)
###################################################
List of IRQs
###################################################
irq: 0 name: timer (struct irq_desc *)0xffff9b42fd00d400  (struct irqaction *)0xffffffff88425240
irq: 1 name: i8042 (struct irq_desc *)0xffff9b42fd00d600  (struct irqaction *)0xffff9b42fcb13c00
irq: 4 name: ttyS0 (struct irq_desc *)0xffff9b42fd00dc00  (struct irqaction *)0xffff9b42fcb2bc00
irq: 8 name: rtc0 (struct irq_desc *)0xffff9b42fd00e400  (struct irqaction *)0xffff9b42fcb59380
irq: 9 name: acpi (struct irq_desc *)0xffff9b42fd00e600  (struct irqaction *)0xffff9b42fcafca80
irq: 11 name: eth0 (struct irq_desc *)0xffff9b42fd00ea00  (struct irqaction *)0xffff9b42fc878d80
irq: 12 name: i8042 (struct irq_desc *)0xffff9b42fd00ec00  (struct irqaction *)0xffff9b42fcb13900
irq: 14 name: ata_piix (struct irq_desc *)0xffff9b42fd00f000  (struct irqaction *)0xffff9b42fc690800
irq: 15 name: ata_piix (struct irq_desc *)0xffff9b42fd00f200  (struct irqaction *)0xffff9b42fc690780


###################################################
IRQ affinities
###################################################
irq: 0 name: timer affinity: 0-7
irq: 1 name: i8042 affinity: 0-7
irq: 4 name: ttyS0 affinity: 0-7
irq: 8 name: rtc0 affinity: 0-7
irq: 9 name: acpi affinity: 0-7
irq: 11 name: eth0 affinity: 0-7
irq: 12 name: i8042 affinity: 0-7
irq: 14 name: ata_piix affinity: 0-7
irq: 15 name: ata_piix affinity: 0-7


###################################################
IRQ stats
###################################################
irq: 0 name: timer (struct irq_desc *)0xffff9b42fd00d400
    CPU: 0  	 count: 162
    Total: 162
irq: 1 name: i8042 (struct irq_desc *)0xffff9b42fd00d600
    CPU: 0  	 count: 10
    Total: 10
irq: 4 name: ttyS0 (struct irq_desc *)0xffff9b42fd00dc00
    CPU: 0  	 count: 220
    Total: 220
irq: 8 name: rtc0 (struct irq_desc *)0xffff9b42fd00e400
    CPU: 0  	 count: 1
    Total: 1
    Total: 0
irq: 11 name: eth0 (struct irq_desc *)0xffff9b42fd00ea00
    CPU: 0  	 count: 85
    Total: 85
irq: 12 name: i8042 (struct irq_desc *)0xffff9b42fd00ec00
    CPU: 0  	 count: 125
    Total: 125
irq: 14 name: ata_piix (struct irq_desc *)0xffff9b42fd00f000
    CPU: 0  	 count: 496
    Total: 496
irq: 15 name: ata_piix (struct irq_desc *)0xffff9b42fd00f200
    CPU: 0  	 count: 11
    Total: 11


###################################################
cpuwise IRQ stats
###################################################
IRQ stats for cpu: 0
    irq: 0 name: timer (struct irq_desc *)0xffff9b42fd00d400 count: 162
    irq: 1 name: i8042 (struct irq_desc *)0xffff9b42fd00d600 count: 10
    irq: 4 name: ttyS0 (struct irq_desc *)0xffff9b42fd00dc00 count: 220
    irq: 8 name: rtc0 (struct irq_desc *)0xffff9b42fd00e400 count: 1
    irq: 11 name: eth0 (struct irq_desc *)0xffff9b42fd00ea00 count: 85
    irq: 12 name: i8042 (struct irq_desc *)0xffff9b42fd00ec00 count: 125
    irq: 14 name: ata_piix (struct irq_desc *)0xffff9b42fd00f000 count: 496
    irq: 15 name: ata_piix (struct irq_desc *)0xffff9b42fd00f200 count: 11
Total: 1110


IRQ stats for cpu: 1
Total: 0


IRQ stats for cpu: 2
Total: 0


IRQ stats for cpu: 3
Total: 0


IRQ stats for cpu: 4
Total: 0


IRQ stats for cpu: 5
Total: 0


IRQ stats for cpu: 6
Total: 0


IRQ stats for cpu: 7
Total:0