### PR TITLE
libdrgn: add drgn_error_catch()

### DIFF
--- a/libdrgn/arch_aarch64.c
+++ b/libdrgn/arch_aarch64.c
@@ -90,10 +90,8 @@ fallback_unwind_aarch64(struct drgn_program *prog,
 	err = drgn_program_read_memory(prog, frame, fp.value, sizeof(frame),
 				       false);
 	if (err) {
-		if (err->code == DRGN_ERROR_FAULT) {
-			drgn_error_destroy(err);
+		if (drgn_error_catch(&err, DRGN_ERROR_FAULT))
 			err = &drgn_stop;
-		}
 		return err;
 	}
 

--- a/libdrgn/arch_ppc64.c
+++ b/libdrgn/arch_ppc64.c
@@ -71,10 +71,8 @@ fallback_unwind_ppc64(struct drgn_program *prog,
 					       sizeof(saved_lr), false);
 	}
 	if (err) {
-		if (err->code == DRGN_ERROR_FAULT) {
-			drgn_error_destroy(err);
+		if (drgn_error_catch(&err, DRGN_ERROR_FAULT))
 			err = &drgn_stop;
-		}
 		return err;
 	}
 

--- a/libdrgn/arch_s390x.c
+++ b/libdrgn/arch_s390x.c
@@ -146,10 +146,8 @@ fallback_unwind_s390x(struct drgn_program *prog,
 	return NULL;
 
 err:
-	if (err->code == DRGN_ERROR_FAULT) {
-		drgn_error_destroy(err);
+	if (drgn_error_catch(&err, DRGN_ERROR_FAULT))
 		return &drgn_stop;
-	}
 	return err;
 }
 

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -1039,10 +1039,7 @@ userspace_core_identify_file(struct drgn_program *prog,
 	err = drgn_program_read_memory(prog, &ehdr_buf, ehdr_segment->start,
 				       sizeof(ehdr_buf), false);
 	if (err) {
-		if (err->code == DRGN_ERROR_FAULT) {
-			drgn_error_destroy(err);
-			err = NULL;
-		}
+		drgn_error_catch(&err, DRGN_ERROR_FAULT);
 		return err;
 	}
 	if (memcmp(&ehdr_buf, ELFMAG, SELFMAG) != 0) {
@@ -1082,10 +1079,7 @@ userspace_core_identify_file(struct drgn_program *prog,
 				       ehdr_segment->start + ehdr.e_phoff,
 				       ehdr.e_phnum * ehdr.e_phentsize, false);
 	if (err) {
-		if (err->code == DRGN_ERROR_FAULT) {
-			drgn_error_destroy(err);
-			err = NULL;
-		}
+		drgn_error_catch(&err, DRGN_ERROR_FAULT);
 		return err;
 	}
 	arg.phdr_buf = core->phdr_buf;
@@ -1127,12 +1121,10 @@ userspace_core_identify_file(struct drgn_program *prog,
 						       phdr.p_vaddr + bias,
 						       phdr.p_filesz, false);
 			if (err) {
-				if (err->code == DRGN_ERROR_FAULT) {
-					drgn_error_destroy(err);
+				if (drgn_error_catch(&err, DRGN_ERROR_FAULT))
 					continue;
-				} else {
+				else
 					return err;
-				}
 			}
 			ret->build_id = read_build_id(core->segment_buf,
 						      phdr.p_filesz,

--- a/libdrgn/drgn.h.in
+++ b/libdrgn/drgn.h.in
@@ -275,6 +275,24 @@ int drgn_error_dwrite(int fd, struct drgn_error *err);
  */
 void drgn_error_destroy(struct drgn_error *err);
 
+/**
+ * Catch a @ref drgn_error of a particular kind
+ *
+ * If @a errp points to a non-@c NULL error whose code matches @a code, then the
+ * pointed error will be freed and the pointer replaced by @c NULL, and the
+ * function will return @c true. Otherwise, the function returns @c false.
+ */
+static inline bool drgn_error_catch(struct drgn_error **errp,
+				    enum drgn_error_code code)
+{
+	if (*errp && (*errp)->code == code) {
+		drgn_error_destroy(*errp);
+		*errp = NULL;
+		return true;
+	}
+	return false;
+}
+
 /** @} */
 
 

--- a/libdrgn/dwarf_info.c
+++ b/libdrgn/dwarf_info.c
@@ -4235,7 +4235,7 @@ drgn_object_from_dwarf_location(struct drgn_program *prog,
 	do {
 		uint64_vector_clear(&stack);
 		err = drgn_eval_dwarf_expression(&ctx, &stack, &remaining_ops);
-		if (err == &drgn_not_found)
+		if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
 			goto absent;
 		else if (err)
 			goto out;

--- a/libdrgn/object.c
+++ b/libdrgn/object.c
@@ -1849,10 +1849,8 @@ struct drgn_error *drgn_op_cast(struct drgn_object *res,
 	}
 
 err:
-	if (err->code == DRGN_ERROR_TYPE) {
-		drgn_error_destroy(err);
+	if (drgn_error_catch(&err, DRGN_ERROR_TYPE))
 		goto type_error;
-	}
 	return err;
 
 type_error:;

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -1269,12 +1269,11 @@ drgn_program_kernel_get_crashed_cpu(struct drgn_program *prog, uint64_t *ret)
 		err = drgn_object_read_integer(&cpu, &cpu_value);
 		if (!err)
 			*ret = cpu_value.uvalue;
-	} else if (err->code == DRGN_ERROR_LOOKUP) {
+	} else if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP)) {
 		// On x86 and x86-64 only, the crashed CPU is also in an int
 		// crashing_cpu. Use this as a fallback for kernels before
 		// commit 1717f2096b54 ("panic, x86: Fix re-entrance problem due
 		// to panic on NMI") (in v4.5).
-		drgn_error_destroy(err);
 		err = drgn_program_find_object(prog, "crashing_cpu", NULL,
 					       DRGN_FIND_OBJECT_VARIABLE, &cpu);
 		if (!err) {
@@ -1289,12 +1288,10 @@ drgn_program_kernel_get_crashed_cpu(struct drgn_program *prog, uint64_t *ret)
 				*ret = 0;
 			else
 				*ret = cpu_value.uvalue;
-		} else if (err->code == DRGN_ERROR_LOOKUP) {
+		} else if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP)) {
 			// Before Linux kernel commit 5bc329503e81 ("x86/mce:
 			// Handle broadcasted MCE gracefully with kexec") (in
 			// v4.12), crashing_cpu is only defined in SMP kernels.
-			drgn_error_destroy(err);
-			err = NULL;
 			*ret = 0;
 		}
 	}
@@ -1490,10 +1487,7 @@ struct drgn_error *drgn_program_init_core_dump(struct drgn_program *prog,
 	if (err)
 		return err;
 	err = drgn_program_load_debug_info(prog, NULL, 0, true, true);
-	if (err && err->code == DRGN_ERROR_MISSING_DEBUG_INFO) {
-		drgn_error_destroy(err);
-		err = NULL;
-	}
+	drgn_error_catch(&err, DRGN_ERROR_MISSING_DEBUG_INFO);
 	return err;
 }
 
@@ -1505,10 +1499,7 @@ struct drgn_error *drgn_program_init_kernel(struct drgn_program *prog)
 	if (err)
 		return err;
 	err = drgn_program_load_debug_info(prog, NULL, 0, true, true);
-	if (err && err->code == DRGN_ERROR_MISSING_DEBUG_INFO) {
-		drgn_error_destroy(err);
-		err = NULL;
-	}
+	drgn_error_catch(&err, DRGN_ERROR_MISSING_DEBUG_INFO);
 	return err;
 }
 
@@ -1520,10 +1511,7 @@ struct drgn_error *drgn_program_init_pid(struct drgn_program *prog, pid_t pid)
 	if (err)
 		return err;
 	err = drgn_program_load_debug_info(prog, NULL, 0, true, true);
-	if (err && err->code == DRGN_ERROR_MISSING_DEBUG_INFO) {
-		drgn_error_destroy(err);
-		err = NULL;
-	}
+	drgn_error_catch(&err, DRGN_ERROR_MISSING_DEBUG_INFO);
 	return err;
 }
 

--- a/libdrgn/python/object.c
+++ b/libdrgn/python/object.c
@@ -1404,7 +1404,7 @@ static PyObject *DrgnObject_getattro(DrgnObject *self, PyObject *attr_name)
 	}
 	if (err) {
 		Py_CLEAR(res);
-		if (err->code == DRGN_ERROR_TYPE) {
+		if (drgn_error_catch(&err, DRGN_ERROR_TYPE)) {
 			/*
 			 * If the object doesn't have a compound type, raise a
 			 * generic AttributeError (or restore the original one
@@ -1417,7 +1417,6 @@ static PyObject *DrgnObject_getattro(DrgnObject *self, PyObject *attr_name)
 #else
 			PyErr_Restore(exc_type, exc_value, exc_traceback);
 #endif
-			drgn_error_destroy(err);
 			return NULL;
 		} else if (err->code == DRGN_ERROR_LOOKUP) {
 			PyErr_SetString(PyExc_AttributeError, err->message);

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -1040,12 +1040,10 @@ static DrgnObject *Program_subscript(Program *self, PyObject *key)
 	if (clear)
 		clear_drgn_in_python();
 	if (err) {
-		if (err->code == DRGN_ERROR_LOOKUP) {
-			drgn_error_destroy(err);
+		if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
 			PyErr_SetObject(PyExc_KeyError, key);
-		} else {
+		else
 			set_drgn_error(err);
-		}
 		return NULL;
 	}
 	return_ptr(ret);
@@ -1075,8 +1073,7 @@ static int Program_contains(Program *self, PyObject *key)
 		clear_drgn_in_python();
 	drgn_object_deinit(&tmp);
 	if (err) {
-		if (err->code == DRGN_ERROR_LOOKUP) {
-			drgn_error_destroy(err);
+		if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP)) {
 			return 0;
 		} else {
 			set_drgn_error(err);

--- a/libdrgn/python/stack_trace.c
+++ b/libdrgn/python/stack_trace.c
@@ -160,12 +160,10 @@ static DrgnObject *StackFrame_subscript(StackFrame *self, PyObject *key)
 	if (clear)
 		clear_drgn_in_python();
 	if (err) {
-		if (err->code == DRGN_ERROR_LOOKUP) {
-			drgn_error_destroy(err);
+		if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
 			PyErr_SetObject(PyExc_KeyError, key);
-		} else {
+		else
 			set_drgn_error(err);
-		}
 		return NULL;
 	}
 	return_ptr(ret);
@@ -186,14 +184,12 @@ static int StackFrame_contains(StackFrame *self, PyObject *key)
 	err = drgn_stack_frame_find_object(self->trace->trace, self->i, name,
 					   &tmp);
 	drgn_object_deinit(&tmp);
-	if (!err) {
+	if (!err)
 		return 1;
-	} else if (err->code == DRGN_ERROR_LOOKUP) {
-		drgn_error_destroy(err);
+	else if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
 		return 0;
-	} else {
+	else
 		return -1;
-	}
 }
 
 static PyObject *StackFrame_source(StackFrame *self)


### PR DESCRIPTION
A common enough pattern is to catch errors by their code, and then destroy them and handle them in some way. Add a helper to handle this. The helper always destroys the error and always NULLs the error pointer (which may otherwise be left to point at a stale error).

A less common short-cut is to directly compare error values to global error variables. In particular, "err == &drgn_not_found" should really be replaced with a catch statement that catches all DRGN_ERROR_LOOKUP. However, the others (drgn_stop, drgn_line_wrap, and drgn_enomem) are specialized enough that they probably don't merit this treatment.

Apply the new helper to the whole codebase.