### PR TITLE
scripts/build_manylinux_in_docker.sh: clean build dir between builds

### DIFF
--- a/scripts/build_manylinux_in_docker.sh
+++ b/scripts/build_manylinux_in_docker.sh
@@ -82,6 +82,11 @@ build_for_python() {
 for pybin in /opt/python/cp*/bin; do
 	if build_for_python "$pybin/python"; then
 		"$pybin/pip" wheel . --no-deps -w /tmp/wheels/
+		# When multiple python builds of the same version are present,
+		# (e.g. cp313-cp313 and cp313-cp313t) the build system does not
+		# understand the difference between them and uses the same build
+		# directory. This will result in bad builds for one of the two.
+		rm -rf build
 	fi
 done
 


### PR DESCRIPTION
Currently the python 3.13 manylinux build of drgn fails with a segfault. The reason is that the build system doesn't know not to share a build directory between cp313-cp313, and cp313-cp313t. Whichever is built second will reuse object files from the first build, which are incompatible. The current result of this is a segmentation fault:

```
+ /opt/python/cp313-cp313t/bin/drgn --version 
/io/scripts/build_manylinux_in_docker.sh: line 101: 43331 Segmentation fault
```

Adding insult to injury, the segmentation fault disappears when you try to build only one version in order to save time while debugging.

There may be a better fix for this particular issue, but deleting the build directory doesn't cause any problems and will ensure this doesn't pop up again in other cases.