### PR TITLE
kallsyms: remove docstring of _module_kallsyms()

### DIFF
--- a/drgn/helpers/linux/kallsyms.py
+++ b/drgn/helpers/linux/kallsyms.py
@@ -159,18 +159,6 @@ def _elf_sym_to_symbol(name: str, obj: Object, has_typetab: bool) -> Symbol:
 
 
 def _module_kallsyms(module: Object) -> List[Symbol]:
-    """
-    Return a list of symbols for a kernel module
-
-    When compiled with ``CONFIG_KALLSYMS``, the kernel maintains ELF symbol
-    information about each module within ``struct module``.  This function
-    accesses this symbol information, and returns a list of drgn :class:`Symbol`
-    objects for the module. Keep in mind that unless ``CONFIG_KALLSYMS_ALL`` is
-    enabled, these symbols are typically only function symbols.
-
-    :param module: :class:`Object` of type ``struct module *``
-    :returns: a list of symbols
-    """
     try:
         ks = module.kallsyms
     except AttributeError:


### PR DESCRIPTION
This is intended to be a private function. It doesn't appear in `__all__`, but the docstring still results in it being included in the Sphinx docs. Remove the docstring and verify that the function no longer appears in Sphinx.