### PR TITLE
packit: replace EPEL 9 with centos-stream+epel-next-9 and c9s-build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,39 +25,63 @@ jobs:
   owner: "@meta"
   project: drgn
   targets:
-    - fedora-all-aarch64
-    - fedora-all-i386
-    - fedora-all-ppc64le
-    - fedora-all-s390x
-    - fedora-all-x86_64
-    - fedora-eln-aarch64
-    - fedora-eln-i386
-    - fedora-eln-ppc64le
+    fedora-all-aarch64: {}
+    fedora-all-i386: {}
+    fedora-all-ppc64le: {}
+    fedora-all-s390x: {}
+    fedora-all-x86_64: {}
+    fedora-eln-aarch64: {}
+    fedora-eln-i386: {}
+    fedora-eln-ppc64le: {}
     # Disabled due to fedora-eln/eln#170.
-    # - fedora-eln-s390x
-    - fedora-eln-x86_64
-    - epel-8-aarch64
-    - epel-8-ppc64le
-    - epel-8-s390x
-    - epel-8-x86_64
+    # fedora-eln-s390x: {}
+    fedora-eln-x86_64: {}
+    epel-8-aarch64: {}
+    epel-8-ppc64le: {}
+    epel-8-s390x: {}
+    epel-8-x86_64: {}
+    centos-stream+epel-next-9-aarch64:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/aarch64/
+    centos-stream+epel-next-9-ppc64le:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/ppc64le/
+    centos-stream+epel-next-9-s390x:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/s390x/
+    centos-stream+epel-next-9-x86_64:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/x86_64/
 
 - job: copr_build
   trigger: pull_request
   owner: "@meta"
   project: drgn
   targets:
-    - fedora-all-aarch64
-    - fedora-all-i386
-    - fedora-all-ppc64le
-    - fedora-all-s390x
-    - fedora-all-x86_64
-    - fedora-eln-aarch64
-    - fedora-eln-i386
-    - fedora-eln-ppc64le
+    fedora-all-aarch64: {}
+    fedora-all-i386: {}
+    fedora-all-ppc64le: {}
+    fedora-all-s390x: {}
+    fedora-all-x86_64: {}
+    fedora-eln-aarch64: {}
+    fedora-eln-i386: {}
+    fedora-eln-ppc64le: {}
     # Disabled due to fedora-eln/eln#170.
-    # - fedora-eln-s390x
-    - fedora-eln-x86_64
-    - epel-8-aarch64
-    - epel-8-ppc64le
-    - epel-8-s390x
-    - epel-8-x86_64
+    # fedora-eln-s390x: {}
+    fedora-eln-x86_64: {}
+    epel-8-aarch64: {}
+    epel-8-ppc64le: {}
+    epel-8-s390x: {}
+    epel-8-x86_64: {}
+    centos-stream+epel-next-9-aarch64:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/aarch64/
+    centos-stream+epel-next-9-ppc64le:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/ppc64le/
+    centos-stream+epel-next-9-s390x:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/s390x/
+    centos-stream+epel-next-9-x86_64:
+      additional_repos:
+        - https://kojihub.stream.centos.org/kojifiles/repos/c9s-build/latest/x86_64/


### PR DESCRIPTION
`drgn` no longer builds in EPEL 9 because `libkdumpfile-devel` is in RHEL 9 but not pushed out to CRB: https://issues.redhat.com/browse/RHEL-38224

Instead, let's make sure it still builds on CentOS Stream 9 + EPEL Next 9, with the `c9s-build` repo enabled, since that repo is accessible from COPR.

Fixes: #395