### PR TITLE
drgn.helpers.linux: Add helpers to work with wait-queue(s).

### DIFF
--- a/drgn/helpers/linux/wait.py
+++ b/drgn/helpers/linux/wait.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Wait Queues
+-----------
+
+The ``drgn.helpers.linux.wait`` module provides helpers for working with wait
+queues (``wait_queue_head_t`` and ``wait_queue_entry_t``) from
+:linux:`include/linux/wait.h`.
+
+.. note::
+
+    Since Linux 4.13, entries in a wait queue have type ``wait_queue_entry_t``.
+    Before that, the type was named ``wait_queue_t``.
+"""
+
+from typing import Iterator
+
+from drgn import Object, cast
+from drgn.helpers.linux.list import list_empty, list_for_each_entry
+
+__all__ = (
+    "waitqueue_active",
+    "waitqueue_for_each_entry",
+    "waitqueue_for_each_task",
+)
+
+
+def _get_wait_queue_head(wq: Object) -> Object:
+    # Linux kernel commit 2055da97389a ("sched/wait: Disambiguate
+    # wq_entry->task_list and wq_head->task_list naming") (in v4.13) renamed
+    # the task_list member to head.
+    try:
+        return wq.head
+    except AttributeError:
+        return wq.task_list
+
+
+def waitqueue_active(wq: Object) -> bool:
+    """
+    Return whether a wait queue has any waiters.
+
+    :param wq: ``wait_queue_head_t *``
+    """
+    head = _get_wait_queue_head(wq)
+    return not list_empty(head.address_of_())
+
+
+def waitqueue_for_each_entry(wq: Object) -> Iterator[Object]:
+    """
+    Iterate over all entries in a wait queue.
+
+    :param wq: ``wait_queue_head_t *``
+    :return: Iterator of ``wait_queue_entry_t *`` or ``wait_queue_t *``
+        objects depending on the kernel version.
+    """
+    head_addr = _get_wait_queue_head(wq).address_of_()
+    prog = wq.prog_
+    # Linux kernel commit ac6424b981bc ("sched/wait: Rename wait_queue_t =>
+    # wait_queue_entry_t") (in v4.13) renamed the entry type and commit
+    # 2055da97389a ("sched/wait: Disambiguate wq_entry->task_list and
+    # wq_head->task_list naming") (in v4.13) renamed .task_list to .entry.
+    try:
+        wait_queue_entry_type, link = prog.type("wait_queue_entry_t"), "entry"
+    except LookupError:
+        wait_queue_entry_type, link = prog.type("wait_queue_t"), "task_list"
+
+    return list_for_each_entry(wait_queue_entry_type, head_addr, link)
+
+
+def waitqueue_for_each_task(wq: Object) -> Iterator[Object]:
+    """
+    Iterate over all tasks waiting on a wait queue.
+
+    :param wq: ``wait_queue_head_t *``
+    :return: Iterator of ``struct task_struct *`` objects.
+    """
+    task_structp_type = wq.prog_.type("struct task_struct *")
+    for entry in waitqueue_for_each_entry(wq):
+        yield cast(task_structp_type, entry.private)

--- a/tests/linux_kernel/helpers/test_wait.py
+++ b/tests/linux_kernel/helpers/test_wait.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from drgn.helpers.linux.wait import waitqueue_active, waitqueue_for_each_task
+from tests.linux_kernel import LinuxKernelTestCase, skip_unless_have_test_kmod
+
+
+@skip_unless_have_test_kmod
+class TestWaitqueue(LinuxKernelTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.waitq = cls.prog["drgn_test_waitq"].address_of_()
+        cls.empty_waitq = cls.prog["drgn_test_empty_waitq"].address_of_()
+
+    def test_waitqueue_active(self):
+        self.assertTrue(waitqueue_active(self.waitq))
+        self.assertFalse(waitqueue_active(self.empty_waitq))
+
+    def test_waitqueue_for_each_task(self):
+        self.assertEqual(list(waitqueue_for_each_task(self.empty_waitq)), [])
+        self.assertEqual(
+            list(waitqueue_for_each_task(self.waitq)),
+            [self.prog["drgn_test_waitq_kthread"]],
+        )

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -25,6 +25,7 @@
 #include <linux/slab.h>
 #include <linux/version.h>
 #include <linux/vmalloc.h>
+#include <linux/wait.h>
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
 #define HAVE_XARRAY 1
 #include <linux/xarray.h>
@@ -847,6 +848,40 @@ static void drgn_test_idr_exit(void)
 	idr_destroy(&drgn_test_idr_sparse);
 }
 
+// wait-queue
+static struct task_struct *drgn_test_waitq_kthread;
+static wait_queue_head_t drgn_test_waitq;
+static wait_queue_head_t drgn_test_empty_waitq;
+
+static int drgn_test_waitq_kthread_fn(void *arg)
+{
+	wait_event_interruptible(drgn_test_waitq, kthread_should_stop());
+	return 0;
+}
+
+static int drgn_test_waitq_init(void)
+{
+	init_waitqueue_head(&drgn_test_waitq);
+	init_waitqueue_head(&drgn_test_empty_waitq);
+
+	drgn_test_waitq_kthread = kthread_create(drgn_test_waitq_kthread_fn,
+						 NULL,
+						 "drgn_test_waitq_kthread");
+	if (!drgn_test_waitq_kthread)
+		return -1;
+
+	wake_up_process(drgn_test_waitq_kthread);
+	return 0;
+}
+
+static void drgn_test_waitq_exit(void)
+{
+	if (drgn_test_waitq_kthread) {
+		kthread_stop(drgn_test_waitq_kthread);
+		drgn_test_waitq_kthread = NULL;
+	}
+}
+
 // Dummy function symbol.
 int drgn_test_function(int x)
 {
@@ -862,6 +897,7 @@ static void drgn_test_exit(void)
 	drgn_test_stack_trace_exit();
 	drgn_test_radix_tree_exit();
 	drgn_test_xarray_exit();
+	drgn_test_waitq_exit();
 	drgn_test_idr_exit();
 }
 
@@ -891,6 +927,10 @@ static int __init drgn_test_init(void)
 	if (ret)
 		goto out;
 	ret = drgn_test_xarray_init();
+	if (ret)
+		goto out;
+
+	ret = drgn_test_waitq_init();
 	if (ret)
 		goto out;
 	ret = drgn_test_idr_init();


### PR DESCRIPTION
Helpers to work with kernel's waitqueue subsystem