### PR TITLE
Add the ability to run drgn against the live kernel as non-root user

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -451,7 +451,7 @@ class Program:
             return an :class:`Object`.
         """
         ...
-    def set_core_dump(self, path: Path) -> None:
+    def set_core_dump(self, path: Union[Path, int]) -> None:
         """
         Set the program to a core dump.
 
@@ -459,7 +459,7 @@ class Program:
         mapped executable and libraries. It does not load any debugging
         symbols; see :meth:`load_default_debug_info()`.
 
-        :param path: Core dump file path.
+        :param path: Core dump file path or open file descriptor.
         """
         ...
     def set_kernel(self) -> None:
@@ -888,12 +888,12 @@ def filename_matches(haystack: Optional[str], needle: Optional[str]) -> bool:
     """
     ...
 
-def program_from_core_dump(path: Path) -> Program:
+def program_from_core_dump(path: Union[Path, int]) -> Program:
     """
     Create a :class:`Program` from a core dump file. The type of program (e.g.,
     userspace or kernel) is determined automatically.
 
-    :param path: Core dump file path.
+    :param path: Core dump file path or open file descriptor.
     """
     ...
 

--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, Optional
 
 import drgn
 from drgn.internal.rlcompleter import Completer
+from drgn.internal.sudohelper import open_via_sudo
 
 __all__ = ("run_interactive", "version_header")
 
@@ -264,7 +265,10 @@ def _main() -> None:
         elif args.pid is not None:
             prog.set_pid(args.pid or os.getpid())
         else:
-            prog.set_kernel()
+            try:
+                prog.set_kernel()
+            except PermissionError:
+                prog.set_core_dump(open_via_sudo("/proc/kcore", os.O_RDONLY))
     except PermissionError as e:
         print(e, file=sys.stderr)
         if args.pid is not None:

--- a/drgn/internal/sudohelper.py
+++ b/drgn/internal/sudohelper.py
@@ -1,0 +1,71 @@
+# Copyright (c) Stephen Brennan <stephen@brennan.io>
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Helper for opening a file as root and transmitting it via unix socket"""
+import array
+import os
+from pathlib import Path
+import pickle
+import socket
+import subprocess
+import sys
+import tempfile
+from typing import Union
+
+
+def open_via_sudo(
+    path: Union[Path, str],
+    flags: int,
+    mode: int = 0o777,
+) -> int:
+    """Implements os.open() using sudo to get permissions"""
+    # Currently does not support dir_fd argument
+    with tempfile.TemporaryDirectory() as td:
+        sockpath = Path(td) / "sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
+            sock.bind(str(sockpath))
+            subprocess.check_call(
+                [
+                    "sudo",
+                    sys.executable,
+                    "-B",
+                    __file__,
+                    sockpath,
+                    path,
+                    str(flags),
+                    str(mode),
+                ],
+            )
+            fds = array.array("i")
+            msg, ancdata, flags, addr = sock.recvmsg(
+                4096, socket.CMSG_SPACE(fds.itemsize)
+            )
+            for level, typ, data in ancdata:
+                if level == socket.SOL_SOCKET and typ == socket.SCM_RIGHTS:
+                    data = data[: fds.itemsize]
+                    fds.frombytes(data)
+                    return fds[0]
+            raise pickle.loads(msg)
+
+
+def main() -> None:
+    sockpath = sys.argv[1]
+    filename = sys.argv[2]
+    flags = int(sys.argv[3])
+    mode = int(sys.argv[4])
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    sock.connect(sockpath)
+    try:
+        fd = os.open(filename, flags, mode)
+        fds = array.array("i", [fd])
+        sock.sendmsg(
+            [b"success"],
+            [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)],
+        )
+    except Exception as e:
+        sock.sendmsg([pickle.dumps(e)])
+
+
+if __name__ == "__main__":
+    main()

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -671,6 +671,14 @@ struct drgn_error *drgn_program_set_core_dump(struct drgn_program *prog,
 					      const char *path);
 
 /**
+ * Set a @ref drgn_program to a core dump from a file descriptor.
+ *
+ * @param[in] path Core dump file descriptor.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_set_core_dump_fd(struct drgn_program *prog, int fd);
+
+/**
  * Set a @ref drgn_program to the running operating system kernel.
  *
  * @return @c NULL on success, non-@c NULL on error.
@@ -711,6 +719,19 @@ struct drgn_error *drgn_program_load_debug_info(struct drgn_program *prog,
  */
 struct drgn_error *drgn_program_from_core_dump(const char *path,
 					       struct drgn_program **ret);
+
+/**
+ * Create a @ref drgn_program from a core dump file descriptor.
+ *
+ * Same as @ref drgn_program_from_core_dump but with an already-opened file
+ * descriptor.
+ *
+ * @param[in] fd Core dump file path descriptor.
+ * @param[out] ret Returned program.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_from_core_dump_fd(int fd,
+						  struct drgn_program **ret);
 
 /**
  * Create a @ref drgn_program from the running operating system kernel.

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -227,6 +227,13 @@ struct drgn_error *drgn_program_init_core_dump(struct drgn_program *prog,
 					       const char *path);
 
 /**
+ * Implement @ref drgn_program_from_core_dump_fd() on an initialized @ref
+ * drgn_program.
+ */
+struct drgn_error *drgn_program_init_core_dump_fd(struct drgn_program *prog,
+						  int fd);
+
+/**
  * Implement @ref drgn_program_from_kernel() on an initialized @ref
  * drgn_program.
  */

--- a/libdrgn/python/drgnpy.h
+++ b/libdrgn/python/drgnpy.h
@@ -330,7 +330,9 @@ struct index_arg {
 int index_converter(PyObject *o, void *p);
 
 struct path_arg {
+	bool allow_fd;
 	bool allow_none;
+	int fd;
 	char *path;
 	Py_ssize_t length;
 	PyObject *object;


### PR DESCRIPTION
(As described in Slack)

`/proc/kcore` can only be opened by root, so live debugging has been restricted to running drgn as root. But running drgn as root has downsides:

1. The `PYTHONPATH` does not include your home directory
2. Python may drop `pyc` files as root (this can be avoided with `-B`)
3. All files and other actions your script might take are done by root.

It would be very nice to be able to run Drgn as your current user, and only use escalated privileges to open `/proc/kcore`. One approach would be to drop privileges after creating the program, which improves numbers 2 and 3. Unfortunately the PYTHONPATH, PATH, USER, and HOME environment variables would be unchanged, so much of the standard library would still believe you are root (e.g. `getpass.getuser()`). This can be worked around, but it's just a bit messy.

Instead, we can run a helper program with sudo that will transmit the opened file descriptor back to Drgn via a Unix socket.

To do this, we add `Program.set_fd()` and `program_from_fd()`  which behave just like `set_core_dump()`, etc, except they take the FD rather than the path.

We add a helper script to do the "unix socket magic", and then we tie it all together in the CLI code. When the CLI code runs against the kernel, if it is not running as root, it will use the helper function to get the file descriptor. If the CLI is already running as root, nothing changes.

Running as non-root breaks drgn's module & section iterators, since drgn expects to be able to read data out of `/sys/modules` -- unfortunately some of it has `400` permissions and can only be read by root. Thankfully, that code is just an optimized code path. We can disable that if we're running as a non-root user.

Putting this all together, we have a way to run drgn as non-root user, and have all the features we've come to expect!