### PR TITLE
contrib: ptdrgn: fix FaultError when displaying objects

### DIFF
--- a/contrib/ptdrgn.py
+++ b/contrib/ptdrgn.py
@@ -108,8 +108,11 @@ def configure(repl) -> None:
 
     def _format_result_output(result: object):
         if isinstance(result, drgn.Object):
-            s = result.format_(columns=shutil.get_terminal_size((0, 0)).columns)
-            to_format = _maybe_c_format(s)
+            try:
+                s = result.format_(columns=shutil.get_terminal_size((0, 0)).columns)
+                to_format = _maybe_c_format(s)
+            except drgn.FaultError:
+                to_format = DummyForRepr(repr(result))
         elif isinstance(result, (drgn.StackFrame, drgn.StackTrace)):
             to_format = DummyForRepr(str(result))
         elif isinstance(result, drgn.Type):


### PR DESCRIPTION
See the commit message for the situation and justification. This is just a quick fix for the ptdrgn script (which I use _constantly_). But I did end up comparing against the built-in drgn CLI and noticed that the behavior on the example quoted in the commit is a bit confusing too, so I'll create a separate issue on that.