### PR TITLE
Add option to run CI on all kernel flavors, plus other improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,20 @@ on:
         type: boolean
         default: false
         required: true
+      test_all_kernel_flavors:
+        description: "Run tests on all kernel flavors"
+        type: boolean
+        default: false
+        required: true
   workflow_call:
     inputs:
       test_all_python_versions:
         description: "Run tests on all Python versions"
+        type: boolean
+        default: false
+        required: true
+      test_all_kernel_flavors:
+        description: "Run tests on all kernel flavors"
         type: boolean
         default: false
         required: true
@@ -62,7 +72,7 @@ jobs:
         if: ${{ env.USE_PRE_COMMIT == '1' }}
         run: pre-commit run --all-files mypy
       - name: Build and test with ${{ matrix.cc }}
-        run: CONFIGURE_FLAGS="--enable-compiler-warnings=error" python setup.py test -K
+        run: CONFIGURE_FLAGS="--enable-compiler-warnings=error" python setup.py test -K ${{ inputs.test_all_kernel_flavors && '-F' || '' }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,3 +14,4 @@ jobs:
     if: ${{ github.event.action != 'labeled' || github.event.label.name == 'test-all-python-versions' }}
     with:
       test_all_python_versions: ${{ contains(github.event.pull_request.labels.*.name, 'test-all-python-versions') }}
+      test_all_kernel_flavors: ${{ contains(github.event.pull_request.labels.*.name, 'test-all-kernel-flavors') }}

--- a/.github/workflows/vmtest-build.yml
+++ b/.github/workflows/vmtest-build.yml
@@ -41,3 +41,4 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       test_all_python_versions: true
+      test_all_kernel_flavors: true

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,12 @@ class test(Command):
             f"({', '.join(SUPPORTED_KERNEL_VERSIONS)})",
         ),
         (
+            "flavor=",
+            "f",
+            "when combined with -K, run Linux kernel tests on a specific flavor "
+            f"({', '.join(KERNEL_FLAVORS)}) instead of the default flavor",
+        ),
+        (
             "all-kernel-flavors",
             "F",
             "when combined with -K, run Linux kernel tests on all supported flavors "
@@ -184,6 +190,7 @@ class test(Command):
 
     def initialize_options(self):
         self.kernel = False
+        self.flavor = "default"
         self.all_kernel_flavors = False
         self.extra_kernels = ""
         self.vmtest_dir = None
@@ -191,7 +198,7 @@ class test(Command):
     def finalize_options(self):
         self.kernels = [kernel for kernel in self.extra_kernels.split(",") if kernel]
         if self.kernel:
-            flavors = KERNEL_FLAVORS if self.all_kernel_flavors else ["default"]
+            flavors = KERNEL_FLAVORS if self.all_kernel_flavors else [self.flavor]
             self.kernels.extend(
                 kernel + ".*" + flavor
                 for kernel in SUPPORTED_KERNEL_VERSIONS

--- a/vmtest/download.py
+++ b/vmtest/download.py
@@ -284,9 +284,11 @@ def _download_thread(
 
 @contextmanager
 def download_in_thread(
-    download_dir: Path, downloads: Iterable[Download]
+    download_dir: Path, downloads: Iterable[Download], max_pending_kernels: int = 0
 ) -> Generator[Iterator[Downloaded], None, None]:
-    q: "queue.Queue[Union[Downloaded, Exception]]" = queue.Queue()
+    q: "queue.Queue[Union[Downloaded, Exception]]" = queue.Queue(
+        maxsize=max_pending_kernels
+    )
 
     def aux() -> Iterator[Downloaded]:
         while True:


### PR DESCRIPTION
This branch adds three improvements related to testing different kernel flavors:

1. Allows locally running tests against all kernel versions of a given flavor by `python setup.py test -K -f flavor`. This is just a convenience that I wanted.
2. Adds a "test-all-kernel-flavors" option similar to the "test-all-python-versions" option. Its main difference is that we don't test all flavors on push to the `main` branch (whereas we do test all Python versions for every push to `main`). I think that makes sense, because pushes to main can be rather frequent, and testing each flavor triples the test burden (which is of course multiplicative with all the Python versions). The "test-all-kernel-flavors" option is active after each vmtest build, or when the label is applied to a PR, or for a manual run on the Github Actions UI.
3. Finally, to avoid filling up the disk space with downloaded kernels, I was forced to add some Github Actions specific logic to the testing, in order to cleanup downloaded kernels. We delete kernels after we test them, and we also set a size limit on the queue used to communicate downloaded kernels back to the main test thread. This ensures that at a certain point, the download thread pauses until a message is removed from the queue, and thus we never have more than a finite limit of kernels on-disk. This is important because of course the download speed is frequently faster than running the tests themselves.

I tested part 3 locally and verified that when `GITHUB_ACTIONS=true`, my `build/vmtest` directory never grew beyond ~2.5 GiB for a standard `-K` test, and it was emptied of kernels by the end of the run. I didn't want to do the `-K -F` locally, but I'd assume the result is about the same. For a local `-K` test with `GITHUB_ACTIONS=false`, the `build/vmtest` directory reached 7.5 GiB quickly and never decreased.

Test runs in Github Actions:

1. A test run which includes the changes of #416: https://github.com/brenns10/drgn/actions/runs/9998854777
2. A test run which does not include the changes of #416 and thus is expected to fail: https://github.com/brenns10/drgn/actions/runs/9998964897