### PR TITLE
Further updates to the installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,21 @@ drgn can be installed using the package manager on some Linux distributions.
 
       $ sudo dnf install drgn
 
+* Oracle Linux >= 8
+
+  Enable the ``ol8_addons`` or ``ol9_addons`` repository and install drgn:
+
+  .. code-block:: console
+
+      $ sudo dnf config-manager --enable ol8_addons  # OR: ol9_addons
+      $ sudo dnf install drgn
+
+  See the documentation for drgn in `Oracle Linux 9
+  <https://docs.oracle.com/en/operating-systems/oracle-linux/9/monitoring/working_with_the_drgn_and_corelens.html>`_
+  and `Oracle Linux 8
+  <https://docs.oracle.com/en/operating-systems/oracle-linux/8/monitoring/working_with_the_drgn_and_corelens.html>`_
+  for more information.
+
 * Arch Linux
 
   .. code-block:: console
@@ -151,7 +166,7 @@ First, install dependencies:
 
       $ sudo dnf install autoconf automake check-devel elfutils-devel gcc git libkdumpfile-devel libtool make pkgconf python3 python3-devel python3-pip python3-setuptools
 
-* RHEL/CentOS
+* RHEL/CentOS/Oracle Linux
 
   .. code-block:: console
 
@@ -159,9 +174,16 @@ First, install dependencies:
 
   Optionally, install ``libkdumpfile-devel`` from EPEL on RHEL/CentOS >= 8 or
   install `libkdumpfile <https://github.com/ptesarik/libkdumpfile>`_ from
-  source if you want support for the makedumpfile format.
+  source if you want support for the makedumpfile format. For Oracle Linux >= 7,
+  ``libkdumpfile-devel`` can be installed directly from the corresponding addons
+  repository (e.g. ``ol9_addons``).
 
-  Replace ``dnf`` with ``yum`` for RHEL/CentOS < 8.
+  Replace ``dnf`` with ``yum`` for RHEL/CentOS/Oracle Linux < 8.
+
+  When building on RHEL/CentOS/Oracle Linux < 8, you may need to use a newer
+  version of GCC, for example, using the ``devtoolset-12`` developer toolset.
+  Check your distribution's documentation for information on installing and
+  using these newer toolchains.
 
 * Debian/Ubuntu
 

--- a/README.rst
+++ b/README.rst
@@ -176,11 +176,7 @@ First, install dependencies:
 
   .. code-block:: console
 
-      $ sudo pacman -S --needed autoconf automake check gcc git libelf libtool make pkgconf python python-pip python-setuptools
-
-  Optionally, install `libkdumpfile
-  <https://aur.archlinux.org/packages/libkdumpfile/>`__ from the AUR or from
-  source if you want support for the makedumpfile format.
+      $ sudo pacman -S --needed autoconf automake check gcc git libelf libtool make pkgconf python python-pip python-setuptools libkdumpfile
 
 * Gentoo
 

--- a/docs/getting_debugging_symbols.rst
+++ b/docs/getting_debugging_symbols.rst
@@ -117,3 +117,12 @@ Arch Linux unfortunately does not make debugging symbols available. Packages
 must be manually rebuilt with debugging symbols enabled. See the `ArchWiki
 <https://wiki.archlinux.org/title/Debugging/Getting_traces>`_ and the `feature
 request <https://bugs.archlinux.org/task/38755?project=1>`_.
+
+Oracle Linux
+------------
+
+Oracle Linux provides documentation on using installing the necessary debugging
+symbols. See the documentation for `Oracle Linux 9
+<https://docs.oracle.com/en/operating-systems/oracle-linux/9/monitoring/working_with_the_drgn_and_corelens.html#installing-debuginfo-packages>`_
+and `Oracle Linux 8
+<https://docs.oracle.com/en/operating-systems/oracle-linux/8/monitoring/working_with_the_drgn_and_corelens.html#installing-debuginfo-packages>`_.


### PR DESCRIPTION
I saw the pull request about Arch Linux installation and wanted to make a few similar updates:

1. `libkdumpfile` is now packaged for Arch too, so we can simplify the install steps for building from source there.
2. I wanted to include Oracle Linux instructions alongside RHEL and CentOS, especially where they differ.

So I've added steps to install Oracle Linux's officially supported drgn package (no EPEL) as a separate group. Please note that this one does contain the CTF patches downstream -- if you feel strongly about that, I can omit this, or put a warning to let people know that it has vendor modifications.

I also added steps to the documentation about getting debuginfo. I didn't want to take up a ton of space, but OL does have official documentation that covers how to get kernel debuginfo, so I thought we could at least link directly to it.

Also, for building from source, we got some compiler errors on Oracle Linux 7 (and I'm pretty confident they'd be there on RHEL/CentOS 7 too) that are resolved by using a newer compiler version. So I updated that as well.