### PR TITLE
Add drgn helpers and script for locking primitives

### DIFF
--- a/contrib/locks.py
+++ b/contrib/locks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env drgn
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+""" Script to dump lock information"""
+
+import sys
+from argparse import ArgumentParser
+from drgn import Object
+from drgn.helpers.linux.locks import mutex_is_locked
+from drgn.helpers.linux.locks import mutex_owner
+from drgn.helpers.linux.locks import mutex_for_each_waiter_task
+
+###############################################
+# mutex
+###############################################
+def dump_mutex_waiters_call_stack(mutex: Object) -> None:
+    """
+    Dump call stacks for all tasks blocked on a mutex.
+
+    :param lock: ``struct mutex *``
+    """
+    prog = mutex.prog_
+    print(f"Dumping call stack for waiter of mutex: {mutex.value_():x}")
+    for task in mutex_for_each_waiter_task(mutex):
+        trace = prog.stack_trace(task.pid.value_())
+        print(f"\ncall stack for pid: {task.pid.value_()}")
+        print(trace)
+        print("\n")
+
+
+def dump_mutex_owner_call_stack(mutex: Object) -> None:
+    """
+    Dump call stack of mutex owner.
+
+    :param lock: ``struct mutex *``
+    """
+    prog = mutex.prog_
+    if mutex_is_locked(mutex):
+        owner = mutex_owner(mutex)
+        print(f"Dumping call stack for owner of mutex: {mutex.value_():x}")
+        trace = prog.stack_trace(owner.pid.value_())
+        print(f"\ncall stack for pid: {owner.pid.value_()}")
+        print(trace)
+        print("\n")
+
+
+def parse_cmdline_args(args):
+    parser = ArgumentParser()
+    parser.add_argument("lock_type", type=str, help="type of lock i.e mutex. semaphore, rwsemaphore etc.")
+    parser.add_argument("info_type", type=str, help="\"owner\" or \"waiter\" or \"all\"")
+    parser.add_argument("locks", nargs="*", default=None, help="list of lock addresses")
+    args = parser.parse_args()
+    return args
+
+def main():
+    cmd_opts = parse_cmdline_args(sys.argv[1:])
+    lock_type = cmd_opts.lock_type
+    info_type = cmd_opts.info_type
+    if isinstance(cmd_opts.locks, list):
+        locks = cmd_opts.locks
+
+    if lock_type == "semaphore" and info_type == "owner":
+        print ("Owner info not available for semaphores.")
+
+    if lock_type == "mutex":
+        for lock_addr in locks:
+            lock = Object(prog, "struct mutex", address=int(lock_addr, 16))
+            if (info_type == "all" or info_type == "waiter"):
+                dump_mutex_waiters_call_stack(lock.address_of_())
+            if (info_type == "all" or info_type == "owner"):
+                dump_mutex_owner_call_stack(lock.address_of_())
+    else:
+        print(f"No information available for {lock_type}.") 
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/locks.py
+++ b/contrib/locks.py
@@ -4,13 +4,27 @@
 
 """ Script to dump lock information"""
 
-import sys
-from argparse import ArgumentParser
+import argparse
+
 from drgn import Object
-from drgn.helpers.linux.locks import mutex_is_locked
-from drgn.helpers.linux.locks import mutex_owner
-from drgn.helpers.linux.locks import mutex_for_each_waiter_task
-from drgn.helpers.linux.locks import semaphore_for_each_waiter_task
+from drgn.helpers.linux.list import list_empty
+from drgn.helpers.linux.locks import (
+    _RWSEM_READER_MASK,
+    _RWSEM_READER_SHIFT,
+    get_rwsem_owner,
+    get_rwsem_waiter_type,
+    is_rwsem_reader_owned,
+    is_rwsem_writer_owned,
+    mutex_for_each_waiter_task,
+    mutex_is_locked,
+    mutex_owner,
+    rwsem_for_each_waiter,
+    rwsem_for_each_waiter_task,
+    rwsem_is_locked,
+    semaphore_for_each_waiter_task,
+)
+from drgn.helpers.linux.sched import task_state_to_char
+
 
 ###############################################
 # mutex
@@ -46,9 +60,67 @@ def dump_mutex_owner_call_stack(mutex: Object) -> None:
         print("\n")
 
 
+def get_mutex_waiters_info(mutex: Object) -> None:
+    """
+    Get information about waiter(s) of a given mutex.
+    This consists of ``struct task_struct *``, pid(s)
+    and state of waiter(s)
+
+    :param mutex: ``struct mutex *``
+    """
+    if list_empty(mutex.wait_list.address_of_()):
+        print(f"  mutex: {mutex.value_():x} has no waiters.")
+        return
+
+    print(f"  The waiters of mutex: {mutex.value_():x} are as follows: ")
+    for task in mutex_for_each_waiter_task(mutex):
+        print(
+            f"    ({task.type_.type_name()})0x{task.value_():x} pid: {task.pid.value_()} state: {task_state_to_char(task)}"
+        )
+    print("\n")
+
+
+def get_mutex_info(mutex: Object) -> None:
+    """
+    Get information about given mutex.
+    This consists of ``struct task_struct *``, pid(s) and state
+    of owner and waiter(s) (if any).
+
+    :param mutex: ``struct mutex *``
+    """
+    if mutex_is_locked(mutex):
+        owner = mutex_owner(mutex)
+        print(
+            f"  mutex: {mutex.value_():x} is owned by ({owner.type_.type_name()})0x{owner.value_():x} pid: {owner.pid.value_()} state: {task_state_to_char(owner)}"
+        )
+        get_mutex_waiters_info(mutex)
+    else:
+        print(f"  mutex: {mutex.value_():x} is not locked.")
+
+
 ###############################################
 # semaphore
 ###############################################
+def get_semaphore_waiters_info(semaphore: Object) -> None:
+    """
+    Get information about waiter(s) of a given semaphore.
+    This consists of ``struct task_struct *``, pid(s)
+    and state of waiter(s)
+
+    :param semaphore: ``struct semaphore *``
+    """
+    if list_empty(semaphore.wait_list.address_of_()):
+        print(f"  semaphore: {semaphore.value_():x} has no waiters.")
+        return
+
+    print(f"  The waiters of semaphore: {semaphore.value_():x} are as follows: ")
+    for task in semaphore_for_each_waiter_task(semaphore):
+        print(
+            f"    ({task.type_.type_name()})0x{task.value_():x} pid: {task.pid.value_()} state: {task_state_to_char(task)}"
+        )
+    print("\n")
+
+
 def dump_semaphore_waiters_call_stack(semaphore: Object) -> None:
     """
     Dump call stacks for all tasks blocked on a semaphore.
@@ -63,38 +135,252 @@ def dump_semaphore_waiters_call_stack(semaphore: Object) -> None:
         print(trace)
         print("\n")
 
-def parse_cmdline_args(args):
-    parser = ArgumentParser()
-    parser.add_argument("lock_type", type=str, help="type of lock i.e mutex. semaphore, rwsemaphore etc.")
-    parser.add_argument("info_type", type=str, help="\"owner\" or \"waiter\" or \"all\"")
-    parser.add_argument("locks", nargs="*", default=None, help="list of lock addresses")
-    args = parser.parse_args()
-    return args
+
+###############################################
+# rwsem
+###############################################
+def get_rwsem_info(rwsem: Object) -> None:
+    """
+    Get information about given rwsem.
+    This consists of ``struct task_struct *``, pid(s), type
+    and state of owner and waiter(s) (if any).
+
+    :param rwsem: ``struct rw_semaphore *``
+    """
+
+    # This helper supports LTS versions since v4.14. It may work with
+    # other versions too but has not been tested with other versions.
+    # Now from v4.14 to v5.2 ->owner is of type task_struct * and ->count
+    # is adjusted/interpreted according different BIAS(es) like
+    # ACTIVE_BIAS, WRITE_BIAS etc.
+    # Linux kernel commit 94a9717b3c40 ('locking/rwsem: Make rwsem->owner
+    # an atomic_long_t') (since v5.3.1) changed ->owner type and Linux kernel
+    # commit 64489e78004c ('locking/rwsem: Implement a new locking scheme')
+    # (also since v5.3.1) removed usage of different BIAS(es) and re-defined
+    # usage and interpretation of ->count bits.
+    # So although type change of ->owner and re-definition of ->count bits
+    # happened in 2 different commits, both of these changes are available
+    # since v5.3.1.
+    # So we can use ->owner type to distinguish between new and old usage
+    # of rwsem ->count and ->owner bits.
+    if not rwsem_is_locked(rwsem):
+        print(f"  rwsem: {rwsem.value_():x} is free.")
+        return
+
+    owner_is_writer = is_rwsem_writer_owned(rwsem)
+    owner_is_reader = is_rwsem_reader_owned(rwsem)
+
+    if owner_is_writer:
+        owner_task = get_rwsem_owner(rwsem)
+        if not owner_task:
+            print(f"  rwsem: {rwsem.value_():x} is owned by anonymous writer.")
+        else:
+            print(
+                f"  rwsem: {rwsem.value_():x} owned by writer ({owner_task.type_.type_name()})0x{owner_task.value_():x}  (pid){owner_task.pid.value_()}  (state){task_state_to_char(owner_task)} "
+            )
+    elif owner_is_reader:
+        if rwsem.owner.type_.type_name() == "atomic_long_t":
+            num_readers = (
+                rwsem.count.counter.value_() & _RWSEM_READER_MASK
+            ) >> _RWSEM_READER_SHIFT
+            print(f"  rwsem: {rwsem.value_():x} is owned by {num_readers} reader(s).")
+        else:
+            print(f"  rwsem: {rwsem.value_():x} is owned by one or more readers.")
+    else:
+        print(f"  Can't determine type of owner for rwsem: {rwsem.value_():x}.")
+
+    if list_empty(rwsem.wait_list.address_of_()):
+        print(f"  There are no waiters for rwsem: {rwsem.value_():x}.")
+    else:
+        get_rwsem_waiters_info(rwsem)
+
+
+def dump_rwsem_waiters_call_stack(rwsem: Object) -> None:
+    """
+    Dump call stack of all task(s) blocked on a given rwsem
+
+    :param rwsem: ``struct rw_semaphore *``
+    """
+    if list_empty(rwsem.wait_list.address_of_()):
+        print(f"  rwsem: {rwsem.value_():x} has no waiters.")
+        return
+
+    prog = rwsem.prog_
+    print(f"Dumping call stack for waiter of rwsem: {rwsem.value_():x}")
+    for task in rwsem_for_each_waiter_task(rwsem):
+        trace = prog.stack_trace(task.pid.value_())
+        print(f"\ncall stack for pid: {task.pid.value_()}")
+        print(trace)
+        print("\n")
+
+
+def dump_rwsem_owner_call_stack(rwsem: Object) -> None:
+    """
+    Dump call stack of rwsem's owner (if owner could be found.")
+
+    :param rwsem: ``struct rw_semaphore *``
+    """
+
+    prog = rwsem.prog_
+    owner = get_rwsem_owner(rwsem)
+    if owner:
+        print(f"Dumping call stack for owner of rwsem: {rwsem.value_():x}")
+        trace = prog.stack_trace(owner.pid.value_())
+        print(f"\ncall stack for pid: {owner.pid.value_()}")
+        print(trace)
+        print("\n")
+    else:
+        print(
+            f"rwsem: {rwsem.value_():x} is free or could not find it's owner reliably"
+        )
+
+
+def get_rwsem_waiters_info(rwsem: Object) -> None:
+    """
+    Get a summary of rwsem waiters.
+    The summary consists of ``struct task_struct *``, pid and type and state of waiters
+
+    :param rwsem: ``struct rw_semaphore *``
+    """
+
+    if list_empty(rwsem.wait_list.address_of_()):
+        print(f"  rwsem: {rwsem.value_():x} has no waiters.")
+        return
+
+    waiter_type = "none"
+    print("  The waiters of rwsem are as follows: ")
+    for waiter in rwsem_for_each_waiter(rwsem):
+        waiter_type = get_rwsem_waiter_type(waiter)
+        task = waiter.task
+        print(
+            f"    ({task.type_.type_name()})0x{task.value_():x}: (pid){task.pid.value_()}: type: {waiter_type} state: {task_state_to_char(task)}"
+        )
+    print("\n")
+
+
+def cmd_mutex(args):
+    print("##### In cmd_mutex ####")
+    for lock_addr in args.locks:
+        lock = Object(prog, "struct mutex", address=int(lock_addr, 16))
+        if args.info:
+            get_mutex_info(lock.address_of_())
+        elif args.waiter_list:
+            get_mutex_waiters_info(lock.address_of_())
+        elif args.waiter_callstack:
+            dump_mutex_waiters_call_stack(lock.address_of_())
+        elif args.owner_callstack:
+            dump_mutex_owner_call_stack(lock.address_of_())
+
+
+def cmd_semaphore(args):
+    print("##### In cmd_semaphore ####")
+    for lock_addr in args.locks:
+        lock = Object(prog, "struct semaphore", address=int(lock_addr, 16))
+        if args.info or args.waiter_list:
+            get_semaphore_waiters_info(lock.address_of_())
+        elif args.waiter_callstack:
+            dump_semaphore_waiters_call_stack(lock.address_of_())
+
+
+def cmd_rwsem(args):
+    print("##### In cmd_rwsem ####")
+    for lock_addr in args.locks:
+        lock = Object(prog, "struct rw_semaphore", address=int(lock_addr, 16))
+        if args.info:
+            get_rwsem_info(lock.address_of_())
+        elif args.waiter_list:
+            get_rwsem_waiters_info(lock.address_of_())
+        elif args.waiter_callstack:
+            dump_rwsem_waiters_call_stack(lock.address_of_())
+        elif args.owner_callstack:
+            dump_rwsem_owner_call_stack(lock.address_of_())
+
 
 def main():
-    cmd_opts = parse_cmdline_args(sys.argv[1:])
-    lock_type = cmd_opts.lock_type
-    info_type = cmd_opts.info_type
-    if isinstance(cmd_opts.locks, list):
-        locks = cmd_opts.locks
+    parser = argparse.ArgumentParser("drgn script to dump lock information")
+    sub_parsers = parser.add_subparsers(title="subcommands", dest="subcommand")
+    sub_parsers.required = True
 
-    if lock_type == "semaphore" and info_type == "owner":
-        print ("Owner info not available for semaphores.")
+    parser_mutex = sub_parsers.add_parser("mutex", help="get mutex info.")
+    mutex_arg_group = parser_mutex.add_mutually_exclusive_group()
+    mutex_arg_group.add_argument(
+        "--info",
+        action="store_true",
+        help="dump given mutex's info like owner, waiter(s) etc.",
+    )
+    mutex_arg_group.add_argument(
+        "--waiter-list",
+        action="store_true",
+        help="provide a list, of waiters of given mutex(es)",
+    )
+    mutex_arg_group.add_argument(
+        "--waiter-callstack",
+        action="store_true",
+        help="provide callstack of all waiters of given mutex(es)",
+    )
+    mutex_arg_group.add_argument(
+        "--owner-callstack",
+        action="store_true",
+        help="provide callstack of owner of given mutex(es)",
+    )
+    parser_mutex.add_argument(
+        "locks", nargs="*", default=None, help="list of lock addresses"
+    )
+    parser_mutex.set_defaults(func=cmd_mutex)
 
-    if lock_type == "mutex":
-        for lock_addr in locks:
-            lock = Object(prog, "struct mutex", address=int(lock_addr, 16))
-            if (info_type == "all" or info_type == "waiter"):
-                dump_mutex_waiters_call_stack(lock.address_of_())
-            if (info_type == "all" or info_type == "owner"):
-                dump_mutex_owner_call_stack(lock.address_of_())
-    elif lock_type == "semaphore":
-        for lock_addr in locks:
-            lock = Object(prog, "struct semaphore", address=int(lock_addr, 16))
-            if (info_type == "all" or info_type == "waiter"):
-                dump_semaphore_waiters_call_stack(lock.address_of_())
-    else:
-        print(f"No information available for {lock_type}.") 
+    parser_semaphore = sub_parsers.add_parser("semaphore", help="get semaphore info.")
+    semaphore_arg_group = parser_semaphore.add_mutually_exclusive_group()
+    semaphore_arg_group.add_argument(
+        "--info",
+        action="store_true",
+        help="dump given semaphore's info like waiter(s) etc.",
+    )
+    semaphore_arg_group.add_argument(
+        "--waiter-list",
+        action="store_true",
+        help="provide a list, of waiters of given semaphore(s)",
+    )
+    semaphore_arg_group.add_argument(
+        "--waiter-callstack",
+        action="store_true",
+        help="provide callstack of all waiters of given semaphore(s)",
+    )
+    parser_semaphore.add_argument(
+        "locks", nargs="*", default=None, help="list of lock addresses"
+    )
+    parser_semaphore.set_defaults(func=cmd_semaphore)
+
+    parser_rwsem = sub_parsers.add_parser(
+        "rwsem", help="get read-write semaphore info."
+    )
+    rwsem_arg_group = parser_rwsem.add_mutually_exclusive_group()
+    rwsem_arg_group.add_argument(
+        "--info",
+        action="store_true",
+        help="dump given rwsem's info like owner, waiter(s) etc.",
+    )
+    rwsem_arg_group.add_argument(
+        "--waiter-list",
+        action="store_true",
+        help="provide a list, of waiters of given rwsem(s)",
+    )
+    rwsem_arg_group.add_argument(
+        "--waiter-callstack",
+        action="store_true",
+        help="provide callstack of all waiters of given rwsem(s)",
+    )
+    rwsem_arg_group.add_argument(
+        "--owner-callstack",
+        action="store_true",
+        help="provide callstack of owner of given rwsem(s)",
+    )
+    parser_rwsem.add_argument(
+        "locks", nargs="*", default=None, help="list of lock addresses"
+    )
+    parser_rwsem.set_defaults(func=cmd_rwsem)
+
+    args = parser.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/drgn/helpers/linux/locks.py
+++ b/drgn/helpers/linux/locks.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Locks
+-----------
+
+The ``drgn.helpers.linux.locks`` module provides helpers for working with
+different kernel locking primitives like semaphore, mutex, read-write
+semaphore etc.
+"""
+from typing import Iterator
+
+from drgn import NULL, Object, cast
+from drgn.helpers.linux.list import list_for_each_entry
+
+######################################
+# mutex
+######################################
+
+_MUTEX_FLAGS = 0x07
+
+
+def mutex_owner(lock: Object) -> Object:
+    """
+    Get owner of a mutex.
+
+    :param lock: ``struct mutex *``
+    :return: ``struct task_struct *`` corresponding to owner, ``NULL``
+             otherwise.
+    """
+    try:
+        owner = lock.owner
+        if owner.type_.type_name() == "struct task_struct *":
+            return owner
+        elif owner.value_():
+            # Since Linux kernel commit 3ca0ff571b09 ("locking/mutex: Rework mutex::owner")
+            # (in v4.10) count has been replaced with atomic_long_t owner that contains the
+            # owner information (earlier available under task_struct *owner) and uses lower
+            # bits for mutex state
+            owner = cast("unsigned long", owner.counter.read_()) & ~_MUTEX_FLAGS
+            return Object(lock.prog_, "struct task_struct", address=owner).address_of_()
+        else:
+            return NULL(lock.prog_, "struct task_struct *")
+    except AttributeError:
+        print("Mutex does not have owner information")
+        return NULL(lock.prog_, "struct task_struct *")
+
+
+def mutex_is_locked(lock: Object) -> bool:
+    """
+    Check if a given mutex is locked or not.
+
+    :param lock: ``struct mutex *``
+    :return: True if mutex is locked, False otherwise.
+    """
+    try:
+        count = lock.count
+        if count.counter.value_() != 1:
+            return True
+        else:
+            return False
+    except AttributeError:
+        ret = True if mutex_owner(lock) else False
+        return ret
+
+
+def mutex_for_each_waiter(lock: Object) -> Iterator[Object]:
+    """
+    Iterate over all mutex_waiter objects for a mutex.
+
+    :param lock: ``struct mutex *``
+    :return: Iterator of ``struct mutex_waiter *`` objects.
+    """
+    for waiter in list_for_each_entry(
+        "struct mutex_waiter", lock.wait_list.address_of_(), "list"
+    ):
+        yield waiter
+
+
+def mutex_for_each_waiter_task(lock: Object) -> Iterator[Object]:
+    """
+    Iterate over all tasks blocked on a mutex.
+
+    :param lock: ``struct mutex *``
+    :return: Iterator of ``struct task_struct *`` objects.
+    """
+    for waiter in mutex_for_each_waiter(lock):
+        yield waiter.task

--- a/drgn/helpers/linux/locks.py
+++ b/drgn/helpers/linux/locks.py
@@ -154,6 +154,16 @@ _RWSEM_WR_NONSPINNABLE = 1 << 2
 _RWSEM_NONSPINNABLE = 1 << 1
 
 
+def rwsem_is_locked(lock: Object) -> bool:
+    """
+    Check if a given rwsem is locked or not.
+
+    :param lock: ``struct rw_semaphore *``
+    :return: True if rwsem is locked, False otherwise.
+    """
+    return lock.count.counter.value_() != 0
+
+
 def rwsem_for_each_waiter(rwsem: Object) -> Iterator[Object]:
     """
     Iterate over all rwsem_waiter objects for a given rwsem.

--- a/drgn/helpers/linux/locks.py
+++ b/drgn/helpers/linux/locks.py
@@ -127,3 +127,163 @@ def semaphore_for_each_waiter_task(lock: Object) -> Iterator[Object]:
     """
     for waiter in semaphore_for_each_waiter(lock):
         yield waiter.task
+
+
+######################################
+# rwsem
+######################################
+
+# Masks for rwsem.count
+_RWSEM_WRITER_LOCKED = 1 << 0
+_RWSEM_FLAG_WAITERS = 1 << 1
+_RWSEM_FLAG_HANDOFF = 1 << 2
+# Bits 8-62(i.e. 55 bits of counter indicate number of current readers that hold the lock)
+_RWSEM_READER_MASK = 0x7FFFFFFFFFFFFF00  # Bits 8-62 - 55-bit reader count
+_RWSEM_WRITER_MASK = 1 << 0
+_RWSEM_READER_SHIFT = 8
+
+# Masks for rwsem.owner
+_RWSEM_READER_OWNED = 1 << 0
+_RWSEM_ANONYMOUSLY_OWNED = 1 << 0  # For old kernels
+_RWSEM_RD_NONSPINNABLE = 1 << 1
+_RWSEM_WR_NONSPINNABLE = 1 << 2
+
+# Linux kernel commit 617f3ef95177840c77f59c2aec1029d27d5547d6 ("locking/rwsem:
+# Remove reader optimistic spinning") (in v5.11) removed optimistic spinning for
+# readers and hence left one bit to check for spinnable
+_RWSEM_NONSPINNABLE = 1 << 1
+
+
+def rwsem_for_each_waiter(rwsem: Object) -> Iterator[Object]:
+    """
+    Iterate over all rwsem_waiter objects for a given rwsem.
+
+    :param rwsem: ``struct rw_semaphore *``
+    :returns: Iterator of ``struct rwsem_waiter``
+    """
+
+    for waiter in list_for_each_entry(
+        "struct rwsem_waiter", rwsem.wait_list.address_of_(), "list"
+    ):
+        yield waiter
+
+
+def rwsem_for_each_waiter_task(rwsem: Object) -> Iterator[Object]:
+    """
+    Iterate over all tasks blocked on  a given rwsem.
+
+    :param rwsem: ``struct rw_semaphore *``
+    :returns: Iterator of ``struct task_struct *``
+    """
+
+    for waiter in rwsem_for_each_waiter(rwsem):
+        yield waiter.task
+
+
+def get_rwsem_owner(rwsem: Object) -> Object:
+    """
+    Find owner of  given rwsem
+
+    :param rwsem: ``struct rw_semaphore *``
+    :returns: ``struct task_struct *`` if owner can be found, NULL otherwise
+    """
+    prog = rwsem.prog_
+    if not rwsem.count.counter.value_():
+        print("rwsem is free.")
+        return NULL(prog, "struct task_struct *")
+
+    if is_rwsem_writer_owned(rwsem):
+        if rwsem.owner.type_.type_name() != "atomic_long_t":
+            if rwsem.owner.value_() & _RWSEM_ANONYMOUSLY_OWNED:
+                print("rwsem is owned by anonymous writer")
+                return NULL(prog, "struct task_struct *")
+            else:
+                return rwsem.owner
+        else:
+            owner = cast("struct task_struct *", rwsem.owner.counter)
+            return owner
+    else:
+        # If rwsem is owned by one or more readers or other cases
+        # when owner field is not reliable
+        print("Could not reliably determine rwsem owner")
+        return NULL(prog, "struct task_struct *")
+
+
+def get_rwsem_waiter_type(rwsem_waiter: Object) -> str:
+    """
+    Find type of an rwsem waiter
+
+    :param rwsem_waiter: ``struct rwsem_waiter``
+    :returns: str indicating type of rwsem waiter
+    """
+
+    prog = rwsem_waiter.prog_
+    if rwsem_waiter.type.value_() == prog["RWSEM_WAITING_FOR_WRITE"].value_():
+        waiter_type = "down_write"
+    elif rwsem_waiter.type.value_() == prog["RWSEM_WAITING_FOR_READ"].value_():
+        waiter_type = "down_read"
+    else:
+        waiter_type = "waiter type unknown"
+
+    return waiter_type
+
+
+def is_rwsem_reader_owned(rwsem: Object) -> bool:
+    """
+    Check if rwsem is reader owned or not
+
+    :param rwsem: ``struct rw_semaphore *``
+    :returns: True if rwsem is reader owned, False otherwise (including the
+              case when type of owner could not be determined or when rwsem
+              is free.)
+    """
+    if not rwsem.count.counter.value_():  # rwsem is free
+        return False
+    if rwsem.owner.type_.type_name() == "atomic_long_t":
+        # If LSB of rwsem.count is set, rwsem is owned by a writer
+        owner_is_writer = rwsem.count.counter.value_() & _RWSEM_WRITER_LOCKED
+        # To confirm that rwsem is owned by a reader, 3 conditions
+        # should be true
+        #  1. Reader count i.e bits 8-62 of rwsem.count should have some
+        #     non-zero value
+        #  2. LSB of rwsem.owner should be set
+        #  3. LSB of rwsem.count should not be set i.e rwsem is not owned
+        #     by a writer
+        owner_is_reader = (
+            (rwsem.count.counter.value_() & _RWSEM_READER_MASK)
+            and (rwsem.owner.counter.value_() & _RWSEM_READER_OWNED)
+            and (owner_is_writer == 0)
+        )
+
+        return bool(owner_is_reader)
+    else:
+        if not rwsem.owner.value_():
+            print("rwsem is being acquired but owner info has not yet been set.")
+            return False
+        owner_is_reader = rwsem.owner.value_() == _RWSEM_READER_OWNED
+        return owner_is_reader
+
+
+def is_rwsem_writer_owned(rwsem: Object) -> bool:
+    """
+    Check if rwsem is writer owned or not
+
+    :param rwsem: ``struct rw_semaphore *``
+    :returns: True if rwsem is writer owned, False otherwise (including the
+              case when type of owner could not be determined or when rwsem
+              was free.)
+    """
+    if not rwsem.count.counter.value_():  # rwsem is free
+        return False
+
+    if rwsem.owner.type_.type_name() == "atomic_long_t":
+        # If LSB of rwsem.count is set, rwsem is owned by a writer
+        owner_is_writer = rwsem.count.counter.value_() & _RWSEM_WRITER_LOCKED
+        return bool(owner_is_writer)
+    else:
+        if not rwsem.owner.value_():
+            print("rwsem is being acquired but owner info has not yet been set.")
+            return False
+
+        owner_is_reader = rwsem.owner.value_() == _RWSEM_READER_OWNED
+        return not owner_is_reader

--- a/drgn/helpers/linux/locks.py
+++ b/drgn/helpers/linux/locks.py
@@ -87,3 +87,43 @@ def mutex_for_each_waiter_task(lock: Object) -> Iterator[Object]:
     """
     for waiter in mutex_for_each_waiter(lock):
         yield waiter.task
+
+
+######################################
+# semaphore
+######################################
+
+
+def semaphore_is_locked(lock: Object) -> bool:
+    """
+    Check if a given semaphore is locked or not.
+
+    :param lock: ``struct semaphore *``
+    :return: True if semphore is locked (i.e count <= 0), False otherwise.
+    """
+
+    return lock.count.value_() <= 0
+
+
+def semaphore_for_each_waiter(lock: Object) -> Iterator[Object]:
+    """
+    Iterate over all semaphore_waiter objects for a semaphore.
+
+    :param lock: ``struct semaphore *``
+    :return: Iterator of ``struct semaphore_waiter *`` objects.
+    """
+    for waiter in list_for_each_entry(
+        "struct semaphore_waiter", lock.wait_list.address_of_(), "list"
+    ):
+        yield waiter
+
+
+def semaphore_for_each_waiter_task(lock: Object) -> Iterator[Object]:
+    """
+    Iterate over all tasks blocked on a semaphore.
+
+    :param lock: ``struct semaphore *``
+    :return: Iterator of ``struct task_struct *`` objects.
+    """
+    for waiter in semaphore_for_each_waiter(lock):
+        yield waiter.task

--- a/tests/linux_kernel/helpers/test_locks.py
+++ b/tests/linux_kernel/helpers/test_locks.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from drgn import NULL
+from drgn.helpers.linux.locks import (
+    mutex_for_each_waiter_task,
+    mutex_is_locked,
+    mutex_owner,
+)
+from tests.linux_kernel import LinuxKernelTestCase, skip_unless_have_test_kmod
+
+
+@skip_unless_have_test_kmod
+class TestMutex(LinuxKernelTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.locked_mutex = cls.prog["drgn_test_locked_mutex"].address_of_()
+        cls.unlocked_mutex = cls.prog["drgn_test_unlocked_mutex"].address_of_()
+
+    def test_mutex_owner(self):
+        self.assertEqual(
+            mutex_owner(self.locked_mutex), self.prog["drgn_test_mutex_owner_kthread"]
+        )
+        self.assertEqual(
+            mutex_owner(self.unlocked_mutex), NULL(self.prog, "struct task_struct *")
+        )
+
+    def test_mutex_is_locked(self):
+        self.assertTrue(mutex_is_locked(self.locked_mutex))
+        self.assertFalse(mutex_is_locked(self.unlocked_mutex))
+
+    def test_for_each_mutex_waiter_task(self):
+        self.assertEqual(list(mutex_for_each_waiter_task(self.unlocked_mutex)), [])
+        self.assertEqual(
+            list(mutex_for_each_waiter_task(self.locked_mutex)),
+            [self.prog["drgn_test_mutex_waiter_kthread"]],
+        )

--- a/tests/linux_kernel/helpers/test_locks.py
+++ b/tests/linux_kernel/helpers/test_locks.py
@@ -12,6 +12,7 @@ from drgn.helpers.linux.locks import (
     mutex_owner,
     rwsem_for_each_waiter,
     rwsem_for_each_waiter_task,
+    rwsem_is_locked,
     semaphore_for_each_waiter_task,
     semaphore_is_locked,
 )
@@ -89,6 +90,11 @@ class TestRwsemaphore(LinuxKernelTestCase):
         self.assertTrue(is_rwsem_reader_owned(self.read_locked_rwsemaphore))
         self.assertFalse(is_rwsem_reader_owned(self.write_locked_rwsemaphore))
         self.assertFalse(is_rwsem_reader_owned(self.unlocked_rwsemaphore))
+
+    def test_rwsem_is_locked(self):
+        self.assertTrue(rwsem_is_locked(self.write_locked_rwsemaphore))
+        self.assertTrue(rwsem_is_locked(self.read_locked_rwsemaphore))
+        self.assertFalse(rwsem_is_locked(self.unlocked_rwsemaphore))
 
     def test_get_rwsem_owner(self):
         self.assertEqual(

--- a/tests/linux_kernel/helpers/test_percpu.py
+++ b/tests/linux_kernel/helpers/test_percpu.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from drgn.helpers.linux.cpumask import for_each_possible_cpu
-from drgn.helpers.linux.percpu import per_cpu, per_cpu_ptr
+from drgn.helpers.linux.percpu import per_cpu, per_cpu_owner, per_cpu_ptr
 from tests.linux_kernel import (
     LinuxKernelTestCase,
     prng32,
@@ -37,3 +37,8 @@ class TestPerCpu(LinuxKernelTestCase):
             self.assertEqual(
                 per_cpu_ptr(self.prog["drgn_test_percpu_dynamic"], cpu)[0], expected
             )
+
+    def test_per_cpu_owner(self):
+        for cpu in for_each_possible_cpu(self.prog):
+            osq_node = per_cpu(self.prog["osq_node"], cpu)
+            self.assertEqual(per_cpu_owner("osq_node", osq_node), cpu)

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -1223,6 +1223,55 @@ static void drgn_test_mutex_exit(void)
 		complete(&drgn_test_mutex_release_owner);
 }
 
+// semaphore
+static DECLARE_COMPLETION(drgn_test_semaphore_release_owner);
+static struct task_struct *drgn_test_semaphore_owner_kthread;
+static struct task_struct *drgn_test_semaphore_waiter_kthread;
+static struct semaphore drgn_test_locked_semaphore;
+static struct semaphore drgn_test_unlocked_semaphore;
+
+static int drgn_test_semaphore_owner_kthread_fn(void *arg)
+{
+	down(&drgn_test_locked_semaphore);
+	wait_for_completion(&drgn_test_semaphore_release_owner);
+	up(&drgn_test_locked_semaphore);
+	return 0;
+}
+
+static int drgn_test_semaphore_waiter_kthread_fn(void *arg)
+{
+	down(&drgn_test_locked_semaphore);
+	up(&drgn_test_locked_semaphore);
+	return 0;
+}
+static int drgn_test_semaphore_init(void)
+{
+	sema_init(&drgn_test_locked_semaphore, 1);
+	sema_init(&drgn_test_unlocked_semaphore, 1);
+
+	drgn_test_semaphore_owner_kthread = kthread_create(drgn_test_semaphore_owner_kthread_fn,
+						 NULL,
+						 "drgn_test_semaphore_owner_kthread");
+
+	drgn_test_semaphore_waiter_kthread = kthread_create(drgn_test_semaphore_waiter_kthread_fn,
+						 NULL,
+						 "drgn_test_semaphore_waiter_kthread");
+
+	if (!drgn_test_semaphore_owner_kthread || !drgn_test_semaphore_waiter_kthread)
+		return -1;
+
+	wake_up_process(drgn_test_semaphore_owner_kthread);
+	mdelay(500); //make sure owner gets chance to grab the semaphore
+	wake_up_process(drgn_test_semaphore_waiter_kthread);
+	return 0;
+}
+
+static void drgn_test_semaphore_exit(void)
+{
+	if (drgn_test_semaphore_owner_kthread)
+		complete(&drgn_test_semaphore_release_owner);
+}
+
 // Dummy function symbol.
 int drgn_test_function(int x)
 {
@@ -1241,6 +1290,7 @@ static void drgn_test_exit(void)
 	drgn_test_xarray_exit();
 	drgn_test_waitq_exit();
 	drgn_test_mutex_exit();
+	drgn_test_semaphore_exit();
 	drgn_test_idr_exit();
 }
 
@@ -1282,6 +1332,10 @@ static int __init drgn_test_init(void)
 		goto out;
 
 	ret = drgn_test_mutex_init();
+	if (ret)
+		goto out;
+
+	ret = drgn_test_semaphore_init();
 	if (ret)
 		goto out;
 

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -1272,6 +1272,95 @@ static void drgn_test_semaphore_exit(void)
 		complete(&drgn_test_semaphore_release_owner);
 }
 
+// rwsemaphore
+static DECLARE_COMPLETION(drgn_test_rwsemaphore_release_read_owner);
+static DECLARE_COMPLETION(drgn_test_rwsemaphore_release_write_owner);
+static struct task_struct *drgn_test_rwsemaphore_read_owner_kthread;
+static struct task_struct *drgn_test_rwsemaphore_write_owner_kthread;
+static struct task_struct *drgn_test_rwsemaphore_read_waiter_kthread;
+static struct task_struct *drgn_test_rwsemaphore_write_waiter_kthread;
+static struct rw_semaphore drgn_test_read_locked_rwsemaphore;
+static struct rw_semaphore drgn_test_write_locked_rwsemaphore;
+static struct rw_semaphore drgn_test_unlocked_rwsemaphore;
+
+static int drgn_test_rwsemaphore_read_owner_kthread_fn(void *arg)
+{
+	down_read(&drgn_test_read_locked_rwsemaphore);
+	wait_for_completion(&drgn_test_rwsemaphore_release_read_owner);
+	up_read(&drgn_test_read_locked_rwsemaphore);
+	return 0;
+}
+
+static int drgn_test_rwsemaphore_write_owner_kthread_fn(void *arg)
+{
+	down_write(&drgn_test_write_locked_rwsemaphore);
+	wait_for_completion(&drgn_test_rwsemaphore_release_write_owner);
+	up_write(&drgn_test_write_locked_rwsemaphore);
+	return 0;
+}
+
+static int drgn_test_rwsemaphore_read_waiter_kthread_fn(void *arg)
+{
+	//attempt to acquire lock held by writer so  that down_read blocks
+	down_read(&drgn_test_write_locked_rwsemaphore);
+	up_read(&drgn_test_write_locked_rwsemaphore);
+	return 0;
+}
+
+static int drgn_test_rwsemaphore_write_waiter_kthread_fn(void *arg)
+{
+	//We could have attempted to acquire writer owned lock as well, but this
+	//keeps test simulation simple
+	down_write(&drgn_test_read_locked_rwsemaphore);
+	up_write(&drgn_test_read_locked_rwsemaphore);
+	return 0;
+}
+
+static int drgn_test_rwsemaphore_init(void)
+{
+	init_rwsem(&drgn_test_read_locked_rwsemaphore);
+	init_rwsem(&drgn_test_write_locked_rwsemaphore);
+	init_rwsem(&drgn_test_unlocked_rwsemaphore);
+
+	drgn_test_rwsemaphore_read_owner_kthread = kthread_create(drgn_test_rwsemaphore_read_owner_kthread_fn,
+						 NULL,
+						 "drgn_test_rwsemaphore_read_owner_kthread");
+
+	drgn_test_rwsemaphore_write_owner_kthread = kthread_create(drgn_test_rwsemaphore_write_owner_kthread_fn,
+						 NULL,
+						 "drgn_test_rwsemaphore_write_owner_kthread");
+
+	drgn_test_rwsemaphore_read_waiter_kthread = kthread_create(drgn_test_rwsemaphore_read_waiter_kthread_fn,
+						 NULL,
+						 "drgn_test_rwsemaphore_read_waiter_kthread");
+
+	drgn_test_rwsemaphore_write_waiter_kthread = kthread_create(drgn_test_rwsemaphore_write_waiter_kthread_fn,
+						 NULL,
+						 "drgn_test_rwsemaphore_write_waiter_kthread");
+
+	if (!drgn_test_rwsemaphore_read_owner_kthread ||
+	    !drgn_test_rwsemaphore_write_owner_kthread ||
+	    !drgn_test_rwsemaphore_read_waiter_kthread ||
+	    !drgn_test_rwsemaphore_write_waiter_kthread)
+		return -1;
+
+	wake_up_process(drgn_test_rwsemaphore_read_owner_kthread);
+	wake_up_process(drgn_test_rwsemaphore_write_owner_kthread);
+	mdelay(500); //make sure owners get chance to grab the rwsemaphores
+	wake_up_process(drgn_test_rwsemaphore_read_waiter_kthread);
+	wake_up_process(drgn_test_rwsemaphore_write_waiter_kthread);
+	return 0;
+}
+
+static void drgn_test_rwsemaphore_exit(void)
+{
+	if (drgn_test_rwsemaphore_read_owner_kthread)
+		complete(&drgn_test_rwsemaphore_release_read_owner);
+
+	if (drgn_test_rwsemaphore_write_owner_kthread)
+		complete(&drgn_test_rwsemaphore_release_write_owner);
+}
+
 // Dummy function symbol.
 int drgn_test_function(int x)
 {
@@ -1291,6 +1380,7 @@ static void drgn_test_exit(void)
 	drgn_test_waitq_exit();
 	drgn_test_mutex_exit();
 	drgn_test_semaphore_exit();
+	drgn_test_rwsemaphore_exit();
 	drgn_test_idr_exit();
 }
 
@@ -1336,6 +1426,10 @@ static int __init drgn_test_init(void)
 		goto out;
 
 	ret = drgn_test_semaphore_init();
+	if (ret)
+		goto out;
+
+	ret = drgn_test_rwsemaphore_init();
 	if (ret)
 		goto out;
 


### PR DESCRIPTION
This change set includes helpers for following locking primitives:
1. Mutexes
2. Semaphores
3. Read-write semaphores
4. OSQ locks

Since osq_lock/unlock functions are not available to modules,. I could not add test cases for these and hence I have put all osq helpers in a script under contrib. Besides osq helpers the contrib script also contains helper functions for above mentioned other 3 locking primitives. These helper functions take a lock address as argument and dump various info pertaining to these locks. I have included some examples in commit for reference.

P.S: I also have per-cpu rwsem helpers almost ready but will add them after some more testing.
