### PR TITLE
Cgroup scripts

### DIFF
--- a/contrib/cgroup.py
+++ b/contrib/cgroup.py
@@ -65,6 +65,8 @@ def print_cgroup_bpf_progs(cgrp):
 css = get_cgroup().self.address_of_()
 
 for pos in css_for_each_descendant_pre(css):
+    if not pos.flags & prog["CSS_ONLINE"]:
+        continue
     if sys.argv[-1] == "bpf":
         print_cgroup_bpf_progs(pos.cgroup)
     else:

--- a/drgn/helpers/linux/cgroup.py
+++ b/drgn/helpers/linux/cgroup.py
@@ -159,13 +159,12 @@ def _css_for_each_impl(
         pos = next_fn(pos, css)
         if not pos:
             break
-        if pos.flags & pos.prog_["CSS_ONLINE"]:
-            yield pos
+        yield pos
 
 
 def css_for_each_child(css: Object) -> Iterator[Object]:
     """
-    Iterate through children of the given css.
+    Iterate through children (offline included) of the given css.
 
     :param css: ``struct cgroup_subsys_state *``
     :return: Iterator of ``struct cgroup_subsys_state *`` objects.
@@ -175,7 +174,7 @@ def css_for_each_child(css: Object) -> Iterator[Object]:
 
 def css_for_each_descendant_pre(css: Object) -> Iterator[Object]:
     """
-    Iterate through the given css's descendants in pre-order.
+    Iterate through the given css's descendants (offline included) in pre-order.
 
     :param css: ``struct cgroup_subsys_state *``
     :return: Iterator of ``struct cgroup_subsys_state *`` objects.


### PR DESCRIPTION
This is based on discussion around [cgroup.stat](https://lore.kernel.org/all/20240711025153.2356213-1-longman@redhat.com/) and as an exercise with drgn, I'm sharing it in the case anyone found that useful.
There is also a little change outside of `contrib/`.

BTW How is that with drgn and RCU protected data? Is it simply neglected and one should be ready for transient issues when dereferencing gone data (that's actually not specific to RCU) when debugging a running system?