### PR TITLE
tests/linux_kernel: Skip TestStackDepot unless test kmod is present

### DIFF
--- a/tests/linux_kernel/helpers/test_stackdepot.py
+++ b/tests/linux_kernel/helpers/test_stackdepot.py
@@ -8,6 +8,7 @@ from tests.linux_kernel import skip_unless_have_test_kmod
 from tests.linux_kernel.test_stack_trace import LinuxKernelStackTraceTestCase
 
 
+@skip_unless_have_test_kmod
 class TestStackDepot(LinuxKernelStackTraceTestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
TestStackDeport needs the drgn test kernel module, so if it is not present, skip the test.

Error reported:

```
ERROR: setUpClass (tests.linux_kernel.helpers.test_stackdepot.TestStackDepot)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/drgn/tests/linux_kernel/helpers/test_stackdepot.py", line 15, in setUpClass
    if not cls.prog["drgn_test_have_stackdepot"]:
KeyError: 'drgn_test_have_stackdepot'

----------------------------------------------------------------------
Ran 980 tests in 4.056s
```