### PR TITLE
Add name to drgn.Thread

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -1110,6 +1110,19 @@ class Thread:
 
     tid: Final[int]
     """Thread ID (as defined by :manpage:`gettid(2)`)."""
+    name: Optional[str]
+    """
+    Thread name, or ``None`` if unknown.
+
+    See `PR_SET_NAME
+    <https://man7.org/linux/man-pages/man2/PR_SET_NAME.2const.html>`_ and
+    `/proc/pid/comm
+    <https://man7.org/linux/man-pages/man5/proc_pid_comm.5.html>`_.
+
+    .. note::
+        Linux userspace core dumps only save the name of the main thread, so
+        :attr:`name` will be ``None`` for other threads.
+    """
     object: Final[Object]
     """
     If the program is the Linux kernel, the ``struct task_struct *`` object for

--- a/libdrgn/cleanup.h
+++ b/libdrgn/cleanup.h
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define _cleanup_(x) __attribute__((__cleanup__(x)))
 
@@ -28,6 +29,14 @@ static inline void fclosep(FILE **fp)
 {
 	if (*fp)
 		fclose(*fp);
+}
+
+/** Call @c close() when the variable goes out of scope. */
+#define _cleanup_close_ _cleanup_(closep)
+static inline void closep(int *fd)
+{
+	if (*fd >= 0)
+		close(*fd);
 }
 
 /**

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -3429,6 +3429,15 @@ struct drgn_error *drgn_thread_object(struct drgn_thread *thread,
 struct drgn_error *drgn_thread_stack_trace(struct drgn_thread *thread,
 					   struct drgn_stack_trace **ret);
 
+/**
+ * Get name for the thread represented by @p thread.
+ *
+ * @param[out] ret Returned thread name, or @c NULL if not found. On success, it
+ * should be freed with free(). On error, it is not modified.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *drgn_thread_name(struct drgn_thread *thread, char **ret);
+
 /** @} */
 
 #endif /* DRGN_H */

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -140,6 +140,7 @@ struct drgn_program {
 	uint64_t aarch64_insn_pac_mask;
 	bool core_dump_notes_cached;
 	bool prefer_orc_unwinder;
+	const char *core_dump_fname_cached;
 
 	/*
 	 * Linux kernel-specific.

--- a/libdrgn/python/thread.c
+++ b/libdrgn/python/thread.c
@@ -56,6 +56,18 @@ static DrgnObject *Thread_get_object(Thread *self)
 	return_ptr(ret);
 }
 
+static PyObject *Thread_get_name(Thread *self)
+{
+	_cleanup_free_ char *ret = NULL;
+	struct drgn_error *err = drgn_thread_name(&self->thread, &ret);
+	if (err)
+		return set_drgn_error(err);
+	if (!ret) {
+		Py_RETURN_NONE;
+	}
+	return PyUnicode_DecodeFSDefault(ret);
+}
+
 static PyObject *Thread_stack_trace(Thread *self)
 {
 	struct drgn_error *err;
@@ -72,6 +84,7 @@ static PyObject *Thread_stack_trace(Thread *self)
 static PyGetSetDef Thread_getset[] = {
 	{"tid", (getter)Thread_get_tid, NULL, drgn_Thread_tid_DOC},
 	{"object", (getter)Thread_get_object, NULL, drgn_Thread_object_DOC},
+	{"name", (getter)Thread_get_name, NULL, drgn_Thread_name_DOC},
 	{},
 };
 

--- a/tests/linux_kernel/test_threads.py
+++ b/tests/linux_kernel/test_threads.py
@@ -50,3 +50,10 @@ class TestThreads(LinuxKernelTestCase):
             "crashed thread is only defined for core dumps",
             self.prog.crashed_thread,
         )
+
+    def test_thread_name(self):
+        pid = os.getpid()
+        with open(f"/proc/{pid}/comm", "r") as f:
+            comm = f.read().strip()
+        thread = self.prog.thread(pid)
+        self.assertEqual(comm, thread.name)

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -34,6 +34,13 @@ class TestLive(TestCase):
             self.prog.crashed_thread,
         )
 
+    def test_thread_name(self):
+        with open(f"/proc/{os.getpid()}/comm", "r") as f:
+            comm = f.read().strip()
+        self.assertEqual(self.prog.main_thread().name, comm)
+        for thread in self.prog.threads():
+            self.assertIsNotNone(thread.name)
+
 
 class TestCoreDump(TestCase):
     TIDS = (
@@ -54,6 +61,8 @@ class TestCoreDump(TestCase):
 
     MAIN_TID = 2265413
     CRASHED_TID = 2265419
+
+    MAIN_THREAD_NAME = "segfault_random"
 
     @classmethod
     def setUpClass(cls):
@@ -79,3 +88,9 @@ class TestCoreDump(TestCase):
 
     def test_crashed_thread(self):
         self.assertEqual(self.prog.crashed_thread().tid, self.CRASHED_TID)
+
+    def test_thread_name(self):
+        self.assertEqual(self.prog.main_thread().name, self.MAIN_THREAD_NAME)
+        for tid in self.TIDS:
+            if tid != self.MAIN_TID:
+                self.assertIsNone(self.prog.thread(tid).name)


### PR DESCRIPTION
This PR addresses https://github.com/osandov/drgn/issues/143 by adding `name` to drgn's Thread abstraction.

This behaves differently for 3 use cases:
1. Linux kernel - Use task_struct.comm 
2. Live process - Read /proc/<tid>/comm
3. Core dump - Use fname but only valid for main thread. Returns None for other threads

Notes:
1. We do not cache thread names for Linux kernel and live process since these can change during the lifetime of the process. We do cache for core dump since this will not change
2. As a result of not caching, drgn_thread_name will malloc a new string and expect Python to free the memory when the Python object goes out of scope.
3. We assume all thread names are 16 characters including null character. Given this has been a kernel setting for awhile, I don't imagine it changing.