### PR TITLE
drgn.helpers.linux.stackdepot: add stack_depot_fetch() helper 

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -271,6 +271,13 @@ class Program:
             ``struct task_struct *`` object.
         """
         ...
+    def stack_trace_from_pcs(self, pcs: Sequence[IntegerLike]) -> StackTrace:
+        """
+        Get a stack trace with the supplied list of program counters.
+
+        :param pcs: List of program counters.
+        """
+        ...
     @overload
     def type(self, name: str, filename: Optional[str] = None) -> Type:
         """

--- a/drgn/helpers/linux/stackdepot.py
+++ b/drgn/helpers/linux/stackdepot.py
@@ -1,0 +1,47 @@
+# Copyright (c) Google LLC
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Stack Depot
+-----------
+
+The ``drgn.helpers.linux.stackdepot`` module provides helpers for working with
+the stack depot implementation used by KASAN and other kernel debugging tools.
+"""
+
+from typing import Optional
+
+from drgn import Object, StackTrace, cast, reinterpret
+
+__all__ = ("stack_depot_fetch",)
+
+
+def stack_depot_fetch(handle: Object) -> Optional[StackTrace]:
+    """
+    Returns a stack trace for the given stack handle.
+
+    :param handle: ``depot_stack_handle_t``
+    :return: The stack trace, or ``None`` if not available.
+    """
+    prog = handle.prog_
+    handle_parts = reinterpret("union handle_parts", handle)
+
+    # Renamed in Linux kernel commit 961c949b012f ("lib/stackdepot: rename slab
+    # to pool") (in v6.3).
+    try:
+        pool = prog["stack_pools"][handle_parts.pool_index]
+    except KeyError:
+        pool = prog["stack_slabs"][handle_parts.slabindex]
+
+    if not pool:
+        return None
+
+    # This has remained the same since the stack depot was introduced in
+    # commit cd11016e5f52 ("mm, kasan: stackdepot implementation. Enable
+    # stackdepot for SLAB"), when it was known as STACK_ALLOC_ALIGN.
+    DEPOT_STACK_ALIGN = 4
+
+    record = cast(
+        "struct stack_record *", pool + (handle_parts.offset << DEPOT_STACK_ALIGN)
+    )
+    return prog.stack_trace_from_pcs([record.entries[x] for x in range(record.size)])

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -3096,6 +3096,19 @@ struct drgn_error *drgn_program_stack_trace(struct drgn_program *prog,
 					    struct drgn_stack_trace **ret);
 
 /**
+ * Get a stack trace with the supplied list of program counters.
+ *
+ * @param[out] ret Returned stack trace. On success, it should be freed with
+ * @ref drgn_stack_trace_destroy(). On error, its contents are undefined.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *
+drgn_program_stack_trace_from_pcs(struct drgn_program *prog,
+				  const uint64_t *pcs,
+				  size_t pcs_size,
+				  struct drgn_stack_trace **ret);
+
+/**
  * Get a stack trace for the thread represented by @p obj.
  *
  * @sa drgn_program_stack_trace().


### PR DESCRIPTION
This helper returns a stack trace from the stack depot.