### PR TITLE
libdrgn: accept flattened KDUMP format

### DIFF
--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -94,6 +94,11 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 	}
 
 	ks = kdump_set_number_attr(ctx, KDUMP_ATTR_FILE_FD, prog->core_fd);
+	if (ks == KDUMP_ERR_NOTIMPL) {
+		err = drgn_error_format(DRGN_ERROR_INVALID_ARGUMENT,
+					"%s", kdump_get_err(ctx));
+		goto err;
+	}
 	if (ks != KDUMP_OK) {
 		err = drgn_error_format(DRGN_ERROR_OTHER,
 					"kdump_set_number_attr(KDUMP_ATTR_FILE_FD): %s",

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -215,11 +215,11 @@ drgn_program_check_initialized(struct drgn_program *prog)
 	return NULL;
 }
 
-static struct drgn_error *has_kdump_signature(const char *path, int fd,
-					      bool *ret)
+static struct drgn_error *
+has_kdump_signature(struct drgn_program *prog, const char *path, bool *ret)
 {
 	char signature[max_iconst(KDUMP_SIG_LEN, FLATTENED_SIG_LEN)];
-	ssize_t r = pread_all(fd, signature, sizeof(signature), 0);
+	ssize_t r = pread_all(prog->core_fd, signature, sizeof(signature), 0);
 	if (r < 0)
 		return drgn_error_create_os("pread", errno, path);
 	if (r >= FLATTENED_SIG_LEN
@@ -252,7 +252,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 	bool have_nt_taskstruct = false, is_proc_kcore;
 
 	prog->core_fd = fd;
-	err = has_kdump_signature(path, prog->core_fd, &is_kdump);
+	err = has_kdump_signature(prog, path, &is_kdump);
 	if (err)
 		goto out_fd;
 	if (is_kdump) {


### PR DESCRIPTION
Support for the flattened KDUMP format was added in libkdumpfile-0.5.3.