### PR TITLE
Update trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -439,12 +439,13 @@ setup(
     },
     license="LGPL-2.1-or-later",
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Debuggers",
+        "Topic :: System :: Operating System Kernels :: Linux",
     ],
 )


### PR DESCRIPTION
I noticed it still said "beta" which struck me as odd! Added in the Linux kernel classifier too. Sorry for a tiny PR but I figured it could be just in time for a 0.0.27.
https://pypi.org/classifiers/