### PR TITLE
Support for built-in ORC information

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -838,12 +838,11 @@ class Program:
         self, module_obj: Object, *, create: Literal[False] = False
     ) -> RelocatableModule:
         """
-        Find a Linux kernel loadable module from a ``struct module`` object.
+        Find a Linux kernel loadable module from a ``struct module *`` object.
 
         Note that kernel modules are represented as relocatable modules.
 
-        :param module_obj: ``struct module`` or ``struct module *`` object for
-            the kernel module.
+        :param module_obj: ``struct module *`` object for the kernel module.
         :return: Relocatable module with a name and address matching
             *module_obj*.
         :raises LookupError: if no matching module has been created
@@ -855,14 +854,13 @@ class Program:
         self, module_obj: Object, *, create: Literal[True]
     ) -> Tuple[RelocatableModule, bool]:
         """
-        Find or create a Linux kernel loadable module from a ``struct module``
+        Find or create a Linux kernel loadable module from a ``struct module *``
         object.
 
         If a new module is created, its :attr:`~Module.address_range` and
         :attr:`~RelocatableModule.section_addresses` are set from *module_obj*.
 
-        :param module_obj: ``struct module`` or ``struct module *`` object for
-            the kernel module.
+        :param module_obj: `struct module *`` object for the kernel module.
         :return: Module and ``True`` if it was newly created or ``False`` if it
             was found.
         """
@@ -1665,6 +1663,14 @@ class Module:
     state/core dump when possible. Otherwise, when a file is assigned to the
     module, it is set to the file's build ID if it is not already set. It can
     also be set manually.
+    """
+    object: Object
+    """
+    The object associated with this module.
+
+    For Linux kernel loadable modules, this is the ``struct module *``
+    associated with the kernel module. For other kinds, this is currently an
+    absent object. The object may be set manually.
     """
     loaded_file_status: ModuleFileStatus
     """Status of the module's :ref:`loaded file <module-loaded-file>`."""

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -321,6 +321,7 @@ struct drgn_error *drgn_module_find_or_create(struct drgn_program *prog,
 
 	module->prog = prog;
 	module->kind = key->kind;
+	drgn_object_init(&module->object, prog);
 	// Linux userspace core dumps usually filter out file-backed mappings
 	// (see coredump_filter in core(5)), so we need the loaded file to read
 	// the text. Additionally, .eh_frame is in the loaded file and not the
@@ -412,6 +413,7 @@ struct drgn_error *drgn_module_find_or_create(struct drgn_program *prog,
 err_name:
 	free(module->name);
 err_module:
+	drgn_object_deinit(&module->object);
 	free(module);
 	return err;
 }
@@ -513,6 +515,7 @@ static void drgn_module_destroy(struct drgn_module *module)
 	drgn_elf_file_destroy(module->loaded_file);
 	free(module->build_id);
 	free(module->name);
+	drgn_object_deinit(&module->object);
 	free(module);
 }
 
@@ -983,6 +986,18 @@ drgn_module_wanted_supplementary_debug_file(struct drgn_module *module,
 	return wanted
 	       ? DRGN_SUPPLEMENTARY_FILE_GNU_DEBUGALTLINK
 	       : DRGN_SUPPLEMENTARY_FILE_NONE;
+}
+
+LIBDRGN_PUBLIC struct drgn_error *
+drgn_module_object(const struct drgn_module *module, struct drgn_object *ret)
+{
+	return drgn_object_copy(ret, &module->object);
+}
+
+LIBDRGN_PUBLIC struct drgn_error *
+drgn_module_set_object(struct drgn_module *module, const struct drgn_object *obj)
+{
+	return drgn_object_copy(&module->object, obj);
 }
 
 static struct drgn_error *

--- a/libdrgn/debug_info.h
+++ b/libdrgn/debug_info.h
@@ -260,6 +260,8 @@ struct drgn_module {
 	struct drgn_module_wanted_supplementary_file *wanted_supplementary_debug_file;
 	/** Node in @ref drgn_debug_info::modules_pending_indexing. */
 	struct drgn_module *pending_indexing_next;
+	/** Object the module was created from */
+	struct drgn_object object;
 };
 
 struct drgn_error *drgn_module_find_or_create(struct drgn_program *prog,

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -1314,7 +1314,7 @@ drgn_module_find_or_create_relocatable(struct drgn_program *prog,
 				       struct drgn_module **ret, bool *new_ret);
 
 /**
- * Find a created Linux kernel loadable module from a ``struct module`` object.
+ * Find a created Linux kernel loadable module from a ``struct module *`` object.
  *
  * @param[out] new_ret @c true if the module was newly created, @c false if it
  * was found.
@@ -1324,7 +1324,7 @@ drgn_module_find_linux_kernel_loadable(const struct drgn_object *module_obj,
 				       struct drgn_module **ret);
 
 /**
- * Find a Linux kernel loadable module from a ``struct module`` object, creating
+ * Find a Linux kernel loadable module from a ``struct module *`` object, creating
  * it if it doesn't already exist.
  *
  * @param[out] new_ret @c true if the module was newly created, @c false if it
@@ -1569,6 +1569,26 @@ drgn_module_wanted_supplementary_debug_file(struct drgn_module *module,
 					    const char **supplementary_path_ret,
 					    const void **checksum_ret,
 					    size_t *checksum_len_ret);
+
+/**
+ * Return the object associated with this module.
+ *
+ * For some modules, there may be an object related to it. For example, drgn
+ * automatically identifies the Linux kernel `struct module *` associated with
+ * loadable modules, and associates it with them. Users may set or replace an
+ * associated object with @ref drgn_set_module_object().
+ *
+ * @param[out] ret Initialized object where the module object is placed
+ */
+struct drgn_error *
+drgn_module_object(const struct drgn_module *module, struct drgn_object *ret);
+
+/**
+ * Set the object associated with this module.
+ * @param[in] obj A new (or replacement) object for the module
+ */
+struct drgn_error *
+drgn_module_set_object(struct drgn_module *module, const struct drgn_object *obj);
 
 /** Debugging information finder callback table. */
 struct drgn_debug_info_finder_ops {

--- a/libdrgn/orc_info.h
+++ b/libdrgn/orc_info.h
@@ -41,7 +41,8 @@ struct drgn_module_orc_info {
 	 * Base for calculating program counter corresponding to an ORC unwinder
 	 * entry.
 	 *
-	 * This is the address of the `.orc_unwind_ip` ELF section.
+	 * This is the address of the `.orc_unwind_ip` ELF section. It is the
+	 * actual loaded location, with any bias already applied.
 	 *
 	 * @sa drgn_module_orc_info::entries
 	 */

--- a/libdrgn/orc_info.h
+++ b/libdrgn/orc_info.h
@@ -72,11 +72,14 @@ struct drgn_module_orc_info {
 	unsigned int num_entries;
 	/** Version of the ORC format. See @ref orc.h. */
 	int version;
+	/** Whether to byte swap data */
+	bool bswap;
 };
 
 void drgn_module_orc_info_deinit(struct drgn_module *module);
 
-struct drgn_error *drgn_module_parse_orc(struct drgn_module *module);
+struct drgn_error *drgn_module_parse_orc(struct drgn_module *module,
+					 bool use_builtin);
 
 bool drgn_module_should_prefer_orc_cfi(struct drgn_module *module, uint64_t pc);
 

--- a/libdrgn/python/drgnpy.h
+++ b/libdrgn/python/drgnpy.h
@@ -351,6 +351,12 @@ void *set_error_type_name(const char *format,
 
 PyObject *Module_wrap(struct drgn_module *module);
 PyObject *Module_and_bool_wrap(struct drgn_module *module, bool b);
+static inline Program *Module_prog(Module *module)
+{
+	struct drgn_program *prog = drgn_module_program(module->module);
+	return container_of(prog, Program, prog);
+}
+
 int add_WantedSupplementaryFile(PyObject *m);
 int init_module_section_addresses(void);
 

--- a/libdrgn/python/module.c
+++ b/libdrgn/python/module.c
@@ -68,10 +68,8 @@ PyObject *Module_and_bool_wrap(struct drgn_module *module, bool b)
 
 static void Module_dealloc(Module *self)
 {
-	if (self->module) {
-		struct drgn_program *prog = drgn_module_program(self->module);
-		Py_DECREF(container_of(prog, Program, prog));
-	}
+	if (self->module)
+		Py_DECREF(Module_prog(self));
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
@@ -192,8 +190,7 @@ static PyObject *Module_try_file(Module *self, PyObject *args, PyObject *kwds)
 
 static Program *Module_get_prog(Module *self, void *arg)
 {
-	Program *prog =
-		container_of(drgn_module_program(self->module), Program, prog);
+	Program *prog = Module_prog(self);
 	Py_INCREF(prog);
 	return prog;
 }

--- a/libdrgn/python/module_section_addresses.c
+++ b/libdrgn/python/module_section_addresses.c
@@ -20,8 +20,7 @@ static ModuleSectionAddresses *ModuleSectionAddresses_new(PyTypeObject *subtype,
 	ModuleSectionAddresses *ret =
 		(ModuleSectionAddresses *)subtype->tp_alloc(subtype, 0);
 	if (ret) {
-		struct drgn_program *prog = drgn_module_program(module->module);
-		Py_INCREF(container_of(prog, Program, prog));
+		Py_INCREF(Module_prog(module));
 		ret->module = module->module;
 	}
 	return ret;

--- a/libdrgn/stack_trace.c
+++ b/libdrgn/stack_trace.c
@@ -1067,6 +1067,10 @@ drgn_unwind_one_register(struct drgn_program *prog, struct drgn_elf_file *file,
 	}
 	case DRGN_CFI_RULE_AT_DWARF_EXPRESSION:
 	case DRGN_CFI_RULE_DWARF_EXPRESSION:
+		// It is possible for file to be NULL when using built-in ORC.
+		// However, it should be impossible to encounter a DWARF
+		// expression for built-in ORC.
+		assert(file != NULL);
 		err = drgn_eval_cfi_dwarf_expression(prog, file, rule, regs,
 						     buf, size);
 		break;

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import functools
+import logging
 import os
 import sys
 from typing import Any, Mapping, NamedTuple, Optional
@@ -455,3 +456,14 @@ def modifyenv(vars: Mapping[str, Optional[str]]):
                 del os.environ[key]
             else:
                 os.environ[key] = old_value
+
+
+@contextlib.contextmanager
+def drgn_log_level(level: int):
+    logger = logging.getLogger("drgn")
+    old_level = logger.getEffectiveLevel()
+    logger.setLevel(level)
+    try:
+        yield
+    finally:
+        logger.setLevel(old_level)

--- a/tests/linux_kernel/test_stack_trace.py
+++ b/tests/linux_kernel/test_stack_trace.py
@@ -1,12 +1,15 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import logging
 import os
+import re
 import unittest
 
 from _drgn_util.platform import NORMALIZED_MACHINE_NAME
-from drgn import Object, Program, reinterpret
-from tests import assertReprPrettyEqualsStr, modifyenv
+from drgn import Object, Program, TypeMember, reinterpret
+from drgn.helpers.linux import load_module_kallsyms, load_vmlinux_kallsyms
+from tests import assertReprPrettyEqualsStr, drgn_log_level, modifyenv
 from tests.linux_kernel import (
     LinuxKernelTestCase,
     fork_and_stop,
@@ -59,6 +62,60 @@ class TestStackTrace(LinuxKernelStackTraceTestCase):
     def test_by_pid_orc(self):
         self._test_by_pid(True)
 
+    def _check_logged_orc_message(self, captured_logs, module):
+        # To be sure that we actually used ORC to unwind through the drgn_test
+        # stack frames, search for the log output. We don't know which ORC
+        # version is used, so just ensure that we have a log line that mentions
+        # loading ORC.
+        expr = re.compile(
+            r"DEBUG:drgn:Loaded built-in ORC \(v\d+\) for module " + module
+        )
+        for line in captured_logs.output:
+            if expr.fullmatch(line):
+                break
+        else:
+            self.fail(f"Did not load built-in ORC for {module}")
+
+    @unittest.skipUnless(
+        NORMALIZED_MACHINE_NAME == "x86_64",
+        f"{NORMALIZED_MACHINE_NAME} does not use ORC",
+    )
+    @skip_unless_have_test_kmod
+    def test_by_pid_builtin_orc(self):
+        # ORC was introduced in kernel 4.14. Detect the presence of ORC or skip
+        # the test.
+        try:
+            self.prog.symbol("__start_orc_unwind")
+        except LookupError:
+            ver = self.prog["UTS_RELEASE"].string_().decode()
+            self.skipTest(f"ORC is not available for {ver}")
+
+        with drgn_log_level(logging.DEBUG):
+            # Create a program with the core kernel debuginfo loaded,
+            # but without module debuginfo. Load a symbol finder using
+            # kallsyms so that the module's stack traces can still have
+            # usable frame names.
+            prog = Program()
+            prog.set_kernel()
+            prog.load_debug_info(main=True)
+            # Now that vmlinux is loaded, enumerate all the kernel modules so
+            # that a drgn_module is created to hold the ORC data
+            list(prog.loaded_modules())
+            kallsyms = load_module_kallsyms(prog)
+            prog.register_symbol_finder("module_kallsyms", kallsyms, enable_index=1)
+            for thread in prog.threads():
+                if b"drgn_test_kthread".startswith(thread.object.comm.string_()):
+                    pid = thread.tid
+                    break
+            else:
+                self.fail("couldn't find drgn_test_kthread")
+            # We must set drgn's log level manually, beacuse it won't log messages
+            # to the logger if it isn't enabled for them.
+            with self.assertLogs("drgn", logging.DEBUG) as log:
+                self._test_drgn_test_kthread_trace(prog.stack_trace(pid))
+
+            self._check_logged_orc_message(log, "drgn_test")
+
     @skip_unless_have_test_kmod
     def test_by_pt_regs(self):
         pt_regs = self.prog["drgn_test_kthread_pt_regs"]
@@ -103,6 +160,84 @@ class TestStackTrace(LinuxKernelStackTraceTestCase):
                 break
         else:
             self.fail("Couldn't find drgn_test_kthread_fn3 frame")
+
+    @unittest.skipUnless(
+        NORMALIZED_MACHINE_NAME == "x86_64",
+        f"{NORMALIZED_MACHINE_NAME} does not use ORC",
+    )
+    def test_vmlinux_builtin_orc(self):
+        # ORC was introduced in kernel 4.14. Detect the presence of ORC or skip
+        # the test.
+        try:
+            self.prog.symbol("__start_orc_unwind")
+        except LookupError:
+            ver = self.prog["UTS_RELEASE"].string_().decode()
+            self.skipTest(f"ORC is not available for {ver}")
+
+        with drgn_log_level(logging.DEBUG):
+            # It is difficult to test stack unwinding in a program without also
+            # loading types, which necessarily will also make DWARF CFI and ORC
+            # available in the debug file. The way we get around this is by creating
+            # a new program with no debuginfo, getting a pt_regs from the program
+            # that has debuginfo, and then using that to unwind the kernel. We still
+            # need a symbol finder, and we'll need the Module API to recognize the
+            # kernel address range correctly.
+            prog = Program()
+            prog.set_kernel()
+            prog.register_symbol_finder(
+                "vmlinux_kallsyms", load_vmlinux_kallsyms(prog), enable_index=0
+            )
+            main, _ = prog.main_module(name="kernel", create=True)
+            main.address_range = self.prog.main_module().address_range
+
+            # Luckily, all drgn cares about for x86_64 pt_regs is that it is a
+            # structure. Rather than creating a matching struct pt_regs definition,
+            # we can just create a dummy one of the correct size:
+            #     struct pt_regs { unsigned char[size]; };
+            # Drgn will happily use that and reinterpret the bytes correctly.
+            real_pt_regs_type = self.prog.type("struct pt_regs")
+            fake_pt_regs_type = prog.struct_type(
+                tag="pt_regs",
+                size=real_pt_regs_type.size,
+                members=[
+                    TypeMember(
+                        prog.array_type(
+                            prog.int_type("unsigned char", 1, False),
+                            real_pt_regs_type.size,
+                        ),
+                        "data",
+                    ),
+                ],
+            )
+
+            with fork_and_stop() as pid:
+                trace = self.prog.stack_trace(pid)
+                regs_dict = trace[0].registers()
+                pt_regs_obj = Object(
+                    self.prog,
+                    real_pt_regs_type,
+                    {
+                        "bp": regs_dict["rbp"],
+                        "sp": regs_dict["rsp"],
+                        "ip": regs_dict["rip"],
+                        "r15": regs_dict["r15"],
+                    },
+                )
+                fake_pt_regs_obj = Object.from_bytes_(
+                    prog, fake_pt_regs_type, pt_regs_obj.to_bytes_()
+                )
+                # We must set drgn's log level manually, beacuse it won't log messages
+                # to the logger if it isn't enabled for them.
+                with self.assertLogs("drgn", logging.DEBUG) as log:
+                    no_debuginfo_trace = prog.stack_trace(fake_pt_regs_obj)
+
+                dwarf_pcs = []
+                for frame in trace:
+                    if not dwarf_pcs or dwarf_pcs[-1] != frame.pc:
+                        dwarf_pcs.append(frame.pc)
+                orc_pcs = [frame.pc for frame in no_debuginfo_trace]
+                self.assertEqual(dwarf_pcs, orc_pcs)
+                self._check_logged_orc_message(log, "kernel")
 
     def test_registers(self):
         # Smoke test that we get at least one register and that


### PR DESCRIPTION
Thanks to your work today with 3ce0feea ("tests: don't clobber file in use by libelf") and a1869f95 ("Make StackFrame.name fall back to symbol/PC and add StackFrame.function_name"), this branch is fully unblocked!

Now that the module API has landed, we can usually rely on having a `struct drgn_module` available for a kernel module, even if the module debuginfo is not loaded (either because you have only loaded debuginfo for the kernel, or because you are using CTF). My previous ORC support required essentially re-implementing a small portion of the module API, specifically a tree that mapped address ranges to ORC data. Now, I can drop all that complexity and share this branch which I think is ready for consideration.

This branch's main goal is to enable using built-in ORC information for stack unwinding, for the cases where a module does not have debuginfo. I think the commit messages here describe everything that's important. I think the testing is okay -- I wish I could test the vmlinux ORC, but I think I would need a type finder to allow the module API to even get initialized.