### PR TITLE
Add write support to Program

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -402,12 +402,33 @@ class Program:
         :raises FaultError: if the address is invalid; see :meth:`read()`
         """
         ...
+    def write(
+        self, address: IntegerLike, data: bytes, physical: bool = False
+    ) -> bytes:
+        """
+        Writes *data* starting at *address* in the program memory. The
+        address may be virtual (the default) or physical if the program
+        supports it.
+
+        >>> prog.write(0xffffffffbe012b40, b'swapper/0\x00\x00\x00\x00\x00\x00\x00')
+
+        :param address: The starting address.
+        :param data: The bytes to write.
+        :param physical: Whether *address* is a physical memory address. If
+            ``False``, then it is a virtual memory address. Physical memory can
+            usually only be read when the program is an operating system
+            kernel.
+        :raises FaultError: if the address range is invalid or the type of
+            address (physical or virtual) is not supported by the program
+        """
+        ...
     def add_memory_segment(
         self,
         address: IntegerLike,
         size: IntegerLike,
         read_fn: Callable[[int, int, int, bool], bytes],
         physical: bool = False,
+        write_fn: Optional[Callable[[int, bytes, int, bool], None]] = None,
     ) -> None:
         """
         Define a region of memory in the program.
@@ -425,6 +446,10 @@ class Program:
             the address is physical: ``(address, count, offset, physical)``. It
             should return the requested number of bytes as :class:`bytes` or
             another :ref:`buffer <python:binaryseq>` type.
+        :param write_fn: Callable to call to write memory to the segment. It is
+            passed the address being written to, the bytes to write,
+            the offset in bytes from the beginning of the segment, and whether
+            the address is physical: ``(address, data, offset, physical)``.
         """
         ...
     def add_type_finder(

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -78,8 +78,8 @@ libdrgnimpl_la_SOURCES = $(ARCH_DEFS_PYS:_defs.py=.c) \
 			 linux_kernel_helpers.c \
 			 log.c \
 			 log.h \
-			 memory_reader.c \
-			 memory_reader.h \
+			 memory_interface.c \
+			 memory_interface.h \
 			 minmax.h \
 			 nstring.h \
 			 object.c \

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -534,20 +534,22 @@ struct drgn_error *drgn_program_create(const struct drgn_platform *platform,
 void drgn_program_destroy(struct drgn_program *prog);
 
 /**
- * Callback implementing a memory read.
+ * Callback implementing a memory read and write.
  *
- * @param[out] buf Buffer to read into.
- * @param[in] address Address which we are reading from.
- * @param[in] count Number of bytes to read.
+ * @param[in] is_wirte Whether the operation is a write.
+ * @param[inout] buf Buffer to read into or write to.
+ * @param[in] address Address which we are reading from or writing to.
+ * @param[in] count Number of bytes to read or write.
  * @param[in] offset Offset in bytes of @p address from the beginning of the
  * segment.
  * @param[in] arg Argument passed to @ref drgn_program_add_memory_segment().
  * @param[in] physical Whether @c address is physical.
  * @return @c NULL on success, non-@c NULL on error.
  */
-typedef struct drgn_error *(*drgn_memory_read_fn)(void *buf, uint64_t address,
-						  size_t count, uint64_t offset,
-						  void *arg, bool physical);
+typedef struct drgn_error *(*drgn_memory_rw_fn)(bool is_write, void *buf,
+						uint64_t address, size_t count,
+						uint64_t offset, void *arg,
+						bool physical);
 
 /**
  * Register a segment of memory in a @ref drgn_program.
@@ -558,14 +560,14 @@ typedef struct drgn_error *(*drgn_memory_read_fn)(void *buf, uint64_t address,
  *
  * @param[in] address Address of the segment.
  * @param[in] size Size of the segment in bytes.
- * @param[in] read_fn Callback to read from segment.
- * @param[in] arg Argument to pass to @p read_fn.
+ * @param[in] rw_fn Callback to read from/write to segment.
+ * @param[in] arg Argument to pass to @p rw_fn.
  * @param[in] physical Whether to add a physical memory segment.
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *
 drgn_program_add_memory_segment(struct drgn_program *prog, uint64_t address,
-				uint64_t size, drgn_memory_read_fn read_fn,
+				uint64_t size, drgn_memory_rw_fn rw_fn,
 				void *arg, bool physical);
 
 /**

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -794,6 +794,21 @@ struct drgn_error *drgn_program_read_memory(struct drgn_program *prog,
 					    size_t count, bool physical);
 
 /**
+ * Write to a program's memory.
+ *
+ * @param[in] prog Program to write to.
+ * @param[in] buf Buffer to write.
+ * @param[in] address Starting address in memory to write.
+ * @param[in] count Number of bytes to write.
+ * @param[in] physical Whether @c address is physical. A program may support
+ * only virtual or physical addresses or both.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_program_write_memory(struct drgn_program *prog,
+					     void *buf, uint64_t address,
+					     size_t count, bool physical);
+
+/**
  * Read a C string from a program's memory.
  *
  * This reads up to and including the terminating null byte.

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -154,8 +154,8 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 	err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,
 					      drgn_read_kdump, ctx, true);
 	if (err) {
-		drgn_memory_reader_deinit(&prog->reader);
-		drgn_memory_reader_init(&prog->reader);
+		drgn_memory_interface_deinit(&prog->memory);
+		drgn_memory_interface_init(&prog->memory);
 		goto err_platform;
 	}
 

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -63,10 +63,14 @@ static struct drgn_error *drgn_platform_from_kdump(kdump_ctx_t *ctx,
 	return NULL;
 }
 
-static struct drgn_error *drgn_read_kdump(void *buf, uint64_t address,
-					  size_t count, uint64_t offset,
-					  void *arg, bool physical)
+static struct drgn_error *drgn_read_kdump(bool is_write, void *buf,
+					  uint64_t address, size_t count,
+					  uint64_t offset, void *arg,
+					  bool physical)
 {
+	if(is_write)
+		return drgn_error_create_fault("cannot write to kdump memory",
+					       address);
 	kdump_ctx_t *ctx = arg;
 	kdump_status ks;
 

--- a/libdrgn/linux_kernel.c
+++ b/libdrgn/linux_kernel.c
@@ -33,10 +33,14 @@
 
 #include "drgn_program_parse_vmcoreinfo.inc"
 
-struct drgn_error *read_memory_via_pgtable(void *buf, uint64_t address,
-					   size_t count, uint64_t offset,
-					   void *arg, bool physical)
+struct drgn_error *read_memory_via_pgtable(bool is_write, void *buf,
+					   uint64_t address, size_t count,
+					   uint64_t offset, void *arg,
+					   bool physical)
 {
+	if(is_write)
+		return drgn_error_create_fault("cannot write to memory",
+					       address);
 	struct drgn_program *prog = arg;
 	return linux_helper_read_vm(prog, prog->vmcoreinfo.swapper_pg_dir,
 				    address, buf, count);

--- a/libdrgn/linux_kernel.h
+++ b/libdrgn/linux_kernel.h
@@ -8,9 +8,10 @@
 
 struct drgn_debug_info_load_state;
 
-struct drgn_error *read_memory_via_pgtable(void *buf, uint64_t address,
-					   size_t count, uint64_t offset,
-					   void *arg, bool physical);
+struct drgn_error *read_memory_via_pgtable(bool is_write, void *buf,
+					   uint64_t address, size_t count,
+					   uint64_t offset, void *arg,
+					   bool physical);
 
 struct drgn_error *drgn_program_parse_vmcoreinfo(struct drgn_program *prog,
 						 const char *desc,

--- a/libdrgn/memory_interface.c
+++ b/libdrgn/memory_interface.c
@@ -258,7 +258,7 @@ struct drgn_error *drgn_memory_interface_rw(struct drgn_memory_interface *memory
 
 		size_t n = min((uint64_t)(count - 1),
 			       segment->max_address - address) + 1;
-		err = segment->rw_fn(false, p, address, n,
+		err = segment->rw_fn(is_write, p, address, n,
 				     address - segment->orig_min_address,
 				     segment->arg, physical);
 		if (err)

--- a/libdrgn/memory_interface.c
+++ b/libdrgn/memory_interface.c
@@ -22,9 +22,9 @@ struct drgn_memory_segment {
 	 * drgn_memory_segment::min_address.
 	 */
 	uint64_t orig_min_address;
-	/** Read callback. */
-	drgn_memory_read_fn read_fn;
-	/** Argument to pass to @ref drgn_memory_segment::read_fn. */
+	/** Read/write callback. */
+	drgn_memory_rw_fn rw_fn;
+	/** Argument to pass to @ref drgn_memory_segment::rw_fn. */
 	void *arg;
 };
 
@@ -72,7 +72,7 @@ bool drgn_memory_interface_empty(struct drgn_memory_interface *memory)
 struct drgn_error *
 drgn_memory_interface_add_segment(struct drgn_memory_interface *memory,
 				  uint64_t min_address, uint64_t max_address,
-				  drgn_memory_read_fn read_fn, void *arg,
+				  drgn_memory_rw_fn rw_fn, void *arg,
 				  bool physical)
 {
 	assert(min_address <= max_address);
@@ -128,7 +128,7 @@ drgn_memory_interface_add_segment(struct drgn_memory_interface *memory,
 			tail->min_address = max_address + 1;
 			tail->max_address = it.entry->max_address;
 			tail->orig_min_address = it.entry->orig_min_address;
-			tail->read_fn = it.entry->read_fn;
+			tail->rw_fn = it.entry->rw_fn;
 			tail->arg = it.entry->arg;
 
 			drgn_memory_segment_tree_insert(tree, tail, NULL);
@@ -227,7 +227,7 @@ insert:
 		truncate_tail->max_address = min_address - 1;
 	segment->min_address = segment->orig_min_address = min_address;
 	segment->max_address = max_address;
-	segment->read_fn = read_fn;
+	segment->rw_fn = rw_fn;
 	segment->arg = arg;
 	/* If the segment is stolen, then it's already in the tree. */
 	if (!stolen)
@@ -235,9 +235,10 @@ insert:
 	return NULL;
 }
 
-struct drgn_error *drgn_memory_interface_read(struct drgn_memory_interface *memory,
-					      void *buf, uint64_t address,
-					      size_t count, bool physical)
+struct drgn_error *drgn_memory_interface_rw(struct drgn_memory_interface *memory,
+					    bool is_write, void *buf,
+					    uint64_t address, size_t count,
+					    bool physical)
 {
 	assert(count == 0 || count - 1 <= UINT64_MAX - address);
 
@@ -257,9 +258,9 @@ struct drgn_error *drgn_memory_interface_read(struct drgn_memory_interface *memo
 
 		size_t n = min((uint64_t)(count - 1),
 			       segment->max_address - address) + 1;
-		err = segment->read_fn(p, address, n,
-				       address - segment->orig_min_address,
-				       segment->arg, physical);
+		err = segment->rw_fn(false, p, address, n,
+				     address - segment->orig_min_address,
+				     segment->arg, physical);
 		if (err)
 			return err;
 		p += n;
@@ -269,10 +270,15 @@ struct drgn_error *drgn_memory_interface_read(struct drgn_memory_interface *memo
 	return NULL;
 }
 
-struct drgn_error *drgn_read_memory_file(void *buf, uint64_t address,
-					 size_t count, uint64_t offset,
-					 void *arg, bool physical)
+struct drgn_error *drgn_read_memory_file(bool is_write, void *buf,
+					 uint64_t address, size_t count,
+					 uint64_t offset, void *arg,
+					 bool physical)
 {
+	if(is_write)
+		return drgn_error_create_fault("cannot write to memory",
+					       address);
+
 	struct drgn_memory_file_segment *file_segment = arg;
 	size_t file_count;
 	if (offset < file_segment->file_size) {

--- a/libdrgn/memory_interface.h
+++ b/libdrgn/memory_interface.h
@@ -66,31 +66,33 @@ bool drgn_memory_interface_empty(struct drgn_memory_interface *memory);
  * @param[in] memory Memory interface.
  * @param[in] min_address Start address (inclusive).
  * @param[in] max_address End address (inclusive). Must be `>= min_address`.
- * @param[in] read_fn Callback to read from segment.
- * @param[in] arg Argument to pass to @p read_fn.
+ * @param[in] rw_fn Callback to read from/write to segment.
+ * @param[in] arg Argument to pass to @p rw_fn.
  * @param[in] physical Whether to add a physical memory segment.
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *
 drgn_memory_interface_add_segment(struct drgn_memory_interface *memory,
 				  uint64_t min_address, uint64_t max_address,
-				  drgn_memory_read_fn read_fn, void *arg,
+				  drgn_memory_rw_fn rw_fn, void *arg,
 				  bool physical);
 
 /**
  * Read from a @ref drgn_memory_interface.
  *
  * @param[in] memory Memory interface.
- * @param[out] buf Buffer to read into.
- * @param[in] address Starting address in memory to read.
- * @param[in] count Number of bytes to read. `address + count - 1` must be
- * `<= UINT64_MAX`
+ * @param[in] is_write Whether the operation is a write.
+ * @param[inout] buf Buffer to read into or write from.
+ * @param[in] address Starting address in memory to read or write.
+ * @param[in] count Number of bytes to read or write. `address + count - 1` must
+ * be `<= UINT64_MAX`
  * @param[in] physical Whether @c address is physical.
  * @return @c NULL on success, non-@c NULL on error.
  */
-struct drgn_error *drgn_memory_interface_read(struct drgn_memory_interface *memory,
-					      void *buf, uint64_t address,
-					      size_t count, bool physical);
+struct drgn_error *drgn_memory_interface_rw(struct drgn_memory_interface *memory,
+					    bool is_write, void *buf,
+					    uint64_t address, size_t count,
+					    bool physical);
 
 /** Argument for @ref drgn_read_memory_file(). */
 struct drgn_memory_file_segment {
@@ -116,10 +118,11 @@ struct drgn_memory_file_segment {
 	bool zerofill;
 };
 
-/** @ref drgn_memory_read_fn which reads from a file. */
-struct drgn_error *drgn_read_memory_file(void *buf, uint64_t address,
-					 size_t count, uint64_t offset,
-					 void *arg, bool physical);
+/** @ref drgn_memory_rw_fn which reads from a file. */
+struct drgn_error *drgn_read_memory_file(bool is_write, void *buf,
+					 uint64_t address, size_t count,
+					 uint64_t offset, void *arg,
+					 bool physical);
 
 /** @} */
 

--- a/libdrgn/memory_interface.h
+++ b/libdrgn/memory_interface.h
@@ -9,8 +9,8 @@
  * See @ref MemoryReader.
  */
 
-#ifndef DRGN_MEMORY_READER_H
-#define DRGN_MEMORY_READER_H
+#ifndef DRGN_MEMORY_INTERFACE_H
+#define DRGN_MEMORY_INTERFACE_H
 
 #include "binary_search_tree.h"
 #include "drgn.h"
@@ -18,14 +18,14 @@
 /**
  * @ingroup Internals
  *
- * @defgroup MemoryReader Memory reader
+ * @defgroup MemoryReader Memory interface
  *
- * Memory reading interface.
+ * Memory reading and writing interface.
  *
- * @ref drgn_memory_reader provides a common interface for registering regions
- * of memory in a program and reading from memory.
+ * @ref drgn_memory_interface provides a common interface for registering regions
+ * of memory in a program, reading from and writing to memory.
  *
- * @ref drgn_memory_reader does not have a notion of the maximum address or
+ * @ref drgn_memory_interface does not have a notion of the maximum address or
  * address overflow/wrap-around. Those must be handled at a higher layer.
  *
  * @{
@@ -35,12 +35,12 @@ DEFINE_BINARY_SEARCH_TREE_TYPE(drgn_memory_segment_tree,
 			       struct drgn_memory_segment);
 
 /**
- * Memory reader.
+ * Memory interface.
  *
- * A memory reader maps the segments of memory in an address space to callbacks
- * which can be used to read memory from those segments.
+ * A memory interface maps the segments of memory in an address space to callbacks
+ * which can be used to read and write memory from those segments.
  */
-struct drgn_memory_reader {
+struct drgn_memory_interface {
 	/** Virtual memory segments. */
 	struct drgn_memory_segment_tree virtual_segments;
 	/** Physical memory segments. */
@@ -48,22 +48,22 @@ struct drgn_memory_reader {
 };
 
 /**
- * Initialize a @ref drgn_memory_reader.
+ * Initialize a @ref drgn_memory_interface.
  *
- * The reader is initialized with no segments.
+ * The memory interface is initialized with no segments.
  */
-void drgn_memory_reader_init(struct drgn_memory_reader *reader);
+void drgn_memory_interface_init(struct drgn_memory_interface *memory);
 
-/** Deinitialize a @ref drgn_memory_reader. */
-void drgn_memory_reader_deinit(struct drgn_memory_reader *reader);
+/** Deinitialize a @ref drgn_memory_interface. */
+void drgn_memory_interface_deinit(struct drgn_memory_interface *memory);
 
-/** Return whether a @ref drgn_memory_reader has no segments. */
-bool drgn_memory_reader_empty(struct drgn_memory_reader *reader);
+/** Return whether a @ref drgn_memory_interface has no segments. */
+bool drgn_memory_interface_empty(struct drgn_memory_interface *memory);
 
 /**
- * Add a segment to a @ref drgn_memory_reader.
+ * Add a segment to a @ref drgn_memory_interface.
  *
- * @param[in] reader Memory reader.
+ * @param[in] memory Memory interface.
  * @param[in] min_address Start address (inclusive).
  * @param[in] max_address End address (inclusive). Must be `>= min_address`.
  * @param[in] read_fn Callback to read from segment.
@@ -72,15 +72,15 @@ bool drgn_memory_reader_empty(struct drgn_memory_reader *reader);
  * @return @c NULL on success, non-@c NULL on error.
  */
 struct drgn_error *
-drgn_memory_reader_add_segment(struct drgn_memory_reader *reader,
-			       uint64_t min_address, uint64_t max_address,
-			       drgn_memory_read_fn read_fn, void *arg,
-			       bool physical);
+drgn_memory_interface_add_segment(struct drgn_memory_interface *memory,
+				  uint64_t min_address, uint64_t max_address,
+				  drgn_memory_read_fn read_fn, void *arg,
+				  bool physical);
 
 /**
- * Read from a @ref drgn_memory_reader.
+ * Read from a @ref drgn_memory_interface.
  *
- * @param[in] reader Memory reader.
+ * @param[in] memory Memory interface.
  * @param[out] buf Buffer to read into.
  * @param[in] address Starting address in memory to read.
  * @param[in] count Number of bytes to read. `address + count - 1` must be
@@ -88,9 +88,9 @@ drgn_memory_reader_add_segment(struct drgn_memory_reader *reader,
  * @param[in] physical Whether @c address is physical.
  * @return @c NULL on success, non-@c NULL on error.
  */
-struct drgn_error *drgn_memory_reader_read(struct drgn_memory_reader *reader,
-					   void *buf, uint64_t address,
-					   size_t count, bool physical);
+struct drgn_error *drgn_memory_interface_read(struct drgn_memory_interface *memory,
+					      void *buf, uint64_t address,
+					      size_t count, bool physical);
 
 /** Argument for @ref drgn_read_memory_file(). */
 struct drgn_memory_file_segment {

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -23,7 +23,7 @@
 #include "drgn.h"
 #include "hash_table.h"
 #include "language.h"
-#include "memory_reader.h"
+#include "memory_interface.h"
 #include "object_index.h"
 #include "platform.h"
 #include "pp.h"
@@ -61,7 +61,7 @@ struct drgn_program {
 	/*
 	 * Memory/core dump.
 	 */
-	struct drgn_memory_reader reader;
+	struct drgn_memory_interface memory;
 	/* Elf core dump or /proc/pid/mem file segments. */
 	struct drgn_memory_file_segment *file_segments;
 	/* Elf core dump. Not valid for live programs or kdump files. */

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -303,21 +303,17 @@ static int Program_clear(Program *self)
 	return 0;
 }
 
-static struct drgn_error *py_memory_read_fn(bool is_write, void *buf,
-					    uint64_t address, size_t count,
-					    uint64_t offset, void *arg,
-					    bool physical)
+static struct drgn_error *py_memory_read_fn(void *buf, uint64_t address,
+					    size_t count, uint64_t offset,
+					    PyObject *read_fn, bool physical)
 {
-	if(is_write)
-		return drgn_error_create_fault("cannot write to memory",
-					       address);
-
 	struct drgn_error *err;
 
 	PyGILState_guard();
 
 	_cleanup_pydecref_ PyObject *ret =
-		PyObject_CallFunction(arg, "KKKO", (unsigned long long)address,
+		PyObject_CallFunction(read_fn, "KKKO",
+				      (unsigned long long)address,
 				      (unsigned long long)count,
 				      (unsigned long long)offset,
 				      physical ? Py_True : Py_False);
@@ -340,23 +336,62 @@ out:
 	return err;
 }
 
+static struct drgn_error *py_memory_write_fn(void *buf, uint64_t address,
+					     size_t count, uint64_t offset,
+					     PyObject *write_fn, bool physical)
+{
+	if (write_fn == Py_None)
+		return drgn_error_create_fault("cannot write to memory",
+					       address);
+
+	PyGILState_guard();
+
+	_cleanup_pydecref_ PyObject *ret =
+		PyObject_CallFunction(write_fn, "Ky#KO",
+				      (unsigned long long)address,
+				      (char *)buf,
+				      (Py_ssize_t)count,
+				      (unsigned long long)offset,
+				      physical ? Py_True : Py_False);
+	if (!ret)
+		return drgn_error_from_python();
+	return NULL;
+}
+
+static struct drgn_error *py_memory_rw_fn(bool is_write, void *buf,
+					  uint64_t address, size_t count,
+					  uint64_t offset, void *arg,
+					  bool physical)
+{
+	if (is_write) {
+		PyObject *write_fn = PyTuple_GetItem(arg, 1);
+		return py_memory_write_fn(buf, address, count, offset, write_fn,
+					 physical);
+	} else {
+		PyObject *read_fn = PyTuple_GetItem(arg, 0);
+		return py_memory_read_fn(buf, address, count, offset, read_fn,
+					 physical);
+	}
+}
+
 static PyObject *Program_add_memory_segment(Program *self, PyObject *args,
 					    PyObject *kwds)
 {
 	static char *keywords[] = {
-		"address", "size", "read_fn", "physical", NULL,
+		"address", "size", "read_fn", "physical", "write_fn", NULL,
 	};
 	struct drgn_error *err;
 	struct index_arg address = {};
 	struct index_arg size = {};
 	PyObject *read_fn;
 	int physical = 0;
+	PyObject *write_fn = Py_None;
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwds,
-					 "O&O&O|p:add_memory_segment", keywords,
+					 "O&O&O|pO:add_memory_segment", keywords,
 					 index_converter, &address,
 					 index_converter, &size, &read_fn,
-					 &physical))
+					 &physical, &write_fn))
 	    return NULL;
 
 	if (!PyCallable_Check(read_fn)) {
@@ -364,11 +399,24 @@ static PyObject *Program_add_memory_segment(Program *self, PyObject *args,
 		return NULL;
 	}
 
-	if (Program_hold_object(self, read_fn) == -1)
+	if (write_fn != Py_None && !PyCallable_Check(write_fn)) {
+		PyErr_SetString(PyExc_TypeError, "write_fn must be callable");
+		return NULL;
+	}
+
+	Py_INCREF(read_fn);
+	Py_INCREF(write_fn);
+	PyObject *fns = Py_BuildValue("(OO)", read_fn, write_fn);
+	if (fns == NULL) {
+		PyErr_SetString(PyExc_TypeError, "cannot create function tuple");
+		return NULL;
+	}
+
+	if (Program_hold_object(self, fns) == -1)
 		return NULL;
 	err = drgn_program_add_memory_segment(&self->prog, address.uvalue,
-					      size.uvalue, py_memory_read_fn,
-					      read_fn, physical);
+					      size.uvalue, py_memory_rw_fn,
+					      fns, physical);
 	if (err)
 		return set_drgn_error(err);
 	Py_RETURN_NONE;
@@ -667,6 +715,30 @@ static PyObject *Program_read(Program *self, PyObject *args, PyObject *kwds)
 	clear = set_drgn_in_python();
 	err = drgn_program_read_memory(&self->prog, PyBytes_AS_STRING(buf),
 				       address.uvalue, size, physical);
+	if (clear)
+		clear_drgn_in_python();
+	if (err)
+		return set_drgn_error(err);
+	return_ptr(buf);
+}
+
+static PyObject *Program_write(Program *self, PyObject *args, PyObject *kwds)
+{
+	static char *keywords[] = {"address", "data", "physical", NULL};
+	struct drgn_error *err;
+	struct index_arg address = {};
+	Py_ssize_t size;
+	const char *buf;
+	int physical = 0;
+	bool clear;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&y#|p:write", keywords,
+					 index_converter, &address, &buf, &size,
+					 &physical))
+	    return NULL;
+
+	clear = set_drgn_in_python();
+	err = drgn_program_write_memory(&self->prog, buf,
+				        address.uvalue, size, physical);
 	if (clear)
 		clear_drgn_in_python();
 	if (err)
@@ -1188,6 +1260,8 @@ static PyMethodDef Program_methods[] = {
 	METHOD_DEF_READ(u64),
 	METHOD_DEF_READ(word),
 #undef METHOD_READ_U
+	{"write", (PyCFunction)Program_write, METH_VARARGS | METH_KEYWORDS,
+	 drgn_Program_write_DOC},
 	{"type", (PyCFunction)Program_find_type, METH_VARARGS | METH_KEYWORDS,
 	 drgn_Program_type_DOC},
 	{"object", (PyCFunction)Program_object, METH_VARARGS | METH_KEYWORDS,

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -303,10 +303,15 @@ static int Program_clear(Program *self)
 	return 0;
 }
 
-static struct drgn_error *py_memory_read_fn(void *buf, uint64_t address,
-					    size_t count, uint64_t offset,
-					    void *arg, bool physical)
+static struct drgn_error *py_memory_read_fn(bool is_write, void *buf,
+					    uint64_t address, size_t count,
+					    uint64_t offset, void *arg,
+					    bool physical)
 {
+	if(is_write)
+		return drgn_error_create_fault("cannot write to memory",
+					       address);
+
 	struct drgn_error *err;
 
 	PyGILState_guard();

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -170,6 +170,12 @@ class TestMemory(TestCase):
         self.assertEqual(prog.read(0xFFFF0000, len(data)), data)
         self.assertEqual(prog.read(0xA0, len(data), True), data)
 
+    def test_simple_write(self):
+        data = b"I hate trains"
+        prog = mock_program(segments=[MockMemorySegment(data, 0xFFFF0000, 0xA0, writable=True)])
+        prog.write(0xFFFF0002, b'like')
+        self.assertEqual(prog.read(0xFFFF0000, len(data)), b"I like trains")
+
     def test_read_unsigned(self):
         data = b"\x01\x02\x03\x04\x05\x06\x07\x08"
         for word_size in [8, 4]:


### PR DESCRIPTION
Hi,

I'm trying to add support for writing memory related to #324.

For now, the changes for the Python API are an optional `write_fn` parameter to `Program.add_memory_segment`, and the method `Program.write`.
Before I try to tackle the missing pieces (writable objects, and optional write support in the Program constructors), I wanted to make sure I'm on the right track.

Note that on the C-side, instead of adding `*_write` functions as counterparts to the `*_read` functions, I tried to maintain as much as possible a unique `*_rw(bool is_write, void *buf, size_t count)` kind of functions. 
This has the advantage of reusing the internal logic of some functions for both cases (eg: `drgn_program_read_rw`).
However, I'm now seeing that maybe the buf parameter should be `const void *` for the write functions, or I need to make some dirty casts :/.

Also, the naming choices are maybe not the best (`memory_interface` is meh, and if we keep the `*_rw` functions, maybe `*_transfer` would be prettier).

Anyway, feel free to review the changes and tell me if I made some mistakes, I'll need to rebase it anyway to add the Signed-Off-By that I forgot in the commits :).