### PR TITLE
Add more pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,44 @@
+exclude: ^contrib/
 repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)
-        exclude: ^contrib/
 -   repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:
     -   id: black
-        exclude: ^contrib/
 -   repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
     -   id: flake8
-        exclude: ^contrib/
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:
     -   id: mypy
         args: [--show-error-codes, --strict, --no-warn-return-any, --no-warn-unused-ignores]
         files: ^drgn/.*\.py|_drgn.pyi$
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+        exclude_types: [diff]
+    -   id: end-of-file-fixer
+        exclude_types: [diff]
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: debug-statements
+    -   id: check-merge-conflict
+-   repo: https://github.com/netromdk/vermin
+    rev: v1.5.2
+    hooks:
+    -   id: vermin
+        # The vmtest package in general should adhere to the same version
+        # requirements as drgn, with the following exceptions: The manage &
+        # kbuild scripts are used by Github Actions and need not be broadly
+        # compatible. The rootfsbuild script is used to create test environments
+        # for other architectures, and is sufficiently advanced that it isn't
+        # expected to be run by most users or even most developers.
+        exclude: "^vmtest/(manage|kbuild|rootfsbuild).py$"
+        args: ['-t=3.6-', '--violations', '--eval-annotations']

--- a/drgn/__init__.py
+++ b/drgn/__init__.py
@@ -142,7 +142,7 @@ __all__ = (
 
 
 if sys.version_info >= (3, 8):
-    _open_code = io.open_code
+    _open_code = io.open_code  # novermin
 else:
     from typing import BinaryIO
 


### PR DESCRIPTION
The "pre-commit-hooks" repo contains a few hooks that enforce some nice, common sense guidelines. The "vermin" hook checks compatibility with a supplied minimum Python version requirement, both checking the syntax and standard library usage. It's very helpful for identifying incompatible code before getting to the CI steps.

---

I don't believe I proposed these hooks in my initial pull request, but I've been using them in some of my other projects and find them quite helpful.

The pre-commit-hooks are a bunch of fast, common-sense checks that I've never really had cause issues, but they can catch some obvious things. Some of them would overlap with Black for the Python code, but they will apply to non-python files as well.

The vermin hook is the main reason I submitted this. It has prevented me from breaking my compatibility promises several times. It does occasionally require some `# novermin` comments, but it's super nice to have a fairly reliable way to verify that you're using stdlib APIs which are compatible down to 3.6. There are a few vmtest scripts which actually aren't but I don't think there was really any expectation that the scripts which manage kernels, compilers, and root filesystems, etc. are going to hold to the same compatibility guarantees as the rest of the library.