### PR TITLE
Improvements to opening /proc/kcore via sudo

### DIFF
--- a/drgn/internal/sudohelper.py
+++ b/drgn/internal/sudohelper.py
@@ -27,6 +27,8 @@ def open_via_sudo(
             subprocess.check_call(
                 [
                     "sudo",
+                    "-p",
+                    f"[sudo] password for %p to open {path}: ",
                     sys.executable,
                     "-B",
                     __file__,


### PR DESCRIPTION
A couple of followups to #347:

- Check whether sudo is installed in the first place.
- Make the sudo prompt include why we're asking for sudo.