### PR TITLE
drgn.internal.repl: also catch AttributeError in enhanced REPL attempt

### DIFF
--- a/drgn/internal/repl.py
+++ b/drgn/internal/repl.py
@@ -39,7 +39,7 @@ try:
         print(banner, file=sys.stderr)
         run_multiline_interactive_console(console)
 
-except (ModuleNotFoundError, ImportError):
+except (ModuleNotFoundError, ImportError, AttributeError):
     import code
     import readline
 


### PR DESCRIPTION
I didn't see this in practice, it's mostly out of paranoia. In particular, if `_pyrepl.readline._setup()` goes away, this will catch it.

@brenns10 any objections?