### PR TITLE
libdrgn: fix bashism in M4 macro

### DIFF
--- a/libdrgn/m4/my_c_auto.m4
+++ b/libdrgn/m4/my_c_auto.m4
@@ -12,7 +12,7 @@ if test "x$my_cv_c_auto" != xyes; then
 	AC_CACHE_CHECK([for __auto_type], [my_cv_c___auto_type],
 		       [AC_COMPILE_IFELSE([AC_LANG_SOURCE([[__auto_type x = 1;]])],
 					  [my_cv_c___auto_type=yes], [my_cv_c___auto_type=no])])
-	if test "x$my_cv_c___auto_type" == xyes; then
+	if test "x$my_cv_c___auto_type" = xyes; then
 		AC_DEFINE([auto], [__auto_type])
 	else
 		AC_MSG_ERROR([no auto or __auto_type])


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.