### PR TITLE
contrib: bpf_inspect: adjust syntax for python < 3.12

### DIFF
--- a/contrib/bpf_inspect.py
+++ b/contrib/bpf_inspect.py
@@ -200,10 +200,10 @@ def list_bpf_progs(show_details=False):
                 print(f"\tlinked: {BpfProg(linked_prog)}")
 
         for map_ in bpf_prog.get_used_maps():
-            print(f"\t{"used map:":9} {map_}")
+            print(f"\t{'used map:':9} {map_}")
 
         for index, subprog in bpf_prog.get_subprogs():
-            print(f"\t{f"func[{index:>2}]:":9} {subprog}")
+            print(f"\t{f'func[{index:>2}]:':9} {subprog}")
 
 
 def __list_bpf_progs(args):
@@ -242,16 +242,16 @@ class BpfProgArrayMap(BpfMap):
         array = self.get_prog_array()
         poke_progs = self.get_poke_progs()
 
-        owner_str = f"{"owner:":9} {owner}" if owner else ""
+        owner_str = f"{'owner:':9} {owner}" if owner else ""
         array_str = (
             "\n\t".join(
-                f"{f"idx[{index:>3}]:":9} {BpfProg(prog)}" for index, prog in array
+                f"{f'idx[{index:>3}]:':9} {BpfProg(prog)}" for index, prog in array
             )
             if array
             else ""
         )
         poke_progs_str = (
-            "\n\t".join(f"{"poke:":9} {BpfProg(poke)}" for poke in poke_progs)
+            "\n\t".join(f"{'poke:':9} {BpfProg(poke)}" for poke in poke_progs)
             if poke_progs
             else ""
         )
@@ -345,7 +345,7 @@ class BpfXdpLink(BpfLink):
         mode = self.get_mode()
 
         ifname, ifindex = dev.name.string_().decode(), dev.ifindex.value_()
-        return f"{"netdev:":<9} {ifname}({ifindex})" + f"\n\t{"mode:":<9} {mode}"
+        return f"{'netdev:':<9} {ifname}({ifindex})" + f"\n\t{'mode:':<9} {mode}"
 
 
 def show_bpf_link_details(link):


### PR DESCRIPTION
Hi, this is a totally optional PR, but I noticed that `contrib/bpf_inspect.py` uses nested f-string quotes that are only available in Python 3.12 or later. It would be nice to be able to run this on older Python versions. If @Asphaltt doesn't mind it's a simple tweak to make these work on the older versions.