### PR TITLE
contrib: Add memory related script to dump slabinfo and vmallocinfo

### DIFF
--- a/contrib/slabinfo.py
+++ b/contrib/slabinfo.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env drgn
+# Copyright (c) Canonical Ltd.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+""" Script to dump slabinfo status using drgn"""
+
+from typing import Iterator, Optional
+
+from drgn import Object
+from drgn.helpers.common.format import escape_ascii_string
+from drgn.helpers.linux.list import list_for_each_entry, list_for_each_entry_reverse
+from drgn.helpers.linux.slab import for_each_slab_cache
+
+MAX_PARTIAL_TO_SCAN = 10000
+OO_SHIFT = 16
+OO_MASK = (1 << OO_SHIFT) - 1
+
+
+def for_each_kmem_cache_node(slab_cache: Object) -> Iterator[Object]:
+    """
+    Iterate over all kmem_cache_node of specific slab cache.
+
+    :return: Iterator of ``struct kmem_cache_node *`` objects.
+    """
+    for nid in range(0, prog["nr_node_ids"].value_()):
+        yield slab_cache.node[nid]
+
+
+def count_partial_free_approx(kmem_cache_node: Object) -> Optional[Object]:
+    x = Object(prog, "unsigned long", 0)
+    n = kmem_cache_node
+    if n.nr_partial <= MAX_PARTIAL_TO_SCAN:
+        for slab in list_for_each_entry(
+            "struct slab", n.partial.address_of_(), "slab_list"
+        ):
+            x += slab.objects - slab.inuse
+    else:
+        scanned = 0
+        for slab in list_for_each_entry(
+            "struct slab", n.partial.address_of_(), "slab_list"
+        ):
+            x += slab.objects - slab.inuse
+            scanned += 1
+            if scanned == MAX_PARTIAL_TO_SCAN / 2:
+                break
+        for slab in list_for_each_entry_reverse(
+            "struct slab", n.partial.address_of_(), "slab_list"
+        ):
+            x += slab.objects - slab.inuse
+            scanned += 1
+            if scanned == MAX_PARTIAL_TO_SCAN / 2:
+                break
+        x = x * n.nr_partial / scanned
+        x = min(x, n.total_objects)
+    return x
+
+
+def oo_objects(kmem_cache_order_objects: Object) -> Optional[Object]:
+    return kmem_cache_order_objects.x & OO_MASK
+
+
+def oo_order(kmem_cache_order_objects: Object) -> Optional[Object]:
+    return kmem_cache_order_objects.x >> OO_SHIFT
+
+
+print(
+    f"{'struct kmem_cache *':^20} | {'name':^20} | {'active_objs':^12} | {'num_objs':^12} | {'objsize':^8} | {'objperslab':^11} | {'pageperslab':^13}"
+)
+print(
+    f"{'':-^20} | {'':-^20} | {'':-^12} | {'':-^12} | {'':-^8} | {'':-^11} | {'':-^13}"
+)
+
+for s in for_each_slab_cache(prog):
+    nr_slabs = 0
+    nr_objs = 0
+    nr_free = 0
+    for node in for_each_kmem_cache_node(s):
+        nr_slabs += node.nr_slabs.counter.value_()
+        nr_objs += node.total_objects.counter.value_()
+        nr_free += count_partial_free_approx(node).value_()
+    active_objs = nr_objs - nr_free
+    num_objs = nr_objs
+    active_slab = nr_slabs
+    num_slabs = nr_slabs
+    objects_per_slab = oo_objects(s.oo).value_()
+    cache_order = oo_order(s.oo).value_()
+    name = escape_ascii_string(s.name.string_(), escape_backslash=True)
+
+    print(
+        f"0x{s.value_():<18x} | {name:20.19s} | {active_objs:12} | {num_objs:12} | {s.size.value_():8} | {objects_per_slab:11} | {1<<cache_order:13}"
+    )

--- a/contrib/vmallocinfo.py
+++ b/contrib/vmallocinfo.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env drgn
+# Copyright (c) Canonical Ltd.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+""" Script to dump vmallocinfo status using drgn"""
+
+import re
+from typing import Optional
+
+from drgn import IntegerLike, Program
+from drgn.helpers.linux.mm import for_each_vmap_area
+
+VMAP_RAM = 0x1  # indicates vm_map_ram area
+
+VM_IOREMAP = 0x00000001  # ioremap() and friends
+VM_ALLOC = 0x00000002  # vmalloc()
+VM_MAP = 0x00000004  # vmap()ed pages
+VM_USERMAP = 0x00000008  # suitable for remap_vmalloc_range
+VM_DMA_COHERENT = 0x00000010  # dma_alloc_coherent
+VM_SPARSE = 0x00001000  # sparse vm_area. not all pages are present.
+
+
+def is_vmalloc_addr(prog: Program, addr: IntegerLike) -> Optional[bool]:
+    vmcoreinfo = prog["VMCOREINFO"].string_()
+    match = re.search(
+        rb"^NUMBER\(VMALLOC_START\)=(0x[0-9a-f]+)$", vmcoreinfo, flags=re.M
+    )
+    if match:
+        VMALLOC_START = int(match.group(1), 16)
+
+    match = re.search(rb"^NUMBER\(VMALLOC_END\)=(0x[0-9a-f]+)$", vmcoreinfo, flags=re.M)
+    if match:
+        VMALLOC_END = int(match.group(1), 16)
+
+    try:
+        return True if addr >= VMALLOC_START and addr < VMALLOC_END else False
+    except:
+        return None
+
+
+for vmap_area in for_each_vmap_area(prog):
+    if not vmap_area.vm:
+        if vmap_area.flags & VMAP_RAM:
+            print(
+                f"0x{vmap_area.va_start:x}-0x{vmap_area.va_end:x} {vmap_area.va_end - vmap_area.va_start:10d} vm_map_ram"
+            )
+            continue
+    v = vmap_area.vm
+    print(
+        f"0x{v.addr.value_():x}-0x{(v.addr+v.size).value_():x} {v.size.value_():10d}",
+        end="",
+    )
+    if v.caller:
+        try:
+            print(f" {prog.symbol(v.caller.value_()).name}", end="")
+        except LookupError:
+            print(f" 0x{v.caller.value_():x}", end="")
+    if v.nr_pages:
+        print(f" pages={v.nr_pages.value_():d}", end="")
+    if v.phys_addr:
+        print(f" phys=0x{v.phys_addr.value_():x}", end="")
+    if v.flags & VM_IOREMAP:
+        print(" ioremap", end="")
+    if v.flags & VM_SPARSE:
+        print(" sparse", end="")
+    if v.flags & VM_ALLOC:
+        print(" vmalloc", end="")
+    if v.flags & VM_MAP:
+        print(" vmap", end="")
+    if v.flags & VM_USERMAP:
+        print(" user", end="")
+    if v.flags & VM_DMA_COHERENT:
+        print(" dma-coherent", end="")
+    if is_vmalloc_addr(prog, v.pages):
+        print(" vpages", end="")
+    print("")


### PR DESCRIPTION
Add scripts to dump slabinfo and vmallocinfo.

slabinfo example output:
```
struct kmem_cache *  |         name         | active_objs  |   num_objs   | objsize  | objperslab  | pagesperslab
-------------------- | -------------------- | ------------ | ------------ | -------- | ----------- | -------------
0xffff00000632cf40   | 9p-fcall-cache       |            0 |            0 |   131192 |           1 |            64
0xffff00000632cdc0   | p9_req_t             |            0 |           33 |      248 |          33 |             2
0xffff00000632cc40   | isp1760_qh           |            0 |            0 |      144 |          28 |             1
0xffff00000632cac0   | isp1760_qtd          |            0 |            0 |      168 |          24 |             1
0xffff00000632c940   | isp1760_urb_listite  |            0 |            0 |      120 |          34 |             1
0xffff00000632c7c0   | asd_sas_event        |            0 |            0 |      256 |          32 |             2
```

vmallocinfo example output:
```
0xffff800080000000-0xffff800080005000      20480 start_kernel pages=4 vmalloc
0xffff800080005000-0xffff800080007000       8192 ioremap_prot phys=0x8020000 ioremap
0xffff800080008000-0xffff80008000d000      20480 start_kernel pages=4 vmalloc
0xffff80008000d000-0xffff80008000f000       8192 bpf_prog_alloc_no_stats pages=1 vmalloc
0xffff800082a00000-0xffff8000833d1000   10293248 paging_init phys=0x42c00000 vmap
0xffff800083400000-0xffff800083405000      20480 start_kernel pages=4 vmalloc
0xffff800083405000-0xffff800083408000      12288 pcpu_mem_zalloc pages=2 vmalloc
0xffff800083408000-0xffff80008340d000      20480 kernel_clone pages=4 vmalloc
0xffff80008340d000-0xffff80008340f000       8192 ioremap_prot phys=0x9030000 ioremap
```
