### PR TITLE
Fix CI failure on Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y check dwarves libelf-dev libdw-dev qemu-kvm zstd ${{ matrix.cc == 'clang' && 'libomp-$(clang --version | sed -rn "s/.*clang version ([0-9]+).*/\\1/p")-dev' || '' }}
-          pip install pyroute2 ${USE_PRE_COMMIT/1/pre-commit}
+          pip install pyroute2 setuptools ${USE_PRE_COMMIT/1/pre-commit}
       - name: Generate version.py
         run: python setup.py --version
       - name: Check with mypy


### PR DESCRIPTION
Our setup.py imports setuptools which is no longer provided by Python 3.12. It must be installed manually via pip. We did not notice this because the "nodeenv" package listed setuptools in its install_requires, thus providing the dependency for us.

Four hours ago nodeenv 1.9.0 was released, and it happened to drop the setuptools dependency. This broke CI. Add an explicit setuptools requirement in our pip command to fix it.