### PR TITLE
Python 3.13 REPL support

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -114,6 +114,13 @@ Some of drgn's behavior can be modified through environment variables:
     Whether drgn should use libkdumpfile for ELF vmcores (0 or 1). The default
     is 0. This functionality will be removed in the future.
 
+``DRGN_USE_PYREPL``
+    Whether drgn should attempt to use the improved REPL (pyrepl) from Python
+    3.13. This provides colored output and multiline editing, among other
+    features. The default is 1.  Unfortunately, Python has no public API to use
+    these features, so drgn must rely on internal implementation details. Set
+    this to 0 to disable this feature.
+
 ``DRGN_USE_SYS_MODULE``
     Whether drgn should use ``/sys/module`` to find information about loaded
     kernel modules for the running kernel instead of getting them from the core

--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -6,19 +6,18 @@
 
 import argparse
 import builtins
-import code
 import importlib
 import logging
 import os
 import os.path
 import pkgutil
-import readline
 import runpy
 import shutil
 import sys
 from typing import Any, Callable, Dict, Optional
 
 import drgn
+from drgn.internal.repl import interact, readline
 from drgn.internal.rlcompleter import Completer
 from drgn.internal.sudohelper import open_via_sudo
 
@@ -435,7 +434,7 @@ For help, type help(drgn).
         drgn.set_default_prog(prog)
 
         try:
-            code.interact(banner=banner, exitmsg="", local=init_globals)
+            interact(init_globals, banner)
         finally:
             try:
                 readline.write_history_file(histfile)

--- a/drgn/internal/repl.py
+++ b/drgn/internal/repl.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Compatibility shim between drgn and the pyrepl/code modules"""
+
+import os
+import sys
+from typing import Any, Dict
+
+__all__ = ("interact", "readline")
+
+# Python 3.13 introduces a new REPL implemented by the "_pyrepl" internal
+# module. It includes features such as colored output and multiline editing.
+# Unfortunately, there is no public API exposing these abilities to users, even
+# in the "code" module. We'd like to give the best experience possible, so we'll
+# detect _pyrepl and try to use it where possible.
+try:
+    # Since this mucks with internals, add a knob that can be used to disable it
+    # and use the traditional REPL.
+    if os.environ.get("DRGN_USE_PYREPL") in ("0", "n", "N", "false", "False"):
+        raise ModuleNotFoundError()
+
+    # Unfortunately, the typeshed library behind mypy explicitly removed type
+    # stubs for these modules. This makes sense as they are private APIs, but it
+    # means we need to disable mypy checks.
+    from _pyrepl import readline  # type: ignore
+    from _pyrepl.console import InteractiveColoredConsole  # type: ignore
+    from _pyrepl.simple_interact import (  # type: ignore
+        run_multiline_interactive_console,
+    )
+
+    # This _setup() function clobbers the readline completer, but it is
+    # protected so it only runs once. Call it early so that our overridden
+    # completer doesn't get clobbered.
+    readline._setup({})
+
+    def interact(local: Dict[str, Any], banner: str) -> None:
+        console = InteractiveColoredConsole(local)
+        print(banner, file=sys.stderr)
+        run_multiline_interactive_console(console)
+
+except (ModuleNotFoundError, ImportError):
+    import code
+    import readline
+
+    def interact(local: Dict[str, Any], banner: str) -> None:
+        code.interact(banner=banner, exitmsg="", local=local)

--- a/drgn/internal/rlcompleter.py
+++ b/drgn/internal/rlcompleter.py
@@ -6,8 +6,9 @@
 import builtins
 import keyword
 import re
-import readline
 from typing import Any, Dict, List, Optional
+
+from drgn.internal.repl import readline
 
 _EXPR_RE = re.compile(
     r"""


### PR DESCRIPTION
This implements #446, it's essentially the same workaround (using the internal APIs of `_pyrepl`), but I needed to make some further tweaks to get it working.

1. I stuck all of the import madness into another internal module so it only needs to be included once, not both in `cli.py` and `rlcompleter.py`.
2. I had to import readline from the `_pyrepl` package. It's honestly quite nice that this is a drop-in enough replacement. The history file works as expected without any tweaks.
3. Unfortunately, there's a `_setup()` function that resets the completer, regardless of what you have set previously. So I had to add a call to that so that our `set_completer()` call would stick.
4. Mypy is very unhappy with the use of this internal API, so we've got some `type: ignore` added to the imports.
5. I added an escape hatch so that we can revert to the old behavior in case some internals change in a Python release.

Incidentally, I did this by factoring out a simple `interact()` API that can be implemented via `code` or `_pyrepl`, and that makes it trivial to substitute in the `prompt_toolkit` implementation from `contrib.ptdrgn`. So I took the opportunity to simplify that script in a follow-up commit.

I'm not entirely sure that this is _good_ overall. It does work on my build of Python 3.13, and it is genuinely nice to use. It's not like Python is making frequent releases, but it does seem totally possible for these internals to change, and that would be a pain to handle.