### PR TITLE
libdrgn: detect flattened vmcores and raise error

### DIFF
--- a/libdrgn/linux_kernel.h
+++ b/libdrgn/linux_kernel.h
@@ -32,6 +32,9 @@ linux_kernel_report_debug_info(struct drgn_debug_info_load_state *load);
 #define KDUMP_SIGNATURE "KDUMP   "
 #define KDUMP_SIG_LEN (sizeof(KDUMP_SIGNATURE) - 1)
 
+#define FLATTENED_SIGNATURE "makedumpfile"
+#define FLATTENED_SIG_LEN (sizeof(FLATTENED_SIGNATURE) - 1)
+
 #ifdef WITH_LIBKDUMPFILE
 struct drgn_error *drgn_program_cache_kdump_notes(struct drgn_program *prog);
 struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog);


### PR DESCRIPTION
The makedumpfile flattened format is occasionally seen by users, but is not read by libkdumpfile and thus unsupported by Drgn. A simple 'reassembly' process is all that is necessary to allow Drgn to open the vmcore, but this fact isn't easily discoverable, resulting in issues like #344. To help users, detect this when we're testing for kdump signatures, and raise an error with reassembly instructions.

For further details on the flattened format, consult makedumpfile(8), particularly the sections documenting options -F and -R.