### PR TITLE
Update pre-commit hooks, dropping support for development on 3.6-3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+      - name: Check Python version for pre-commit
+        # Only run pre-commit / mypy on upstream supported Python versions
+        run: |
+          if [[ "${{ matrix.python-version }}" =~ ^3\.([89]|[0-9][0-9])$ ]]; then
+              echo USE_PRE_COMMIT=1 >> $GITHUB_ENV
+          fi
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install dwarves libelf-dev libdw-dev qemu-kvm zstd ${{ matrix.cc == 'clang' && 'libomp-$(clang --version | sed -rn "s/.*clang version ([0-9]+).*/\\1/p")-dev' || '' }}
-          pip install pyroute2 pre-commit
+          pip install pyroute2 ${USE_PRE_COMMIT/1/pre-commit}
       - name: Generate version.py
         run: python setup.py --version
       - name: Check with mypy
+        if: ${{ env.USE_PRE_COMMIT == '1' }}
         run: pre-commit run --all-files mypy
       - name: Build and test with ${{ matrix.cc }}
         run: CONFIGURE_FLAGS="--enable-compiler-warnings=error" python setup.py test -K

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: isort
         name: isort (python)
 -   repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
@@ -14,7 +14,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v1.7.1
     hooks:
     -   id: mypy
         args: [--show-error-codes, --strict, --no-warn-return-any, --no-warn-unused-ignores]
@@ -31,7 +31,7 @@ repos:
     -   id: debug-statements
     -   id: check-merge-conflict
 -   repo: https://github.com/netromdk/vermin
-    rev: v1.5.2
+    rev: v1.6.0
     hooks:
     -   id: vermin
         # The vmtest package in general should adhere to the same version

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,6 +18,13 @@ instructions <README.rst#from-source>`_, then run:
     $ CONFIGURE_FLAGS="--enable-compiler-warnings=error" python3 setup.py build_ext -i
     $ python3 -m drgn --help
 
+Drgn can build, run, and pass its test suite on Python 3.6 or later. However,
+many of the tools used as part of the development workflow do not support Python
+versions once they have reached their end-of-life. Thus, your main drgn
+development environment should use a Python version which is actively supported
+upstream. In particular, the drgn development workflow no longer supported on
+Python 3.6.
+
 Testing
 -------
 
@@ -66,6 +73,9 @@ Or you can run them manually:
 .. code-block:: console
 
     $ pre-commit run --all-files
+
+Please remember that these pre-commit hooks do not support Python 3.6; they
+require a Python major version which is actively supported upstream.
 
 Coding Guidelines
 -----------------

--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -240,7 +240,7 @@ def _main() -> None:
         try:
             script_type = _identify_script(args.script[0])
         except OSError as e:
-            sys.exit(e)
+            sys.exit(str(e))
         if script_type == "core":
             sys.exit(
                 f"error: {args.script[0]} is a core dump\n"
@@ -280,7 +280,7 @@ def _main() -> None:
                 else:
                     prog.set_core_dump(open_via_sudo("/proc/kcore", os.O_RDONLY))
     except OSError as e:
-        sys.exit(e)
+        sys.exit(str(e))
     except ValueError as e:
         # E.g., "not an ELF core file"
         sys.exit(f"error: {e}")

--- a/drgn/helpers/common/format.py
+++ b/drgn/helpers/common/format.py
@@ -232,7 +232,7 @@ def number_in_binary_units(n: SupportsFloat, precision: int = 1) -> str:
     for prefix in ("", "K", "M", "G", "T", "P", "E", "Z"):
         if abs(n) < 1024:
             break
-        n /= 1024
+        n /= 1024.0
     else:
         prefix = "Y"
     if n.is_integer():


### PR DESCRIPTION
Reflecting a bit of our discussion at Plumbers, I think this won't be too controversial. I've gone ahead and updated the pre-commit hooks to their latest versions, and handled any breakages there (see commit message for details). Of course, this blitzes past several tool versions which drop support for Python 3.6. So I've updated the CI to skip pre-commit/mypy on 3.6 / 3.7, and I've updated the contributing guide to explicitly state a policy on Python versions: 3.6+ is supported for building, running, & testing, but development tooling requires a non-EOL Python version.

Let me know your feelings on this, I think it will help alleviate some, but not all, of our woes with Python 3.6 support.