### PR TITLE
Update getting_debugging_symbols.rst

### DIFF
--- a/docs/getting_debugging_symbols.rst
+++ b/docs/getting_debugging_symbols.rst
@@ -14,6 +14,13 @@ distributions. If drgn prints an error like::
 
 Then you need to install debugging symbols.
 
+On the other hand, because drgn is based on the elfutils library, and elfutils
+can use the debuginfod protocol to automatically fetch debuginfo, on many 
+distros the $DEBUGINFOD_URLS environment variable is set, and the preceding
+message will not appear, and following steps may be unnecessary.  See 
+https://sourceware.org/elfutils/Debuginfod.html for details.
+
+
 Fedora
 ------
 


### PR DESCRIPTION
Confirmed elfutils/debuginfod code working fine for userspace drgn -p $pid type work.

Note that elfutils also has code for dwfl-reporting a running kernel and its modules ("dwfl_linux_kernel_report_kernel", "dwfl_linux_kernel_report_modules"), which could make your libdrgn code simpler, and also just work (tm) with debuginfod.