### PR TITLE
Improve debuginfo warning

### DIFF
--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -336,10 +336,12 @@ drgn_debug_info_report_error(struct drgn_debug_info_load_state *load,
 	}
 	if (load->num_errors == 0 &&
 	    !string_builder_append(&load->errors,
-				   "could not get debugging information for:"))
+				   "missing some debugging symbols (see https://drgn.readthedocs.io/en/latest/getting_debugging_symbols.html):"))
 		goto err;
 	if (load->num_errors < load->max_errors) {
 		if (!string_builder_line_break(&load->errors))
+			goto err;
+		if (!string_builder_append(&load->errors, "  "))
 			goto err;
 		if (name && !string_builder_append(&load->errors, name))
 			goto err;


### PR DESCRIPTION
Rather than the indirect link between verbage in the docs and getting dependencies, just include the URL. Indent the related modules for clarity.

This might not be the most elegant way to solve this problem, but I found myself coming to this with fresh eyes today on a fresh Linux install and got lost in the weeds of yum.repos.conf and enabling the debug info repository before I eventually came around to the right documents and was reminded of the debuginfo-install command.

I'm assuming that the URL will remain stable so this will be a quality of life improvement.