### PR TITLE
docs: update links to Oracle Documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,9 +94,9 @@ drgn can be installed using the package manager on some Linux distributions.
       $ sudo dnf install drgn
 
   See the documentation for drgn in `Oracle Linux 9
-  <https://docs.oracle.com/en/operating-systems/oracle-linux/9/monitoring/working_with_the_drgn_and_corelens.html>`_
+  <https://docs.oracle.com/en/operating-systems/oracle-linux/9/drgn/how_to_install_drgn.html>`_
   and `Oracle Linux 8
-  <https://docs.oracle.com/en/operating-systems/oracle-linux/8/monitoring/working_with_the_drgn_and_corelens.html>`_
+  <https://docs.oracle.com/en/operating-systems/oracle-linux/8/drgn/how_to_install_drgn.html>`_
   for more information.
 
 * Arch Linux

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ drgn can be installed using the package manager on some Linux distributions.
       $ sudo dnf config-manager --enable ol8_addons  # OR: ol9_addons
       $ sudo dnf install drgn
 
+  Drgn is also available for Python versions in application streams. For
+  example, use ``dnf install python3.12-drgn`` to install drgn for Python 3.12.
   See the documentation for drgn in `Oracle Linux 9
   <https://docs.oracle.com/en/operating-systems/oracle-linux/9/drgn/how_to_install_drgn.html>`_
   and `Oracle Linux 8

--- a/docs/getting_debugging_symbols.rst
+++ b/docs/getting_debugging_symbols.rst
@@ -123,6 +123,6 @@ Oracle Linux
 
 Oracle Linux provides documentation on using installing the necessary debugging
 symbols. See the documentation for `Oracle Linux 9
-<https://docs.oracle.com/en/operating-systems/oracle-linux/9/monitoring/working_with_the_drgn_and_corelens.html#installing-debuginfo-packages>`_
+<https://docs.oracle.com/en/operating-systems/oracle-linux/9/drgn/how_to_install_debuginfo_packages.html>`_
 and `Oracle Linux 8
-<https://docs.oracle.com/en/operating-systems/oracle-linux/8/monitoring/working_with_the_drgn_and_corelens.html#installing-debuginfo-packages>`_.
+<https://docs.oracle.com/en/operating-systems/oracle-linux/8/drgn/how_to_install_debuginfo_packages.html>`_.


### PR DESCRIPTION
As of today, the Oracle Linux documentation section describing drgn has been split off into its own chapter. There are soft redirects, but update the links here so they point to the relevant content.

Also as of today, there are `python3.11-drgn` and `python3.12-drgn` packages on OL 8 and 9, so I added a brief mention that it should be possible to install drgn for newer Python versions.