### PR TITLE
libdrgn: add support for remote debugging via OpenOCD

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -837,6 +837,11 @@ class ProgramFlags(enum.Flag):
     kernel or a running process).
     """
 
+    IS_LOCAL = ...
+    """
+    The program is running on the local machine.
+    """
+
 class FindObjectFlags(enum.Flag):
     """
     ``FindObjectFlags`` are flags for :meth:`Program.object()`. These can be

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -398,6 +398,43 @@ explicitly::
             int counter;
     } atomic_t
 
+Remote Debugging
+^^^^^^^^^^^^^^^^
+
+drgn supports remote kernel debugging using `OpenOCD
+<https://www.openocd.org/>`_ as an interface to a JTAG/SWD debug adapter
+connected to a remote target. To use the remote debugging feature,
+you must have the following information about your target.
+
+* A suitable OpenOCD configuration file for your target.
+* The name of the Test Access Point (TAP) which may be used to access the
+  physical memory where the kernel is running. The TAP name will 
+  be specified in the OpenOCD configuration file.
+* The load address of the kernel in the target's physical memory.
+
+You must also have debugging symbols for the kernel running on your target
+(i.e. the ``vmlinux`` file).
+
+To begin the debugging session, ensure that your target is running the
+kernel and that OpenOCD is running and connected to your target. Then
+issue the following command, making the necessary substitutions::
+
+    $ drgn --openocd /path/to/vmlinux --openocd-tap $TAP_NAME --openocd-addr $LOAD_ADDR
+
+Debug information for the specified kernel will be loaded automatically,
+but there is currently no support for automatically loading debug
+information for loaded kernel modules. Debug information for modules
+must be loaded manually using :meth:`drgn.Program.load_debug_info()`.
+
+drgn may also be used to debug microcontroller firmware and other
+bare-metal MMU-less programs. To do this, you must have debugging
+symbols for your firmware. To begin debugging, ensure that your target
+is running the firmware and that OpenOCD is running and connected to
+your target. Then issue the following command, making the necessary
+substitutions::
+
+    $ drgn --openocd /path/to/firmware.elf --openocd-tap $TAP_NAME --openocd-nommu
+
 Next Steps
 ----------
 

--- a/libdrgn/arch_aarch64.c
+++ b/libdrgn/arch_aarch64.c
@@ -466,6 +466,12 @@ linux_kernel_pgtable_iterator_next_aarch64(struct drgn_program *prog,
 	}
 }
 
+static uint64_t untagged_addr_aarch64(uint64_t addr)
+{
+	/* Apply TBI by sign extending bit 55 into bits 56-63. */
+	return (((int64_t)addr) << 8) >> 8;
+}
+
 const struct drgn_architecture_info arch_info_aarch64 = {
 	.name = "AArch64",
 	.arch = DRGN_ARCH_AARCH64,
@@ -488,4 +494,5 @@ const struct drgn_architecture_info arch_info_aarch64 = {
 		linux_kernel_pgtable_iterator_init_aarch64,
 	.linux_kernel_pgtable_iterator_next =
 		linux_kernel_pgtable_iterator_next_aarch64,
+	.untagged_addr = untagged_addr_aarch64,
 };

--- a/libdrgn/arch_aarch64.c
+++ b/libdrgn/arch_aarch64.c
@@ -275,8 +275,8 @@ struct pgtable_iterator_aarch64 {
 	int levels;
 	uint16_t entries_per_level;
 	uint16_t last_level_num_entries;
-	uint16_t *index;
-	uint64_t *table;
+	uint64_t cached_virt_addr;
+	uint64_t table[5];
 	uint64_t pa_low_mask;
 	uint64_t pa_high_mask;
 };
@@ -334,18 +334,10 @@ linux_kernel_pgtable_iterator_create_aarch64(struct drgn_program *prog,
 
 	it->levels = ((va_bits - page_shift + pgtable_shift - 1) /
 		      pgtable_shift);
+	assert(it->levels <= sizeof(it->table) / sizeof(it->table[0]));
 	it->entries_per_level = 1 << pgtable_shift;
 	it->last_level_num_entries =
 		1 << ((va_bits - page_shift - 1) % pgtable_shift + 1);
-
-	it->index = malloc_array(it->levels, sizeof(it->index[0]));
-	if (!it->index)
-		goto err_it;
-	it->table = malloc_array((size_t)(it->levels - 1) * it->entries_per_level
-				 + it->last_level_num_entries,
-				 sizeof(it->table[0]));
-	if (!it->table)
-		goto err_index;
 
 	// Descriptor bits [47:PAGE_SHIFT] contain physical address bits
 	// [47:PAGE_SHIFT].
@@ -371,8 +363,6 @@ linux_kernel_pgtable_iterator_create_aarch64(struct drgn_program *prog,
 	*ret = &it->it;
 	return NULL;
 
-err_index:
-	free(it->index);
 err_it:
 	free(it);
 	return &drgn_enomem;
@@ -382,8 +372,6 @@ static void linux_kernel_pgtable_iterator_destroy_aarch64(struct pgtable_iterato
 {
 	struct pgtable_iterator_aarch64 *it =
 		container_of(_it, struct pgtable_iterator_aarch64, it);
-	free(it->table);
-	free(it->index);
 	free(it);
 }
 
@@ -400,7 +388,9 @@ static void linux_kernel_pgtable_iterator_init_aarch64(struct drgn_program *prog
 		it->va_range_max =
 			(UINT64_C(1) << prog->vmcoreinfo.va_bits) - 1;
 	}
-	memset(it->index, 0xff, it->levels * sizeof(it->index[0]));
+
+	it->cached_virt_addr = 0;
+	memset(it->table, 0, sizeof(it->table));
 }
 
 static struct drgn_error *
@@ -409,7 +399,6 @@ linux_kernel_pgtable_iterator_next_aarch64(struct drgn_program *prog,
 					   uint64_t *virt_addr_ret,
 					   uint64_t *phys_addr_ret)
 {
-	struct drgn_error *err;
 	const uint64_t page_shift = prog->vmcoreinfo.page_shift;
 	const uint64_t pgtable_shift = page_shift - 3;
 	const bool bswap = drgn_platform_bswap(&prog->platform);
@@ -417,70 +406,63 @@ linux_kernel_pgtable_iterator_next_aarch64(struct drgn_program *prog,
 		container_of(_it, struct pgtable_iterator_aarch64, it);
 	const uint64_t virt_addr = it->it.virt_addr;
 	int level;
+	uint16_t num_entries = it->last_level_num_entries;
+	uint64_t table = it->it.pgtable;
+	bool table_physical = false;
 
-	// Find the lowest level with cached entries.
-	for (level = 0; level < it->levels - 1; level++) {
-		if (it->index[level] < it->entries_per_level)
-			break;
+	if (virt_addr < it->va_range_min ||
+	    virt_addr > it->va_range_max) {
+		*virt_addr_ret = it->va_range_min;
+		*phys_addr_ret = UINT64_MAX;
+		it->it.virt_addr = it->va_range_max + 1;
+		return NULL;
 	}
-	if (level == it->levels - 1 &&
-	    it->index[level] >= it->last_level_num_entries)
-		level++;
-	// For every level below that, refill the cache/return pages.
-	for (;; level--) {
-		uint16_t num_entries;
-		uint64_t table;
-		bool table_physical;
-		if (level == it->levels) {
-			num_entries = it->last_level_num_entries;
-			if (virt_addr < it->va_range_min ||
-			    virt_addr > it->va_range_max) {
-				*virt_addr_ret = it->va_range_min;
-				*phys_addr_ret = UINT64_MAX;
-				it->it.virt_addr = it->va_range_max + 1;
-				return NULL;
+
+	for (level = it->levels;; level--) {
+		uint8_t level_shift = page_shift + pgtable_shift * (level - 1);
+		uint16_t index = (virt_addr >> level_shift) & (num_entries - 1);
+		uint16_t cached_index = (it->cached_virt_addr >> level_shift) &
+					(num_entries - 1);
+		if (index != cached_index)
+			memset(it->table, 0, 8 * level);
+		uint64_t *entry_ptr = &it->table[level - 1];
+		if (!*entry_ptr) {
+			struct drgn_error *err = drgn_program_read_memory(
+			    prog, entry_ptr, table + 8 * index, 8,
+			    table_physical);
+			if (err) {
+				it->cached_virt_addr = 0;
+				memset(it->table, 0, sizeof(it->table));
+				return err;
 			}
-			table = it->it.pgtable;
-			table_physical = false;
-		} else {
-			num_entries = it->entries_per_level;
-			uint64_t entry = it->table[level * num_entries + it->index[level]++];
 			if (bswap)
-				entry = bswap_64(entry);
-			table = ((entry & it->pa_low_mask) |
-				 (entry & it->pa_high_mask) << 36);
-			// Descriptor bits [1:0] identify the descriptor type:
-			//
-			// 0x0, 0x2: invalid
-			// 0x1: lowest level: reserved, invalid
-			//      higher levels: block
-			// 0x3: lowest level: page
-			//      higher levels: table
-			if ((entry & 0x3) != 0x3 || level == 0) {
-				uint64_t mask = (UINT64_C(1) <<
-						 (page_shift +
-						  pgtable_shift * level)) - 1;
-				*virt_addr_ret = virt_addr & ~mask;
-				if ((entry & 0x3) == (level == 0 ? 0x3 : 0x1))
-					*phys_addr_ret = table & ~mask;
-				else
-					*phys_addr_ret = UINT64_MAX;
-				it->it.virt_addr = (virt_addr | mask) + 1;
-				return NULL;
-			}
-			table_physical = true;
+				*entry_ptr = bswap_64(*entry_ptr);
 		}
-		uint16_t index = ((virt_addr >>
-				   (page_shift + pgtable_shift * (level - 1)))
-				  & (num_entries - 1));
-		err = drgn_program_read_memory(prog,
-					       &it->table[(level - 1) * it->entries_per_level + index],
-					       table + 8 * index,
-					       8 * (num_entries - index),
-					       table_physical);
-		if (err)
-			return err;
-		it->index[level - 1] = index;
+		uint64_t entry = *entry_ptr;
+
+		num_entries = it->entries_per_level;
+		table = ((entry & it->pa_low_mask) |
+			 (entry & it->pa_high_mask) << 36);
+
+		// Descriptor bits [1:0] identify the descriptor type:
+		//
+		// 0x0, 0x2: invalid
+		// 0x1: lowest level: reserved, invalid
+		//      higher levels: block
+		// 0x3: lowest level: page
+		//      higher levels: table
+		if ((entry & 0x3) != 0x3 || level == 1) {
+			uint64_t mask = (UINT64_C(1) << level_shift) - 1;
+			*virt_addr_ret = virt_addr & ~mask;
+			if ((entry & 0x3) == (level == 1 ? 0x3 : 0x1))
+				*phys_addr_ret = table & ~mask;
+			else
+				*phys_addr_ret = UINT64_MAX;
+			it->cached_virt_addr = virt_addr;
+			it->it.virt_addr = (virt_addr | mask) + 1;
+			return NULL;
+		}
+		table_physical = true;
 	}
 }
 

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -490,6 +490,8 @@ enum drgn_program_flags {
 	DRGN_PROGRAM_IS_LINUX_KERNEL = (1 << 0),
 	/** The program is currently running. */
 	DRGN_PROGRAM_IS_LIVE = (1 << 1),
+	/** The program is running on the local machine. */
+	DRGN_PROGRAM_IS_LOCAL = (1 << 2),
 };
 
 /**

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -793,7 +793,8 @@ struct drgn_error *drgn_program_read_memory(struct drgn_program *prog,
 struct drgn_error *drgn_program_read_c_string(struct drgn_program *prog,
 					      uint64_t address, bool physical,
 					      size_t max_size,
-					      struct string_builder *str);
+					      struct string_builder *str,
+					      bool *done);
 
 struct drgn_error *drgn_program_read_u8(struct drgn_program *prog,
 					uint64_t address, bool physical,

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -685,6 +685,26 @@ struct drgn_error *drgn_program_set_core_dump(struct drgn_program *prog,
 struct drgn_error *drgn_program_set_kernel(struct drgn_program *prog);
 
 /**
+ * Set a @ref drgn_program to a running operating system kernel on a remote
+ * target accessible via OpenOCD.
+ *
+ * @param[in] vmlinux The path to the kernel vmlinux binary.
+ * @param[in] tap The name of the Test Access Port (TAP) providing access to
+ * the physical memory where the kernel is running.
+ * @param[in] mmu Whether this program uses the MMU. True for the Linux
+ * kernel, but may be set to false to debug an MMU-less program such as a
+ * bootloader or microcontroller firmware.
+ * @param[in] text_pa The kernel load address in physical memory. Only used
+ * if @p mmu is true.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_set_openocd(struct drgn_program *prog,
+					    const char *vmlinux,
+					    const char *host, const char *port,
+					    const char *tap, bool mmu,
+					    uint64_t text_pa);
+
+/**
  * Set a @ref drgn_program to a running process.
  *
  * @sa drgn_program_from_pid()

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -530,6 +530,30 @@ typedef struct drgn_error *(*drgn_memory_read_fn)(void *buf, uint64_t address,
 						  size_t count, uint64_t offset,
 						  void *arg, bool physical);
 
+struct string_builder;
+
+/**
+ * Callback implementing a memory read of a C string.
+ *
+ * @param[out] str String builder to read into.
+ * @param[out] done Whether we were able to read the whole string.
+ * @param[in] address Address which we are reading from.
+ * @param[in] limit Maximum number of bytes to read.
+ * @param[in] offset Offset in bytes of @p address from the beginning of the
+ * segment.
+ * @param[in] arg Argument passed to @ref drgn_program_add_memory_segment().
+ * @param[in] physical Whether @c address is physical.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+typedef struct drgn_error *(*drgn_memory_read_cstr_fn)(
+	struct string_builder *str, bool *done, uint64_t address, size_t limit,
+	uint64_t offset, void *arg, bool physical);
+
+struct drgn_memory_ops {
+	drgn_memory_read_fn read_fn;
+	drgn_memory_read_cstr_fn read_cstr_fn;
+};
+
 /**
  * Register a segment of memory in a @ref drgn_program.
  *
@@ -539,14 +563,14 @@ typedef struct drgn_error *(*drgn_memory_read_fn)(void *buf, uint64_t address,
  *
  * @param[in] address Address of the segment.
  * @param[in] size Size of the segment in bytes.
- * @param[in] read_fn Callback to read from segment.
+ * @param[in] ops Memory operations for this segment.
  * @param[in] arg Argument to pass to @p read_fn.
  * @param[in] physical Whether to add a physical memory segment.
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *
 drgn_program_add_memory_segment(struct drgn_program *prog, uint64_t address,
-				uint64_t size, drgn_memory_read_fn read_fn,
+				uint64_t size, const struct drgn_memory_ops *ops,
 				void *arg, bool physical);
 
 /**
@@ -760,13 +784,14 @@ struct drgn_error *drgn_program_read_memory(struct drgn_program *prog,
  * drgn_program_read_memory().
  * @param[in] max_size Stop after this many bytes are read, not including the
  * null byte. A null byte is appended to @p ret in this case.
- * @param[out] ret Returned string. On success, it must be freed with @c free().
+ * @param[out] str String builder for the returned string. Owned by the caller.
  * On error, its contents are undefined.
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *drgn_program_read_c_string(struct drgn_program *prog,
 					      uint64_t address, bool physical,
-					      size_t max_size, char **ret);
+					      size_t max_size,
+					      struct string_builder *str);
 
 struct drgn_error *drgn_program_read_u8(struct drgn_program *prog,
 					uint64_t address, bool physical,

--- a/libdrgn/drgn_program_parse_vmcoreinfo.inc.strswitch
+++ b/libdrgn/drgn_program_parse_vmcoreinfo.inc.strswitch
@@ -59,6 +59,7 @@ struct drgn_error *drgn_program_parse_vmcoreinfo(struct drgn_program *prog,
 						   &prog->vmcoreinfo.swapper_pg_dir);
 			if (err)
 				return err;
+			prog->vmcoreinfo.swapper_pg_dir_phys = false;
 			break;
 		@case "LENGTH(mem_section)"@
 			err = parse_vmcoreinfo_u64(value, newline, 0,

--- a/libdrgn/helpers.h
+++ b/libdrgn/helpers.h
@@ -25,16 +25,18 @@ struct drgn_error *linux_helper_direct_mapping_offset(struct drgn_program *prog,
 						      uint64_t *ret);
 
 struct drgn_error *linux_helper_read_vm(struct drgn_program *prog,
-					uint64_t pgtable, uint64_t virt_addr,
-					void *buf, size_t count);
+					uint64_t pgtable, bool pgtable_phys,
+					uint64_t virt_addr, void *buf,
+					size_t count);
 
 struct drgn_error *linux_helper_read_cstr(struct drgn_program *prog,
-					  uint64_t pgtable, uint64_t virt_addr,
+					  uint64_t pgtable, bool pgtable_phys,
+					  uint64_t virt_addr,
 					  struct string_builder *str,
 					  bool *done, size_t count);
 
 struct drgn_error *linux_helper_follow_phys(struct drgn_program *prog,
-					    uint64_t pgtable,
+					    uint64_t pgtable, bool pgtable_phys,
 					    uint64_t virt_addr, uint64_t *ret);
 
 struct drgn_error *linux_helper_per_cpu_ptr(struct drgn_object *res,

--- a/libdrgn/helpers.h
+++ b/libdrgn/helpers.h
@@ -28,6 +28,11 @@ struct drgn_error *linux_helper_read_vm(struct drgn_program *prog,
 					uint64_t pgtable, uint64_t virt_addr,
 					void *buf, size_t count);
 
+struct drgn_error *linux_helper_read_cstr(struct drgn_program *prog,
+					  uint64_t pgtable, uint64_t virt_addr,
+					  struct string_builder *str,
+					  bool *done, size_t count);
+
 struct drgn_error *linux_helper_follow_phys(struct drgn_program *prog,
 					    uint64_t pgtable,
 					    uint64_t virt_addr, uint64_t *ret);

--- a/libdrgn/language_c.c
+++ b/libdrgn/language_c.c
@@ -644,24 +644,26 @@ c_format_string(struct drgn_program *prog, uint64_t address, uint64_t length,
 		struct string_builder *sb)
 {
 	struct drgn_error *err;
+	struct string_builder tmp = STRING_BUILDER_INIT;
 
-	if (!string_builder_appendc(sb, '"'))
-		return &drgn_enomem;
-	while (length) {
-		unsigned char c;
-		err = drgn_program_read_memory(prog, &c, address++, 1, false);
-		if (err)
-			return err;
-
-		if (c == '\0') {
-			break;
-		} else {
-			err = c_format_character(c, false, true, sb);
-			if (err)
-				return err;
-		}
-		length--;
+	err = drgn_program_read_c_string(prog, address, false, length, &tmp);
+	if (err) {
+		free(tmp.str);
+		return err;
 	}
+
+	if (!string_builder_appendc(sb, '"')) {
+		free(tmp.str);
+		return &drgn_enomem;
+	}
+	for (size_t i = 0; i != tmp.len; ++i) {
+		err = c_format_character(tmp.str[i], false, true, sb);
+		if (err) {
+			free(tmp.str);
+			return err;
+		}
+	}
+	free(tmp.str);
 	if (!string_builder_appendc(sb, '"'))
 		return &drgn_enomem;
 	return NULL;

--- a/libdrgn/language_c.c
+++ b/libdrgn/language_c.c
@@ -645,8 +645,10 @@ c_format_string(struct drgn_program *prog, uint64_t address, uint64_t length,
 {
 	struct drgn_error *err;
 	struct string_builder tmp = STRING_BUILDER_INIT;
+	bool done;
 
-	err = drgn_program_read_c_string(prog, address, false, length, &tmp);
+	err = drgn_program_read_c_string(prog, address, false, length, &tmp,
+	                                 &done);
 	if (err) {
 		free(tmp.str);
 		return err;

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -1572,7 +1572,7 @@ report_kernel_modules(struct drgn_debug_info_load_state *load,
 	 * can be disabled via an environment variable for testing.
 	 */
 	bool use_sys_module = false;
-	if (prog->flags & DRGN_PROGRAM_IS_LIVE) {
+	if (prog->flags & DRGN_PROGRAM_IS_LOCAL) {
 		char *env = getenv("DRGN_USE_SYS_MODULE");
 		use_sys_module = !env || atoi(env);
 	}

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -32,14 +32,29 @@
 
 #include "drgn_program_parse_vmcoreinfo.inc"
 
-struct drgn_error *read_memory_via_pgtable(void *buf, uint64_t address,
-					   size_t count, uint64_t offset,
-					   void *arg, bool physical)
+static struct drgn_error *read_memory_via_pgtable(void *buf, uint64_t address,
+						  size_t count, uint64_t offset,
+						  void *arg, bool physical)
 {
 	struct drgn_program *prog = arg;
 	return linux_helper_read_vm(prog, prog->vmcoreinfo.swapper_pg_dir,
 				    address, buf, count);
 }
+
+static struct drgn_error *read_cstr_via_pgtable(struct string_builder *str,
+						bool *done, uint64_t address,
+						size_t limit, uint64_t offset,
+						void *arg, bool physical)
+{
+	struct drgn_program *prog = arg;
+	return linux_helper_read_cstr(prog, prog->vmcoreinfo.swapper_pg_dir,
+				      address, str, done, limit);
+}
+
+const struct drgn_memory_ops segment_pgtable_ops = {
+	.read_fn = read_memory_via_pgtable,
+	.read_cstr_fn = read_cstr_via_pgtable,
+};
 
 struct drgn_error *proc_kallsyms_symbol_addr(const char *name,
 					     unsigned long *ret)

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -38,6 +38,7 @@ static struct drgn_error *read_memory_via_pgtable(void *buf, uint64_t address,
 {
 	struct drgn_program *prog = arg;
 	return linux_helper_read_vm(prog, prog->vmcoreinfo.swapper_pg_dir,
+				    prog->vmcoreinfo.swapper_pg_dir_phys,
 				    address, buf, count);
 }
 
@@ -48,6 +49,7 @@ static struct drgn_error *read_cstr_via_pgtable(struct string_builder *str,
 {
 	struct drgn_program *prog = arg;
 	return linux_helper_read_cstr(prog, prog->vmcoreinfo.swapper_pg_dir,
+				      prog->vmcoreinfo.swapper_pg_dir_phys,
 				      address, str, done, limit);
 }
 
@@ -328,7 +330,7 @@ unrecognized_mem_section_type:
 	}
 
 	// Find a valid section.
-	for (uint64_t i = 0; i < nr_section_roots; i++) {
+	for (uint64_t i = 0; !nr_section_roots || i < nr_section_roots; i++) {
 		err = drgn_object_subscript(&root, &mem_section, i);
 		if (err)
 			goto out;

--- a/libdrgn/linux_kernel.h
+++ b/libdrgn/linux_kernel.h
@@ -8,9 +8,7 @@
 
 struct drgn_debug_info_load_state;
 
-struct drgn_error *read_memory_via_pgtable(void *buf, uint64_t address,
-					   size_t count, uint64_t offset,
-					   void *arg, bool physical);
+extern const struct drgn_memory_ops segment_pgtable_ops;
 
 struct drgn_error *drgn_program_parse_vmcoreinfo(struct drgn_program *prog,
 						 const char *desc,

--- a/libdrgn/linux_kernel_helpers.c
+++ b/libdrgn/linux_kernel_helpers.c
@@ -190,6 +190,57 @@ out:
 	return err;
 }
 
+struct drgn_error *linux_helper_read_cstr(struct drgn_program *prog,
+					  uint64_t pgtable, uint64_t virt_addr,
+					  struct string_builder *str,
+					  bool *done, size_t count)
+{
+	struct drgn_error *err;
+
+	err = begin_virtual_address_translation(prog, pgtable, virt_addr);
+	if (err)
+		return err;
+	if (!count) {
+		*done = false;
+		err = NULL;
+		goto out;
+	}
+
+	struct pgtable_iterator *it = prog->pgtable_it;
+	pgtable_iterator_next_fn *next =
+		prog->platform.arch->linux_kernel_pgtable_iterator_next;
+	uint64_t read_addr = 0;
+	size_t read_size = 0;
+	virt_addr = it->virt_addr;
+	do {
+		uint64_t start_virt_addr, start_phys_addr;
+		err = next(prog, it, &start_virt_addr, &start_phys_addr);
+		if (err)
+			break;
+		if (start_phys_addr == UINT64_MAX) {
+			err = drgn_error_create_fault("address is not mapped",
+						      virt_addr);
+			break;
+		}
+
+		uint64_t phys_addr =
+			start_phys_addr + (virt_addr - start_virt_addr);
+		size_t n = min(it->virt_addr - virt_addr, (uint64_t)count);
+		err = drgn_memory_reader_read_cstr(&prog->reader, str, done,
+						   phys_addr, n, true);
+		if (err)
+			break;
+		if (*done)
+			goto out;
+		virt_addr = it->virt_addr;
+		count -= n;
+	} while (count);
+
+out:
+	end_virtual_address_translation(prog);
+	return err;
+}
+
 struct drgn_error *linux_helper_follow_phys(struct drgn_program *prog,
 					    uint64_t pgtable,
 					    uint64_t virt_addr, uint64_t *ret)

--- a/libdrgn/linux_kernel_helpers.c
+++ b/libdrgn/linux_kernel_helpers.c
@@ -18,7 +18,7 @@ static void end_virtual_address_translation(struct drgn_program *prog)
 
 static struct drgn_error *
 begin_virtual_address_translation(struct drgn_program *prog, uint64_t pgtable,
-				  uint64_t virt_addr)
+				  bool pgtable_phys, uint64_t virt_addr)
 {
 	struct drgn_error *err;
 
@@ -53,6 +53,7 @@ begin_virtual_address_translation(struct drgn_program *prog, uint64_t pgtable,
 		}
 	}
 	prog->pgtable_it->pgtable = pgtable;
+	prog->pgtable_it->pgtable_phys = pgtable_phys;
 	prog->pgtable_it->virt_addr = virt_addr;
 	prog->platform.arch->linux_kernel_pgtable_iterator_init(prog, prog->pgtable_it);
 	return NULL;
@@ -107,6 +108,7 @@ struct drgn_error *linux_helper_direct_mapping_offset(struct drgn_program *prog,
 
 	err = begin_virtual_address_translation(prog,
 						prog->vmcoreinfo.swapper_pg_dir,
+						prog->vmcoreinfo.swapper_pg_dir_phys,
 						virt_addr);
 	if (err)
 		return err;
@@ -132,12 +134,13 @@ out:
 }
 
 struct drgn_error *linux_helper_read_vm(struct drgn_program *prog,
-					uint64_t pgtable, uint64_t virt_addr,
-					void *buf, size_t count)
+					uint64_t pgtable, bool pgtable_phys,
+					uint64_t virt_addr, void *buf,
+					size_t count)
 {
 	struct drgn_error *err;
 
-	err = begin_virtual_address_translation(prog, pgtable, virt_addr);
+	err = begin_virtual_address_translation(prog, pgtable, pgtable_phys, virt_addr);
 	if (err)
 		return err;
 	if (!count) {
@@ -191,13 +194,14 @@ out:
 }
 
 struct drgn_error *linux_helper_read_cstr(struct drgn_program *prog,
-					  uint64_t pgtable, uint64_t virt_addr,
+					  uint64_t pgtable, bool pgtable_phys,
+					  uint64_t virt_addr,
 					  struct string_builder *str,
 					  bool *done, size_t count)
 {
 	struct drgn_error *err;
 
-	err = begin_virtual_address_translation(prog, pgtable, virt_addr);
+	err = begin_virtual_address_translation(prog, pgtable, pgtable_phys, virt_addr);
 	if (err)
 		return err;
 	if (!count) {
@@ -242,12 +246,12 @@ out:
 }
 
 struct drgn_error *linux_helper_follow_phys(struct drgn_program *prog,
-					    uint64_t pgtable,
+					    uint64_t pgtable, bool pgtable_phys,
 					    uint64_t virt_addr, uint64_t *ret)
 {
 	struct drgn_error *err;
 
-	err = begin_virtual_address_translation(prog, pgtable, virt_addr);
+	err = begin_virtual_address_translation(prog, pgtable, pgtable_phys, virt_addr);
 	if (err)
 		return err;
 

--- a/libdrgn/linux_kernel_helpers.c
+++ b/libdrgn/linux_kernel_helpers.c
@@ -226,8 +226,8 @@ struct drgn_error *linux_helper_read_cstr(struct drgn_program *prog,
 		uint64_t phys_addr =
 			start_phys_addr + (virt_addr - start_virt_addr);
 		size_t n = min(it->virt_addr - virt_addr, (uint64_t)count);
-		err = drgn_memory_reader_read_cstr(&prog->reader, str, done,
-						   phys_addr, n, true);
+		err = drgn_program_read_c_string(prog, phys_addr, true, n, str,
+						 done);
 		if (err)
 			break;
 		if (*done)

--- a/libdrgn/memory_reader.h
+++ b/libdrgn/memory_reader.h
@@ -74,7 +74,7 @@ bool drgn_memory_reader_empty(struct drgn_memory_reader *reader);
 struct drgn_error *
 drgn_memory_reader_add_segment(struct drgn_memory_reader *reader,
 			       uint64_t min_address, uint64_t max_address,
-			       drgn_memory_read_fn read_fn, void *arg,
+			       const struct drgn_memory_ops *ops, void *arg,
 			       bool physical);
 
 /**
@@ -91,6 +91,11 @@ drgn_memory_reader_add_segment(struct drgn_memory_reader *reader,
 struct drgn_error *drgn_memory_reader_read(struct drgn_memory_reader *reader,
 					   void *buf, uint64_t address,
 					   size_t count, bool physical);
+
+struct drgn_error *
+drgn_memory_reader_read_cstr(struct drgn_memory_reader *reader,
+			     struct string_builder *buf, bool *done,
+			     uint64_t address, size_t count, bool physical);
 
 /** Argument for @ref drgn_read_memory_file(). */
 struct drgn_memory_file_segment {
@@ -116,10 +121,7 @@ struct drgn_memory_file_segment {
 	bool zerofill;
 };
 
-/** @ref drgn_memory_read_fn which reads from a file. */
-struct drgn_error *drgn_read_memory_file(void *buf, uint64_t address,
-					 size_t count, uint64_t offset,
-					 void *arg, bool physical);
+extern const struct drgn_memory_ops segment_file_ops;
 
 /** @} */
 

--- a/libdrgn/object.c
+++ b/libdrgn/object.c
@@ -14,6 +14,7 @@
 #include "object.h"
 #include "program.h"
 #include "serialize.h"
+#include "string_builder.h"
 #include "type.h"
 #include "util.h"
 
@@ -870,8 +871,14 @@ drgn_object_read_c_string(const struct drgn_object *obj, char **ret)
 				       obj->type);
 	}
 
-	return drgn_program_read_c_string(drgn_object_program(obj), address,
-					  false, max_size, ret);
+	struct string_builder sb = STRING_BUILDER_INIT;
+	err = drgn_program_read_c_string(drgn_object_program(obj), address,
+					 false, max_size, &sb);
+	if (err)
+		return err;
+
+	*ret = string_builder_null_terminate(&sb);
+	return NULL;
 }
 
 LIBDRGN_PUBLIC struct drgn_error *

--- a/libdrgn/object.c
+++ b/libdrgn/object.c
@@ -872,8 +872,9 @@ drgn_object_read_c_string(const struct drgn_object *obj, char **ret)
 	}
 
 	struct string_builder sb = STRING_BUILDER_INIT;
+	bool done;
 	err = drgn_program_read_c_string(drgn_object_program(obj), address,
-					 false, max_size, &sb);
+					 false, max_size, &sb, &done);
 	if (err)
 		return err;
 

--- a/libdrgn/platform.h
+++ b/libdrgn/platform.h
@@ -422,6 +422,12 @@ struct drgn_architecture_info {
 	 * @see pgtable_iterator_next_fn
 	 */
 	pgtable_iterator_next_fn *linux_kernel_pgtable_iterator_next;
+	/**
+	 * Return the canonical form of a virtual address, i.e. apply any
+	 * transformations that the CPU applies to the address before page
+	 * table walking.
+	 */
+	uint64_t (*untagged_addr)(uint64_t addr);
 };
 
 /**

--- a/libdrgn/platform.h
+++ b/libdrgn/platform.h
@@ -118,6 +118,8 @@ apply_elf_reloc_fn(const struct drgn_relocating_section *relocating,
 struct pgtable_iterator {
 	/** Address of the top-level page table to iterate. */
 	uint64_t pgtable;
+	/** Whether pgtable is a physical address. */
+	bool pgtable_phys;
 	/** Current virtual address to translate. */
 	uint64_t virt_addr;
 };
@@ -422,6 +424,15 @@ struct drgn_architecture_info {
 	 * @see pgtable_iterator_next_fn
 	 */
 	pgtable_iterator_next_fn *linux_kernel_pgtable_iterator_next;
+	/**
+	 * Initialize vmcoreinfo for @p prog using the given vmlinux binary and
+	 * by reading from @p prog's physical memory, for which segments have
+	 * already been set up. @p text_pa is the physical address where the
+	 * kernel was loaded.
+	 */
+	struct drgn_error *(*linux_kernel_init_vmcoreinfo_from_phys)(
+		struct drgn_program *prog, Elf *vmlinux, GElf_Ehdr *ehdr,
+		uint64_t text_pa);
 	/**
 	 * Return the canonical form of a virtual address, i.e. apply any
 	 * transformations that the CPU applies to the address before page

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -168,10 +168,9 @@ LIBDRGN_PUBLIC void drgn_program_destroy(struct drgn_program *prog)
 	}
 }
 
-LIBDRGN_PUBLIC struct drgn_error *
-drgn_program_add_memory_segment(struct drgn_program *prog, uint64_t address,
-				uint64_t size, drgn_memory_read_fn read_fn,
-				void *arg, bool physical)
+LIBDRGN_PUBLIC struct drgn_error *drgn_program_add_memory_segment(
+	struct drgn_program *prog, uint64_t address, uint64_t size,
+	const struct drgn_memory_ops *ops, void *arg, bool physical)
 {
 	uint64_t address_mask;
 	struct drgn_error *err = drgn_program_address_mask(prog, &address_mask);
@@ -181,7 +180,7 @@ drgn_program_add_memory_segment(struct drgn_program *prog, uint64_t address,
 		return NULL;
 	uint64_t max_address = address + min(size - 1, address_mask - address);
 	return drgn_memory_reader_add_segment(&prog->reader, address,
-					      max_address, read_fn, arg,
+					      max_address, ops, arg,
 					      physical);
 }
 
@@ -399,7 +398,7 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 		 * page table.
 		 */
 		err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,
-						      read_memory_via_pgtable,
+						      &segment_pgtable_ops,
 						      prog, false);
 		if (err)
 			goto out_segments;
@@ -455,7 +454,7 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 		prog->file_segments[j].zerofill = vmcoreinfo_note && !is_proc_kcore;
 		err = drgn_program_add_memory_segment(prog, phdr->p_vaddr,
 						      phdr->p_memsz,
-						      drgn_read_memory_file,
+						      &segment_file_ops,
 						      &prog->file_segments[j],
 						      false);
 		if (err)
@@ -465,7 +464,7 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 			err = drgn_program_add_memory_segment(prog,
 							      phdr->p_paddr,
 							      phdr->p_memsz,
-							      drgn_read_memory_file,
+							      &segment_file_ops,
 							      &prog->file_segments[j],
 							      true);
 			if (err)
@@ -512,7 +511,7 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 								      pgtable_reader ?
 								      phdr->p_filesz :
 								      phdr->p_memsz,
-								      drgn_read_memory_file,
+								      &segment_file_ops,
 								      &prog->file_segments[j],
 								      true);
 				if (err)
@@ -619,7 +618,7 @@ drgn_program_set_pid(struct drgn_program *prog, pid_t pid)
 	prog->file_segments[0].eio_is_fault = true;
 	prog->file_segments[0].zerofill = false;
 	err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,
-					      drgn_read_memory_file,
+					      &segment_file_ops,
 					      prog->file_segments, false);
 	if (err)
 		goto out_segments;
@@ -1600,41 +1599,26 @@ drgn_program_read_memory(struct drgn_program *prog, void *buf, uint64_t address,
 	return NULL;
 }
 
-DEFINE_VECTOR(char_vector, char)
-
 LIBDRGN_PUBLIC struct drgn_error *
 drgn_program_read_c_string(struct drgn_program *prog, uint64_t address,
-			   bool physical, size_t max_size, char **ret)
+			   bool physical, size_t max_size, struct string_builder *str)
 {
 	uint64_t address_mask;
 	struct drgn_error *err = drgn_program_address_mask(prog, &address_mask);
 	if (err)
 		return err;
-	struct char_vector str = VECTOR_INIT;
-	for (;;) {
-		address &= address_mask;
-		char *c = char_vector_append_entry(&str);
-		if (!c) {
-			char_vector_deinit(&str);
-			return &drgn_enomem;
-		}
-		if (str.size <= max_size) {
-			err = drgn_memory_reader_read(&prog->reader, c, address,
-						      1, physical);
-			if (err) {
-				char_vector_deinit(&str);
-				return err;
-			}
-			if (!*c)
-				break;
-		} else {
-			*c = '\0';
-			break;
-		}
-		address++;
+	bool done;
+	while (max_size > 0) {
+		size_t n = min((uint64_t)(max_size - 1), address_mask - address) + 1;
+		err = drgn_memory_reader_read_cstr(&prog->reader, str, &done, address, n,
+					      physical);
+		if (err)
+			return err;
+		if (done)
+			return NULL;
+		address = 0;
+		max_size -= n;
 	}
-	char_vector_shrink_to_fit(&str);
-	*ret = str.data;
 	return NULL;
 }
 

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -534,7 +534,8 @@ drgn_program_set_core_dump(struct drgn_program *prog, const char *path)
 				goto out_segments;
 		}
 		prog->flags |= (DRGN_PROGRAM_IS_LINUX_KERNEL |
-				DRGN_PROGRAM_IS_LIVE);
+				DRGN_PROGRAM_IS_LIVE |
+		                DRGN_PROGRAM_IS_LOCAL);
 		elf_end(prog->core);
 		prog->core = NULL;
 	} else if (vmcoreinfo_note) {
@@ -624,7 +625,7 @@ drgn_program_set_pid(struct drgn_program *prog, pid_t pid)
 		goto out_segments;
 
 	prog->pid = pid;
-	prog->flags |= DRGN_PROGRAM_IS_LIVE;
+	prog->flags |= DRGN_PROGRAM_IS_LIVE | DRGN_PROGRAM_IS_LOCAL;
 	return NULL;
 
 out_segments:

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -277,6 +277,19 @@ drgn_program_address_mask(const struct drgn_program *prog, uint64_t *ret)
 	return NULL;
 }
 
+static inline struct drgn_error *
+drgn_program_untagged_addr(const struct drgn_program *prog, uint64_t *address)
+{
+	if (!prog->has_platform) {
+		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+					 "program address size is not known");
+	}
+	*address &= drgn_platform_address_mask(&prog->platform);
+	if (prog->platform.arch->untagged_addr)
+		*address = prog->platform.arch->untagged_addr(*address);
+	return NULL;
+}
+
 struct drgn_error *drgn_thread_dup_internal(const struct drgn_thread *thread,
 					    struct drgn_thread *ret);
 

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -68,6 +68,8 @@ struct drgn_program {
 	int core_fd;
 	/* PID of live userspace program. */
 	pid_t pid;
+	const char *openocd_tap;
+	int openocd_fd;
 #ifdef WITH_LIBKDUMPFILE
 	kdump_ctx_t *kdump_ctx;
 #endif
@@ -159,7 +161,12 @@ struct drgn_program {
 		uint64_t kaslr_offset;
 		/** Kernel page table. */
 		uint64_t swapper_pg_dir;
-		/** Length of mem_section array (i.e., NR_SECTION_ROOTS). */
+		/** Whether swapper_pg_dir is a physical addres. */
+		bool swapper_pg_dir_phys;
+		/**
+		 * Length of mem_section array (i.e., NR_SECTION_ROOTS),
+		 * or 0 if unknown.
+		 */
 		uint64_t mem_section_length;
 		/** VA_BITS on AArch64. */
 		uint64_t va_bits;

--- a/libdrgn/python/helpers.c
+++ b/libdrgn/python/helpers.c
@@ -43,8 +43,9 @@ PyObject *drgnpy_linux_helper_read_vm(PyObject *self, PyObject *args,
 	buf = PyBytes_FromStringAndSize(NULL, size);
 	if (!buf)
 		return NULL;
-	err = linux_helper_read_vm(&prog->prog, pgtable.uvalue, address.uvalue,
-				   PyBytes_AS_STRING(buf), size);
+	err = linux_helper_read_vm(&prog->prog, pgtable.uvalue, false,
+				   address.uvalue, PyBytes_AS_STRING(buf),
+				   size);
 	if (err) {
 		Py_DECREF(buf);
 		return set_drgn_error(err);
@@ -67,7 +68,7 @@ PyObject *drgnpy_linux_helper_follow_phys(PyObject *self, PyObject *args,
 		return NULL;
 
 	uint64_t phys;
-	err = linux_helper_follow_phys(&prog->prog, pgtable.uvalue,
+	err = linux_helper_follow_phys(&prog->prog, pgtable.uvalue, false,
 				       address.uvalue, &phys);
 	if (err)
 		return set_drgn_error(err);

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -418,6 +418,33 @@ static PyObject *Program_set_kernel(Program *self)
 	Py_RETURN_NONE;
 }
 
+static PyObject *Program_set_openocd(Program *self, PyObject *args,
+				     PyObject *kwds)
+{
+	static char *keywords[] = {
+		"vmlinux", "host", "port", "tap", "mmu", "paddr", NULL,
+	};
+	const char *vmlinux;
+	const char *host;
+	const char *port;
+	const char *tap;
+	int mmu;
+	unsigned long long paddr = 0;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "ssssp|K:set_openocd",
+					 keywords, &vmlinux, &host, &port, &tap,
+					 &mmu, &paddr))
+		return NULL;
+
+	struct drgn_error *err;
+
+	err = drgn_program_set_openocd(&self->prog, vmlinux, host, port, tap,
+				       mmu, paddr);
+	if (err)
+		return set_drgn_error(err);
+	Py_RETURN_NONE;
+}
+
 static PyObject *Program_set_pid(Program *self, PyObject *args, PyObject *kwds)
 {
 	static char *keywords[] = {"pid", NULL};
@@ -1012,6 +1039,8 @@ static PyMethodDef Program_methods[] = {
 	{"set_core_dump", (PyCFunction)Program_set_core_dump,
 	 METH_VARARGS | METH_KEYWORDS, drgn_Program_set_core_dump_DOC},
 	{"set_kernel", (PyCFunction)Program_set_kernel, METH_NOARGS,
+	 drgn_Program_set_kernel_DOC},
+	{"set_openocd", (PyCFunction)Program_set_openocd, METH_VARARGS | METH_KEYWORDS,
 	 drgn_Program_set_kernel_DOC},
 	{"set_pid", (PyCFunction)Program_set_pid, METH_VARARGS | METH_KEYWORDS,
 	 drgn_Program_set_pid_DOC},

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -172,6 +172,10 @@ out:
 	return err;
 }
 
+static const struct drgn_memory_ops segment_py_ops = {
+	.read_fn = py_memory_read_fn,
+};
+
 static PyObject *Program_add_memory_segment(Program *self, PyObject *args,
 					    PyObject *kwds)
 {
@@ -199,7 +203,7 @@ static PyObject *Program_add_memory_segment(Program *self, PyObject *args,
 	if (Program_hold_object(self, read_fn) == -1)
 		return NULL;
 	err = drgn_program_add_memory_segment(&self->prog, address.uvalue,
-					      size.uvalue, py_memory_read_fn,
+					      size.uvalue, &segment_py_ops,
 					      read_fn, physical);
 	if (err)
 		return set_drgn_error(err);


### PR DESCRIPTION
OpenOCD may be used to establish a JTAG or SWD connection to a remote
debugging target. This patch adds the necessary support to drgn for
debugging a remote target using OpenOCD.

A new memory backend is added that issues memory transactions using
OpenOCD's Tcl interface. With remote debugging using direct physical
memory accesses there is no need for the kernel to have core dump
support. Instead, we use the debugging information in the vmlinux
file, together with information available in the physical memory of
the target. A new arch-specific hook is added for figuring out the
information in vmcoreinfo using the vmlinux file and the physical load
address of the kernel, which must be supplied by the user.

With this patch, drgn can also act as a debugger for microcontroller
firmware and other bare-metal programs that run without an MMU, using
the same OpenOCD memory backend used for kernel debugging.

(Since this has dependencies on my other PRs, I included their commits in this PR.)