### PR TITLE
contrib/bpf_inspect.py: add interactive mode

### DIFF
--- a/contrib/bpf_inspect.py
+++ b/contrib/bpf_inspect.py
@@ -14,6 +14,27 @@ BpfProgType = enum_type_to_class(prog.type("enum bpf_prog_type"), "BpfProgType")
 BpfAttachType = enum_type_to_class(prog.type("enum bpf_attach_type"), "BpfAttachType")
 
 
+def is_version_ge_0_0_23():
+    """Check if drgn version is 0.0.23 or greater."""
+
+    from drgn import __version__
+
+    version = __version__.split("+")[0]
+    version_nums = [int(x) for x in version.split(".")]
+    major, minor, patch = version_nums
+    return major > 0 or minor > 0 or patch >= 23
+
+
+def __run_interactive(args):
+    if not is_version_ge_0_0_23():
+        print("Interactive mode requires drgn 0.0.23+")
+        exit(1)
+
+    from drgn.cli import run_interactive
+
+    run_interactive(prog)
+
+
 def get_btf_name(btf, btf_id):
     type_ = btf.types[btf_id]
     if type_.name_off < btf.hdr.str_len:
@@ -123,6 +144,11 @@ def main():
 
     map_parser = subparsers.add_parser("map", aliases=["m"], help="list BPF maps")
     map_parser.set_defaults(func=list_bpf_maps)
+
+    interact_parser = subparsers.add_parser(
+        "interact", aliases=["i"], help="start interactive shell, requires 0.0.23+ drgn"
+    )
+    interact_parser.set_defaults(func=__run_interactive)
 
     args = parser.parse_args()
     args.func(args)


### PR DESCRIPTION
It's convenient to run drgn shell with bpf helpers in bpf_inspect.py.