### PR TITLE
Support setting custom vmcoreinfo

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -67,7 +67,11 @@ class Program:
     :meth:`[] <.__getitem__>` operator.
     """
 
-    def __init__(self, platform: Optional[Platform] = None) -> None:
+    def __init__(
+        self,
+        platform: Optional[Platform] = None,
+        vmcoreinfo: Union[bytes, str, None] = None,
+    ) -> None:
         """
         Create a ``Program`` with no target program. It is usually more
         convenient to use one of the :ref:`api-program-constructors`.
@@ -75,6 +79,9 @@ class Program:
         :param platform: The platform of the program, or ``None`` if it should
             be determined automatically when a core dump or symbol file is
             added.
+        :param vmcoreinfo: Optionally provide the ``VMCOREINFO`` note data for
+            Linux kernel core dumps, which will override any detected data. When
+            not provided or ``None``, automatically detect the info.
         """
         ...
     flags: ProgramFlags

--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -210,6 +210,21 @@ def _main() -> None:
     )
 
     parser.add_argument(
+        "-a",
+        "--architecture",
+        metavar="ARCH",
+        choices=[a.name for a in drgn.Architecture]
+        + [a.name.lower() for a in drgn.Architecture],
+        help="set the program architecture, in case it can't be auto-detected",
+    )
+    parser.add_argument(
+        "-i",
+        "--vmcoreinfo",
+        type=str,
+        default=None,
+        help="path to vmcoreinfo file (overrides any already present in the file)",
+    )
+    parser.add_argument(
         "--log-level",
         choices=["debug", "info", "warning", "error", "critical", "none"],
         default="warning",
@@ -258,7 +273,16 @@ def _main() -> None:
     else:
         logger.setLevel(args.log_level.upper())
 
-    prog = drgn.Program()
+    platform = None
+    if args.architecture:
+        platform = drgn.Platform(drgn.Architecture[args.architecture.upper()])
+
+    vmcoreinfo = None
+    if args.vmcoreinfo:
+        with open(args.vmcoreinfo, "rb") as f:
+            vmcoreinfo = f.read()
+
+    prog = drgn.Program(platform=platform, vmcoreinfo=vmcoreinfo)
     try:
         if args.core is not None:
             prog.set_core_dump(args.core)

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -35,11 +35,16 @@ static struct drgn_error *drgn_platform_from_kdump(kdump_ctx_t *ctx,
 		arch = &arch_info_arm;
 	else if (strcmp(str, KDUMP_ARCH_PPC64) == 0)
 		arch = &arch_info_ppc64;
-	/* libkdumpfile doesn't support RISC-V */
 	else if (strcmp(str, KDUMP_ARCH_S390X) == 0)
 		arch = &arch_info_s390x;
 	else if (strcmp(str, KDUMP_ARCH_S390) == 0)
 		arch = &arch_info_s390;
+#if KDUMPFILE_VERSION >= KDUMPFILE_MKVER(0, 5, 4)
+	else if (strcmp(str, KDUMP_ARCH_RISCV64) == 0)
+		arch = &arch_info_riscv64;
+	else if (strcmp(str, KDUMP_ARCH_RISCV32) == 0)
+		arch = &arch_info_riscv32;
+#endif
 	else
 		arch = &arch_info_unknown;
 
@@ -79,11 +84,16 @@ static struct drgn_error *drgn_platform_to_kdump(kdump_ctx_t *ctx,
 		arch_str = KDUMP_ARCH_ARM;
 	else if (platform->arch == &arch_info_ppc64)
 		arch_str = KDUMP_ARCH_PPC64;
-	/* libkdumpfile doesn't support RISC-V */
 	else if (platform->arch == &arch_info_s390x)
 		arch_str = KDUMP_ARCH_S390X;
 	else if (platform->arch == &arch_info_s390)
 		arch_str = KDUMP_ARCH_S390;
+#if KDUMPFILE_VERSION >= KDUMPFILE_MKVER(0, 5, 4)
+	else if (platform->arch == &arch_info_riscv64)
+		arch_str = KDUMP_ARCH_RISCV64;
+	else if (platform->arch == &arch_info_riscv32)
+		arch_str = KDUMP_ARCH_RISCV32;
+#endif
 
 	if (arch_str) {
 		ks = kdump_set_string_attr(ctx, KDUMP_ATTR_ARCH_NAME, arch_str);

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -63,6 +63,40 @@ static struct drgn_error *drgn_platform_from_kdump(kdump_ctx_t *ctx,
 	return NULL;
 }
 
+static struct drgn_error *drgn_platform_to_kdump(kdump_ctx_t *ctx,
+						 const struct drgn_platform *platform)
+{
+	kdump_status ks;
+	char *arch_str = NULL;
+
+	if (platform->arch == &arch_info_x86_64)
+		arch_str = KDUMP_ARCH_X86_64;
+	else if (platform->arch == &arch_info_i386)
+		arch_str = KDUMP_ARCH_IA32;
+	else if (platform->arch == &arch_info_aarch64)
+		arch_str = KDUMP_ARCH_AARCH64;
+	else if (platform->arch == &arch_info_arm)
+		arch_str = KDUMP_ARCH_ARM;
+	else if (platform->arch == &arch_info_ppc64)
+		arch_str = KDUMP_ARCH_PPC64;
+	/* libkdumpfile doesn't support RISC-V */
+	else if (platform->arch == &arch_info_s390x)
+		arch_str = KDUMP_ARCH_S390X;
+	else if (platform->arch == &arch_info_s390)
+		arch_str = KDUMP_ARCH_S390;
+
+	if (arch_str) {
+		ks = kdump_set_string_attr(ctx, KDUMP_ATTR_ARCH_NAME, arch_str);
+		if (ks != KDUMP_OK) {
+			return drgn_error_format(DRGN_ERROR_OTHER,
+						 "kdump_set_string_attr(\"%s\"): %s",
+						 arch_str, kdump_get_err(ctx));
+		}
+	}
+
+	return NULL;
+}
+
 static struct drgn_error *drgn_read_kdump(void *buf, uint64_t address,
 					  size_t count, uint64_t offset,
 					  void *arg, bool physical)
@@ -91,6 +125,38 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 	if (!ctx) {
 		return drgn_error_create(DRGN_ERROR_OTHER,
 					 "kdump_new() failed");
+	}
+
+	/*
+	 * We need to be careful to set libkdumpfile attributes in the correct
+	 * order, in order to achive the desired result in the rare cases when
+	 * the program has the architecture and/or vmcoreinfo already set. In
+	 * these cases, frequently, the information is not available to
+	 * libkdumpfile, and so the user is providing it instead. We should set:
+	 *
+	 * - Architecture before file descriptor. This is because when
+	 *   libkdumpfile reads the vmcore, it immediately parses the notes in
+	 *   the header. If it doesn't know the current architecture, it will
+	 *   skip the architecture-specific notes, such as the PRSTATUS. This
+	 *   manifests to users as a missing "cpu.number" attribute, and thus a
+	 *   failure to get accurate stack traces for on-CPU tasks.
+	 * - Vmcoreinfo after architecture. This is because when libkdumpfile
+	 *   gets a new vmcoreinfo note set, it marks the address translation
+	 *   metadata as dirty and resets its address translation info using the
+	 *   new data. If no architecture is set, it skips this setup since it
+	 *   won't know how to do so. This manifests for users as FaultError
+	 *   when they access almost any memory address.
+	 *
+	 * For the common case, where we are just setting the FD and OS type,
+	 * and then letting libkdumpfile give us the vmcoreinfo and platform
+	 * info, the only ordering constraint is the obvious one: we need to set
+	 * the FD before getting data from libkdumpfile.
+	 */
+
+	if (prog->has_platform) {
+		err = drgn_platform_to_kdump(ctx, drgn_program_platform(prog));
+		if (err)
+			goto err;
 	}
 
 	ks = kdump_set_number_attr(ctx, KDUMP_ATTR_FILE_FD, prog->core_fd);
@@ -138,6 +204,30 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 #endif
 		if (err)
 			goto err;
+	} else {
+		char *vmcoreinfo = memdup(prog->vmcoreinfo.raw, prog->vmcoreinfo.raw_size);
+		if (!vmcoreinfo) {
+			err = &drgn_enomem;
+			goto err;
+		}
+		kdump_blob_t *blob = kdump_blob_new(vmcoreinfo, prog->vmcoreinfo.raw_size);
+		if (!blob) {
+			free(vmcoreinfo);
+			err = &drgn_enomem;
+			goto err;
+		}
+		kdump_attr_t attr;
+		attr.type = KDUMP_BLOB;
+		attr.val.blob = blob;
+		ks = kdump_set_attr(ctx, "linux.vmcoreinfo.raw", &attr);
+		if (ks != KDUMP_OK) {
+			free(vmcoreinfo);
+			kdump_blob_decref(blob);
+			err = drgn_error_format(DRGN_ERROR_OTHER,
+						"kdump_set_attr(linux.vmcoreinfo.raw): %s",
+						kdump_get_err(ctx));
+			goto err;
+		}
 	}
 
 	had_platform = prog->has_platform;

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -113,30 +113,32 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 		goto err;
 	}
 
+	if (!prog->vmcoreinfo.raw) {
 #if KDUMPFILE_VERSION >= KDUMPFILE_MKVER(0, 4, 1)
-	char *vmcoreinfo;
+		char *vmcoreinfo;
 #else
-	const char *vmcoreinfo;
+		const char *vmcoreinfo;
 #endif
-	ks = kdump_vmcoreinfo_raw(ctx, &vmcoreinfo);
-	if (ks != KDUMP_OK) {
-		err = drgn_error_format(DRGN_ERROR_OTHER,
-					"kdump_vmcoreinfo_raw: %s",
-					kdump_get_err(ctx));
-		goto err;
-	}
+		ks = kdump_vmcoreinfo_raw(ctx, &vmcoreinfo);
+		if (ks != KDUMP_OK) {
+			err = drgn_error_format(DRGN_ERROR_OTHER,
+						"kdump_vmcoreinfo_raw: %s",
+						kdump_get_err(ctx));
+			goto err;
+		}
 
-	err = drgn_program_parse_vmcoreinfo(prog, vmcoreinfo,
-					    strlen(vmcoreinfo) + 1);
-	/*
-	 * As of libkdumpfile 0.4.1, the string returned by
-	 * kdump_vmcoreinfo_raw() needs to be freed.
-	 */
+		err = drgn_program_parse_vmcoreinfo(prog, vmcoreinfo,
+						strlen(vmcoreinfo) + 1);
+		/*
+		* As of libkdumpfile 0.4.1, the string returned by
+		* kdump_vmcoreinfo_raw() needs to be freed.
+		*/
 #if KDUMPFILE_VERSION >= KDUMPFILE_MKVER(0, 4, 1)
-	free(vmcoreinfo);
+		free(vmcoreinfo);
 #endif
-	if (err)
-		goto err;
+		if (err)
+			goto err;
+	}
 
 	had_platform = prog->has_platform;
 	if (!had_platform) {

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -264,6 +264,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 	const char *vmcoreinfo_note = NULL;
 	size_t vmcoreinfo_size = 0;
 	bool have_nt_taskstruct = false, is_proc_kcore;
+	bool have_vmcoreinfo = prog->vmcoreinfo.raw;
 
 	prog->core_fd = fd;
 	err = has_kdump_signature(prog, path, &is_kdump);
@@ -373,6 +374,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 					 * may be valid.
 					 */
 					have_phys_addrs = true;
+					have_vmcoreinfo = true;
 				} else if (nhdr.n_namesz == sizeof("QEMU") &&
 					   memcmp(name, "QEMU",
 						  sizeof("QEMU")) == 0) {
@@ -399,7 +401,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 		is_proc_kcore = false;
 	}
 
-	if (vmcoreinfo_note && !is_proc_kcore) {
+	if (have_vmcoreinfo && !is_proc_kcore) {
 		char *env;
 
 		/* Use libkdumpfile for ELF vmcores if it was requested. */
@@ -420,7 +422,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 	}
 
 	bool pgtable_reader =
-		(is_proc_kcore || vmcoreinfo_note) &&
+		(is_proc_kcore || have_vmcoreinfo) &&
 		prog->platform.arch->linux_kernel_pgtable_iterator_next;
 	if (pgtable_reader) {
 		/*
@@ -481,7 +483,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 		 * all zeroes and memory that was excluded by makedumpfile for
 		 * another reason, so we're forced to always return zeroes.
 		 */
-		prog->file_segments[j].zerofill = vmcoreinfo_note && !is_proc_kcore;
+		prog->file_segments[j].zerofill = have_vmcoreinfo && !is_proc_kcore;
 		err = drgn_program_add_memory_segment(prog, phdr->p_vaddr,
 						      phdr->p_memsz,
 						      drgn_read_memory_file,
@@ -550,7 +552,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 			j++;
 		}
 	}
-	if (vmcoreinfo_note) {
+	if (vmcoreinfo_note && !prog->vmcoreinfo.raw) {
 		err = drgn_program_parse_vmcoreinfo(prog, vmcoreinfo_note,
 						    vmcoreinfo_size);
 		if (err)
@@ -558,7 +560,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 	}
 
 	if (is_proc_kcore) {
-		if (!vmcoreinfo_note) {
+		if (!have_vmcoreinfo) {
 			err = read_vmcoreinfo_fallback(prog);
 			if (err)
 				goto out_segments;
@@ -568,7 +570,7 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 		                DRGN_PROGRAM_IS_LOCAL);
 		elf_end(prog->core);
 		prog->core = NULL;
-	} else if (vmcoreinfo_note) {
+	} else if (have_vmcoreinfo) {
 		prog->flags |= DRGN_PROGRAM_IS_LINUX_KERNEL;
 	} else if (have_qemu_note) {
 		err = drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -10,6 +10,7 @@
 #include "../string_builder.h"
 #include "../util.h"
 #include "../vector.h"
+#include "../linux_kernel.h"
 
 DEFINE_HASH_SET_FUNCTIONS(pyobjectp_set, ptr_key_hash_pair, scalar_key_eq);
 
@@ -238,10 +239,13 @@ static void drgnpy_end_blocking(struct drgn_program *prog, void *arg, void *stat
 static Program *Program_new(PyTypeObject *subtype, PyObject *args,
 			    PyObject *kwds)
 {
-	static char *keywords[] = { "platform", NULL };
+	static char *keywords[] = { "platform", "vmcoreinfo", NULL };
 	PyObject *platform_obj = NULL;
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:Program", keywords,
-					 &platform_obj))
+	const char *vmcoreinfo = NULL;
+	size_t vmcoreinfo_size;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oz#:Program", keywords,
+					 &platform_obj, &vmcoreinfo,
+					 &vmcoreinfo_size))
 		return NULL;
 
 	struct drgn_platform *platform;
@@ -267,6 +271,12 @@ static Program *Program_new(PyTypeObject *subtype, PyObject *args,
 	drgn_program_init(&prog->prog, platform);
 	drgn_program_set_blocking_callback(&prog->prog, drgnpy_begin_blocking,
 					   drgnpy_end_blocking, NULL);
+	if (vmcoreinfo) {
+		struct drgn_error *err = drgn_program_parse_vmcoreinfo(
+			&prog->prog, vmcoreinfo, vmcoreinfo_size);
+		if (err)
+			return set_drgn_error(err);
+	}
 	if (Program_init_logging(prog))
 		return NULL;
 	return_ptr(prog);


### PR DESCRIPTION
This branch has sat on the back burner for a while, but new discussion in #350 led me to update it and get it ready to merge. It adds the ability to give drgn some data to be interpreted as the vmcoreinfo when the Program is created. Later, when a core dump is attached, drgn will respect the pre-existing info rather than trying to get it from the core dump.

There's a bit of a delicate dance to be had with libkdumpfile, because it also wants to use the vmcoreinfo to find the page tables. For vmcores missing the vmcoreinfo, it seems that libkdumpfile doesn't know how to find their architecture, so we need to manually provide the architecture, then the dump FD, then the vmcoreinfo.

While I was at it, I threw in RISC-V support for libkdumpfile, which has been available since 0.5.4, but since we have some if-statements that enumerate all the libkdumpfile architectures, we never updated those and thus haven't been able to use it (I think... I don't actually have a RISC-V core dump handy).

---

Testing this is of course the important part. One obvious candidate where this code makes drgn work is hypervisor core dumps that are missing vmcoreinfo. QEMU will produce them if you don't have `-device vmcoreinfo`, which drgn already notes and produces a nice error message about.

Thankfully, drgn's own test framework runs QEMU without that option, so it's easy to generate a good test vmcore:

```
python -m vmtest.vm -k 6.9*
...
# Issue key sequence: Ctrl-A C to switch to the QEMU monitor
(qemu) dump-guest-memory file.elf
## OR
(qemu) dump-guest-memory -z file.kdump.flat
```

Running drgn against it will fail:

```
$ drgn -c file.kdump.flat -s build/vmtest/x86_64/kernel-6.9.1-vmtest29.1default/build/vmlinux
drgn 0.0.26 (using Python 3.9.18, elfutils 0.190, with libkdumpfile)
warning: the given file is in the makedumpfile flattened format; if open fails or is too slow, reassemble it with 'makedumpfile -R newfile <oldfile'
Traceback (most recent call last):
  File "/home/stepbren/.local/bin/drgn", line 33, in <module>
    sys.exit(load_entry_point('drgn', 'console_scripts', 'drgn')())
  File "/usr/lib64/python3.9/site-packages/drgn/cli.py", line 270, in _main
    prog.set_core_dump(args.core)
Exception: kdump_vmcoreinfo_raw: linux.vmcoreinfo.raw is not set

$ drgn -c foo.elf -s build/vmtest/x86_64/kernel-6.9.1-vmtest29.1default/build/vmlinux
drgn 0.0.26 (using Python 3.9.18, elfutils 0.190, with libkdumpfile)
error: unrecognized QEMU memory dump; for Linux guests, run QEMU with '-device vmcoreinfo', compile the kernel with CONFIG_FW_CFG_SYSFS and CONFIG_KEXEC, and load the qemu_fw_cfg kernel module before dumping the guest memory (requires Linux >= 4.17 and QEMU >= 2.11)
```

But with this branch, you can use my [dumpphys](https://github.com/brenns10/kernel_stuff/blob/master/vmcoreinfo/dumpphys.c) tool like below to get a text file containing the vmcoreinfo:
```
dumpphys -c file.kdump.flat -o file.vmcoreinfo -i
## or
dumpphys -c file.elf -o file.vmcoreinfo -i
```

And then, you can go ahead and run drgn, but add new arguments `-i file.vmcoreinfo` to specify the vmcoreinfo, and `-a X86_64` to specify the architecture (since libkdumpfile cannot detect it). At that point, drgn works like normal.

---

The current known issue with this branch is that this won't work with ELF vmcores that drgn opens natively. Drgn expects to have virtual address mappings provided for it, at least for the linear/direct map. When they're not there, drgn will fail with a recursive page translation error:

```
>>> prog["slab_caches"]
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/stepbren/repos/drgn/drgn/cli.py", line 141, in _displayhook
    text = value.format_(columns=shutil.get_terminal_size((0, 0)).columns)
_drgn.FaultError: recursive address translation; page table may be missing from core dump: 0xffffffff9662aff8
```

A workaround is to use libkdumpfile for those vmcores via `DRGN_USE_LIBKDUMPFILE_FOR_ELF`. I would like to address that issue next, but I'd like to do it properly, and that may be a bit more involved (do we add a new arch-specific callback? etc). I was hoping this could be merged since it's a bit more straightforward, and then we could focus on the best solution for these recursive address translation errors.