### PR TITLE
mm, slab: Fix infinite loop at _slub_get_freelist()

### DIFF
--- a/drgn/helpers/linux/slab.py
+++ b/drgn/helpers/linux/slab.py
@@ -310,6 +310,8 @@ class _SlabCacheHelperSlub(_SlabCacheHelper):
         def _slub_get_freelist(freelist: Object, freelist_set: Set[int]) -> None:
             ptr = freelist.value_()
             while ptr:
+                if ptr in freelist_set:
+                    break
                 freelist_set.add(ptr)
                 ptr = self._freelist_dereference(ptr + freelist_offset)
 


### PR DESCRIPTION
In some cases, _slub_get_freelist() loops forever when ptr dereferences to itself.

This causes instructions like the following to loop forever.  (I got this with a vmcore)

	identify_address(prog, 18446613188003018408)

If I break if the pointer is already in the freelist-set, then, I can get drgn unstuck:

>>> identify_address(prog, 18446613188003018408)
'slab object: sock_inode_cache+0x2a8'

Co-developed-with: Leandro Silva <ldfsilva@gmail.com>