### PR TITLE
[not ready for merge] Userspace stack tracing from kernel programs

### DIFF
--- a/contrib/pstack.py
+++ b/contrib/pstack.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Print a kernel & userspace stack
+"""
+import sys
+from struct import Struct
+from typing import BinaryIO
+from typing import NamedTuple
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+from drgn import Program
+from drgn import Object
+from drgn import TypeMember
+from drgn import sizeof
+from drgn.helpers.linux import access_remote_vm
+from drgn.helpers.linux import d_path
+from drgn.helpers.linux import find_vmap_area
+from drgn.helpers.linux import for_each_vma
+
+
+AT_PHDR = 3
+SHT_DYNAMIC = 6
+PT_DYNAMIC = 2
+
+T = TypeVar("T")
+
+
+def read_struct(cls: Type[T], prog: Program, addr: int, file: Optional[BinaryIO], file_base: int) -> T:
+    if file:
+        file.seek(addr - file_base)
+        return cls(*cls.struct.unpack(file.read(cls.struct.size)))
+    else:
+        return cls(*cls.struct.unpack(prog.read(addr, cls.struct.size)))
+
+
+class Ehdr(NamedTuple):
+    e_ident: bytes
+    e_type: int
+    e_machine: int
+    e_version: int
+    e_entry: int
+    e_phoff: int
+    e_shoff: int
+    e_flags: int
+    e_ehsize: int
+    e_phentsize: int
+    e_phnum: int
+    e_shentsize: int
+    e_shnum: int
+    e_shstrndx: int
+
+    struct = Struct("=16sHHIQQQIHHHHHH")
+
+
+class Phdr(NamedTuple):
+    p_type: int
+    p_flags: int
+    p_offset: int
+    p_vaddr: int
+    p_paddr: int
+    p_filesz: int
+    p_memsz: int
+    p_align: int
+
+    struct = Struct("=IIQQQQQQ")
+
+
+class Shdr(NamedTuple):
+    sh_name: int
+    sh_type: int
+    sh_flags: int
+    sh_addr: int
+    sh_offset: int
+    sh_size: int
+    sh_link: int
+    sh_info: int
+    sh_addralign: int
+    sh_entsize: int
+
+    struct = Struct("=IIQQQQIIQQ")
+
+
+def dynamic_address(up: Program, file_addr: int, path: Optional[str]) -> int:
+    file = None
+    if path:
+        file = open(path, "rb")
+    ehdr = read_struct(Ehdr, up, file_addr, file, file_addr)
+    if ehdr.e_shoff:
+        for i in range(ehdr.e_phnum):
+            phdr = read_struct(
+                Phdr, up, file_addr + ehdr.e_phoff + i * ehdr.e_phentsize, file, file_addr
+            )
+            if phdr.p_type == PT_DYNAMIC:
+                return phdr.p_offset
+    raise LookupError(f"cannot find DYNAMIC address in {file_addr:x}")
+
+
+def get_auxval(arr: Object, kind: int) -> int:
+    for i in range(0, len(arr), 2):
+        if arr[i] == kind:
+            return arr[i + 1].value_()
+    raise LookupError(f"cannot find auxval: {kind}")
+
+
+def find_main(mm: Object) -> Tuple[bytes, int, Object]:
+    phdr = get_auxval(mm.saved_auxv, AT_PHDR)
+    for vma in for_each_vma(mm):
+        if vma.vm_start <= phdr < vma.vm_end:
+            path = d_path(vma.vm_file.f_path)
+            return (path, vma.vm_start.value_(), vma)
+
+
+def address_range(mm: Object, file: Object, start: int, end: int) -> Tuple[int, int]:
+    for vma in for_each_vma(mm):
+        if vma.vm_file == file:
+            start = min(start, vma.vm_start.value_())
+            end = max(end, vma.vm_end.value_())
+    return start, end
+
+
+def load_shared_libraries(up: Program, mm: Object, main: bytes):
+    VM_EXEC = 0x4
+    for vma in for_each_vma(mm):
+        if vma.vm_flags & VM_EXEC:
+            path = None
+            if vma.vm_file:
+                path = d_path(vma.vm_file.f_path)
+            if path == main:
+                continue
+            file_start = (
+                vma.vm_start - vma.vm_pgoff * mm.prog_["PAGE_SIZE"]
+            ).value_()
+            try:
+                address = dynamic_address(up, file_start, path)
+            except Exception:
+                print(f"error setting up module for {file_start} ({path})")
+                continue
+            if path:
+                mod, _ = up.shared_library_module(
+                    path, dynamic_address=file_start + address, create=True
+                )
+                mod.try_file(path, force=True)
+                mod.address_range = address_range(mm, vma.vm_file, vma.vm_start.value_(), vma.vm_end.value_())
+            else:
+                # vdso
+                mod, _ = up.vdso_module(
+                    "linux-vdso.so.1", dynamic_address=file_start + address, create=True
+                )
+
+
+def get_user_prog(prog: Program, pid: int):
+    up = Program(prog.platform)
+    thread = prog.thread(pid)
+    tsk = thread.object
+    mm = tsk.mm
+
+    def read_fn(addr, count, offset, _):
+        val = access_remote_vm(mm, offset, count)
+        return val
+
+    up.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, read_fn, False)
+
+    main_prog, bias, vma = find_main(mm)
+    main_mod, _ = up.main_module(name=main_prog, create=True)
+    main_mod.try_file(main_prog, force=True)
+    main_mod.loaded_file_bias = bias
+    main_mod.address_range = address_range(mm, vma.vm_file, vma.vm_start.value_(), vma.vm_end.value_())
+    load_shared_libraries(up, mm, main_prog)
+    return up
+
+
+def get_pt_regs(prog: Program, pid: int, up: Program) -> Object:
+    # The pt_regs is dumped at the top of the stack. The stack size may vary,
+    # but I believe it gets one page of padding, and the registers are dumped at
+    # an offset of 16 bytes for 64-bit.
+    thread = prog.thread(pid)
+    stack = thread.object.stack
+    regs_addr = (
+        find_vmap_area(prog, stack).va_end.value_()
+        - sizeof(prog.type("struct pt_regs"))
+        - prog["PAGE_SIZE"]
+        - 16
+    )
+    regs = Object(prog, "struct pt_regs", address=regs_addr)
+
+    # Luckily, all drgn cares about for x86_64 pt_regs is that it is a
+    # structure. Rather than creating a matching struct pt_regs definition,
+    # we can just create a dummy one of the correct size:
+    #     struct pt_regs { unsigned char[size]; };
+    # Drgn will happily use that and reinterpret the bytes correctly.
+    fake_pt_regs_type = up.struct_type(
+        tag="pt_regs",
+        size=regs.type_.size,
+        members=[
+            TypeMember(
+                up.array_type(
+                    up.int_type("unsigned char", 1, False),
+                    regs.type_.size,
+                ),
+                "data",
+            ),
+        ],
+    )
+    # Return a fake struct pt_regs that drgn will unwind.
+    return Object.from_bytes_(
+        up, fake_pt_regs_type, regs.to_bytes_()
+    )
+
+
+def main(prog: Program, pid: int) -> None:
+    print(prog.stack_trace(pid))
+    up = get_user_prog(prog, pid)
+    regs = get_pt_regs(prog, pid, up)
+    print("------ userspace ---------")
+    print(up.stack_trace(regs))
+
+
+if __name__ == "__main__":
+    prog: Program
+    main(prog, int(sys.argv[1]))  # noqa

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -1305,7 +1305,7 @@ drgn_module_maybe_use_elf_file(struct drgn_module *module,
 		// We should only be here if we want a file.
 		assert(drgn_module_wants_file(module));
 		use_loaded = module->loaded_file_status == DRGN_MODULE_FILE_WANT
-			     && file->is_loadable;
+			     && (file->is_loadable || module->kind == DRGN_MODULE_EXTRA);
 		has_dwarf = drgn_elf_file_has_dwarf(file);
 		use_debug = drgn_module_wants_debug_file(module) && has_dwarf;
 	}

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -510,6 +510,7 @@ static void drgn_module_destroy(struct drgn_module *module)
 	drgn_elf_file_destroy(module->supplementary_debug_file);
 	if (module->debug_file != module->loaded_file)
 		drgn_elf_file_destroy(module->debug_file);
+	drgn_elf_file_destroy(module->gnu_debugdata_file);
 	drgn_elf_file_destroy(module->loaded_file);
 	free(module->build_id);
 	free(module->name);

--- a/libdrgn/debug_info.h
+++ b/libdrgn/debug_info.h
@@ -213,6 +213,7 @@ struct drgn_module {
 	struct drgn_elf_file *loaded_file;
 	struct drgn_elf_file *debug_file;
 	struct drgn_elf_file *supplementary_debug_file;
+	struct drgn_elf_file *gnu_debugdata_file;
 	/** Table mapping libdw handle to corresponding @ref drgn_elf_file. */
 	struct drgn_elf_file_dwarf_table split_dwarf_files;
 	uint64_t loaded_file_bias;
@@ -226,7 +227,7 @@ struct drgn_module {
 	/** ORC unwinder information. */
 	struct drgn_module_orc_info orc;
 	/** ELF symbol table. */
-	struct drgn_elf_symbol_table elf_symtab;
+	struct drgn_elf_symbol_table elf_symtab[2];
 
 	/** Whether .debug_frame has been parsed. */
 	bool parsed_debug_frame;

--- a/libdrgn/elf_symtab.c
+++ b/libdrgn/elf_symtab.c
@@ -3,8 +3,10 @@
 
 #include <gelf.h>
 #include <libelf.h>
+#include <lzma.h>
 #include <stdlib.h>
 
+#include "array.h"
 #include "debug_info.h"
 #include "elf_file.h"
 #include "elf_symtab.h"
@@ -21,13 +23,22 @@ static struct drgn_error *find_elf_file_symtab(struct drgn_elf_file *file,
 					       Elf_Scn **scn_ret,
 					       GElf_Word *strtab_idx_ret,
 					       GElf_Word *num_local_symbols_ret,
-					       bool *full_symtab_ret)
+					       bool *full_symtab_ret,
+					       Elf_Scn **gnu_debugdata_ret)
 {
 	Elf_Scn *scn = NULL;
+	size_t shstrndx;
+	if (elf_getshdrstrndx(file->elf, &shstrndx))
+		return drgn_error_libelf();
 	while ((scn = elf_nextscn(file->elf, scn))) {
 		GElf_Shdr shdr_mem, *shdr = gelf_getshdr(scn, &shdr_mem);
 		if (!shdr)
 			return drgn_error_libelf();
+
+		const char *scnname = elf_strptr(file->elf, shstrndx, shdr->sh_name);
+		if (scnname && gnu_debugdata_ret && shdr->sh_type == SHT_PROGBITS
+		    && strcmp(".gnu_debugdata", scnname) == 0)
+			*gnu_debugdata_ret = scn;
 
 		if (shdr->sh_type == SHT_SYMTAB
 		    || shdr->sh_type == SHT_DYNSYM) {
@@ -46,54 +57,104 @@ static struct drgn_error *find_elf_file_symtab(struct drgn_elf_file *file,
 }
 
 static struct drgn_error *
-find_module_elf_symtab(struct drgn_module *module)
+drgn_error_lzma(lzma_ret code)
 {
+	switch (code) {
+		case LZMA_MEM_ERROR:
+			return &drgn_enomem;
+		case LZMA_OPTIONS_ERROR:
+			return drgn_error_format(DRGN_ERROR_INVALID_ARGUMENT,
+						 "lzma: invalid options");
+		case LZMA_FORMAT_ERROR:
+		case LZMA_DATA_ERROR:
+		case LZMA_BUF_ERROR:
+			return drgn_error_format(DRGN_ERROR_INVALID_ARGUMENT,
+						 "lzma: format error (%d)", code);
+		default:
+			return drgn_error_format(DRGN_ERROR_OTHER,
+						 "lzma: unknown error (%d)", code);
+	}
+}
+
+static struct drgn_error *
+load_gnu_debugdata_file(struct drgn_module *module, Elf_Scn *gnu_debugdata_scn)
+{
+	if (module->gnu_debugdata_file)
+		return NULL;
+
+	Elf_Data *gnu_debugdata_data;
 	struct drgn_error *err;
+	err = read_elf_section(gnu_debugdata_scn, &gnu_debugdata_data);
+	if (err)
+		return err;
 
-	if (!module->elf_symtab_pending_files)
-		return NULL;
+	_cleanup_(lzma_end) lzma_stream stream = LZMA_STREAM_INIT;
+	uint64_t memlimit = UINT64_MAX;
+	lzma_ret ret = lzma_stream_decoder(&stream, UINT64_MAX, 0);
+	if (ret != LZMA_OK)
+		return drgn_error_lzma(ret);
 
-	if (module->elf_symtab.num_symbols > 0 && !module->have_full_symtab) {
-		module->elf_symtab_pending_files = 0;
-		return NULL;
+	stream.next_in = gnu_debugdata_data->d_buf;
+	stream.avail_in = gnu_debugdata_data->d_size;
+
+	size_t datasize = 2 * gnu_debugdata_data->d_size;
+	_cleanup_free_ void *data = malloc(datasize);
+
+	stream.next_out = data;
+	stream.avail_out = gnu_debugdata_data->d_size;
+
+	size_t bytes_decoded;
+	while (1) {
+		ret = lzma_code(&stream, LZMA_RUN);
+		if (ret != LZMA_OK && ret != LZMA_STREAM_END)
+			return drgn_error_lzma(ret);
+
+		bytes_decoded = (void *)stream.next_out - data;
+		if (ret == LZMA_STREAM_END)
+			datasize = bytes_decoded;
+		else
+			datasize *= 2;
+
+		data = realloc(data, datasize);
+		if (!data)
+			return &drgn_enomem;
+
+		stream.next_out = data + bytes_decoded;
+		stream.avail_out = datasize - bytes_decoded;
+		if (ret == LZMA_STREAM_END)
+			break;
 	}
 
-	struct drgn_elf_file *file = NULL;
-	uint64_t bias;
-	Elf_Scn *symtab_scn;
-	GElf_Word strtab_idx, num_local_symbols;
-	bool full_symtab = false;
+	Elf *elf = elf_memory(data, bytes_decoded);
+	if (!elf)
+		return drgn_error_libelf();
 
-	if (module->elf_symtab_pending_files & DRGN_MODULE_FILE_MASK_DEBUG) {
-		err = find_elf_file_symtab(module->debug_file,
-					   module->debug_file_bias, &file,
-					   &bias, &symtab_scn, &strtab_idx,
-					   &num_local_symbols, &full_symtab);
-		if (err)
-			return err;
-	}
+	err = drgn_elf_file_create(module, module->loaded_file->path, -1, data, elf,
+				   &module->gnu_debugdata_file);
+	if (err)
+		elf_end(elf);
+	else
+		data = NULL;
+	return err;
+}
 
-	if (!full_symtab &&
-	    (module->elf_symtab_pending_files & DRGN_MODULE_FILE_MASK_LOADED)) {
-		err = find_elf_file_symtab(module->loaded_file,
-					   module->loaded_file_bias, &file,
-					   &bias, &symtab_scn, &strtab_idx,
-					   &num_local_symbols, &full_symtab);
-		if (err)
-			return err;
-	}
-
-	if (!file) {
-		drgn_log_debug(module->prog, "%s: no ELF symbol table",
-			       module->name);
-		module->elf_symtab_pending_files = 0;
-		return NULL;
-	}
+static struct drgn_error *
+append_module_elf_symtab(struct drgn_module *module, struct drgn_elf_file *file,
+			 uint64_t bias, Elf_Scn *symtab_scn, GElf_Word strtab_idx,
+			 GElf_Word num_local_symbols)
+{
+	size_t i = 0;
+	while (i < array_size(module->elf_symtab) && module->elf_symtab[i].file)
+		i++;
+	if (i == array_size(module->elf_symtab))
+		return drgn_error_format(DRGN_ERROR_OTHER,
+					 "reached maximum number of ELF symbol tables");
 
 	Elf_Scn *strtab_scn = elf_getscn(file->elf, strtab_idx);
 	if (!strtab_scn)
 		return drgn_error_libelf();
 
+	struct drgn_error *err;
 	Elf_Data *data, *strtab_data;
 	if ((err = read_elf_section(symtab_scn, &data))
 	    || (err = read_elf_section(strtab_scn, &strtab_data)))
@@ -113,54 +174,135 @@ find_module_elf_symtab(struct drgn_module *module)
 			return err;
 	}
 
-	module->elf_symtab.file = file;
-	module->elf_symtab.bias = bias;
-	module->elf_symtab.data = data->d_buf;
-	module->elf_symtab.num_symbols =
+	module->elf_symtab[i].file = file;
+	module->elf_symtab[i].bias = bias;
+	module->elf_symtab[i].data = data->d_buf;
+	module->elf_symtab[i].num_symbols =
 		data->d_size
 		/ (drgn_elf_file_is_64_bit(file)
 		   ? sizeof(Elf64_Sym) : sizeof(Elf32_Sym));
 	if (num_local_symbols < 1)
 		num_local_symbols = 1;
-	if (num_local_symbols > module->elf_symtab.num_symbols)
-		num_local_symbols = module->elf_symtab.num_symbols;
-	module->elf_symtab.num_local_symbols = num_local_symbols;
-	module->elf_symtab.strtab = strtab_data;
-	module->elf_symtab.shndx = shndx_data;
+	if (num_local_symbols > module->elf_symtab[i].num_symbols)
+		num_local_symbols = module->elf_symtab[i].num_symbols;
+	module->elf_symtab[i].num_local_symbols = num_local_symbols;
+	module->elf_symtab[i].strtab = strtab_data;
+	module->elf_symtab[i].shndx = shndx_data;
 	module->elf_symtab_pending_files = 0;
-	module->have_full_symtab = full_symtab;
+	return NULL;
+}
 
-	drgn_log_debug(module->prog,
-		       "%s: found ELF %ssymbol table with %zu symbols",
-		       module->name, full_symtab ? "" : "dynamic ",
-		       module->elf_symtab.num_symbols);
+static struct drgn_error *
+find_module_elf_symtab(struct drgn_module *module)
+{
+	struct drgn_error *err;
+
+	if (!module->elf_symtab_pending_files)
+		return NULL;
+
+	if (module->elf_symtab[0].num_symbols > 0 && !module->have_full_symtab) {
+		module->elf_symtab_pending_files = 0;
+		return NULL;
+	}
+
+	struct drgn_elf_file *file = NULL;
+	uint64_t bias;
+	Elf_Scn *symtab_scn;
+	GElf_Word strtab_idx, num_local_symbols;
+	bool full_symtab = false;
+
+	if (module->elf_symtab_pending_files & DRGN_MODULE_FILE_MASK_DEBUG) {
+		err = find_elf_file_symtab(module->debug_file,
+					   module->debug_file_bias, &file,
+					   &bias, &symtab_scn, &strtab_idx,
+					   &num_local_symbols, &full_symtab,
+					   NULL);
+		if (err)
+			return err;
+	}
+
+	Elf_Scn *gnu_debugdata_scn = NULL;
+	if (!full_symtab &&
+	    (module->elf_symtab_pending_files & DRGN_MODULE_FILE_MASK_LOADED)) {
+		err = find_elf_file_symtab(module->loaded_file,
+					   module->loaded_file_bias, &file,
+					   &bias, &symtab_scn, &strtab_idx,
+					   &num_local_symbols, &full_symtab,
+					   &gnu_debugdata_scn);
+		if (err)
+			return err;
+	}
+
+	if (!file && !gnu_debugdata_scn) {
+		drgn_log_debug(module->prog, "%s: no ELF symbol table",
+			       module->name);
+		module->elf_symtab_pending_files = 0;
+		return NULL;
+	}
+
+	int sym_tab = 0;
+	if (file) {
+		err = append_module_elf_symtab(module, file, bias, symtab_scn, strtab_idx,
+					num_local_symbols);
+		if (err)
+			return err;
+
+		module->have_full_symtab = full_symtab;
+		drgn_log_debug(module->prog,
+			"%s: found ELF %ssymbol table with %zu symbols",
+			module->name, full_symtab ? "" : "dynamic ",
+			module->elf_symtab[sym_tab].num_symbols);
+		sym_tab++;
+	}
+
+	if (!full_symtab && gnu_debugdata_scn) {
+		err = load_gnu_debugdata_file(module, gnu_debugdata_scn);
+		if (err)
+			return err;
+		err = find_elf_file_symtab(module->gnu_debugdata_file,
+					   module->loaded_file_bias, &file,
+					   &bias, &symtab_scn, &strtab_idx,
+					   &num_local_symbols, &full_symtab,
+					   NULL);
+		if (err)
+			return err;
+		err = append_module_elf_symtab(module, file, bias, symtab_scn, strtab_idx,
+					num_local_symbols);
+		if (err)
+			return err;
+		module->have_full_symtab = full_symtab;
+		drgn_log_debug(module->prog,
+			"%s: found ELF .gnu_debugdata symbol table with %zu symbols",
+			module->name, module->elf_symtab[sym_tab].num_symbols);
+
+	}
 
 	return NULL;
 }
 
-static size_t elf_symbol_shndx(struct drgn_module *module, size_t sym_idx,
-			       const GElf_Sym *sym)
+static size_t elf_symbol_shndx(struct drgn_module *module, int sym_tab,
+			       size_t sym_idx, const GElf_Sym *sym)
 {
 	if (sym->st_shndx < SHN_LORESERVE)
 		return sym->st_shndx;
 	if (sym->st_shndx == SHN_XINDEX
-	    && module->elf_symtab.shndx
+	    && module->elf_symtab[sym_tab].shndx
 	    && sym_idx <
-	       module->elf_symtab.shndx->d_size / sizeof(uint32_t)) {
+	       module->elf_symtab[sym_tab].shndx->d_size / sizeof(uint32_t)) {
 		uint32_t tmp;
 		memcpy(&tmp,
-		       (const char *)module->elf_symtab.shndx->d_buf
+		       (const char *)module->elf_symtab[sym_tab].shndx->d_buf
 		       + sym_idx * sizeof(uint32_t),
 		       sizeof(uint32_t));
-		if (drgn_elf_file_bswap(module->elf_symtab.file))
+		if (drgn_elf_file_bswap(module->elf_symtab[sym_tab].file))
 			tmp = bswap_32(tmp);
 		return tmp;
 	}
 	return SHN_UNDEF;
 }
 
-static bool elf_symbol_address(struct drgn_module *module, size_t sym_idx,
-			       const GElf_Sym *sym, uint64_t *ret)
+static bool elf_symbol_address(struct drgn_module *module, int sym_tab,
+			       size_t sym_idx, const GElf_Sym *sym, uint64_t *ret)
 {
 	uint64_t addr = sym->st_value;
 
@@ -172,16 +314,16 @@ static bool elf_symbol_address(struct drgn_module *module, size_t sym_idx,
 	// currently support V1 of the 64-bit PowerPC ELF ABI where st_value is
 	// the address of a "function descriptor" instead of the function entry
 	// point.
-	if (module->elf_symtab.file->platform.arch->arch == DRGN_ARCH_ARM
+	if (module->elf_symtab[sym_tab].file->platform.arch->arch == DRGN_ARCH_ARM
 	    && GELF_ST_TYPE(sym->st_info) == STT_FUNC)
 		addr &= ~1;
 
-	addr += module->elf_symtab.bias;
-	if (module->elf_symtab.file->is_relocatable) {
-		size_t shndx = elf_symbol_shndx(module, sym_idx, sym);
+	addr += module->elf_symtab[sym_tab].bias;
+	if (module->elf_symtab[sym_tab].file->is_relocatable) {
+		size_t shndx = elf_symbol_shndx(module, sym_tab, sym_idx, sym);
 		if (shndx == SHN_UNDEF)
 			return false;
-		Elf_Scn *scn = elf_getscn(module->elf_symtab.file->elf, shndx);
+		Elf_Scn *scn = elf_getscn(module->elf_symtab[sym_tab].file->elf, shndx);
 		if (!scn)
 			return false;
 		GElf_Shdr shdr_mem, *shdr = gelf_getshdr(scn, &shdr_mem);
@@ -265,13 +407,14 @@ static bool better_sizeless_addr_match(const GElf_Sym *a, uint64_t a_addr,
 	       > elf_symbol_binding_precedence(b);
 }
 
-static bool addr_in_sym_section(struct drgn_module *module, size_t sym_idx,
-				const GElf_Sym *sym, uint64_t unbiased_addr)
+static bool addr_in_sym_section(struct drgn_module *module, int sym_tab,
+				size_t sym_idx, const GElf_Sym *sym,
+				uint64_t unbiased_addr)
 {
-	size_t shndx = elf_symbol_shndx(module, sym_idx, sym);
+	size_t shndx = elf_symbol_shndx(module, sym_tab, sym_idx, sym);
 	if (shndx == SHN_UNDEF)
 		return false;
-	Elf_Scn *scn = elf_getscn(module->elf_symtab.file->elf, shndx);
+	Elf_Scn *scn = elf_getscn(module->elf_symtab[sym_tab].file->elf, shndx);
 	if (!scn)
 		return false;
 	GElf_Shdr shdr_mem, *shdr = gelf_getshdr(scn, &shdr_mem);
@@ -287,15 +430,16 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 			       struct drgn_symbol_result_builder *builder)
 {
 	struct drgn_error *err;
+	int sym_tab = 0;
 
 	err = find_module_elf_symtab(module);
 	if (err)
 		return err;
-	if (module->elf_symtab.num_symbols == 0)
+	if (module->elf_symtab[sym_tab].num_symbols == 0)
 		return NULL;
 
-	const bool is_64_bit = drgn_elf_file_is_64_bit(module->elf_symtab.file);
-	const bool bswap = drgn_elf_file_bswap(module->elf_symtab.file);
+	const bool is_64_bit = drgn_elf_file_is_64_bit(module->elf_symtab[sym_tab].file);
+	const bool bswap = drgn_elf_file_bswap(module->elf_symtab[sym_tab].file);
 	const size_t sym_size =
 		is_64_bit ? sizeof(Elf64_Sym) : sizeof(Elf32_Sym);
 
@@ -310,6 +454,7 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 	// sizeless_sym_idx last seen with GCC 12.
 	uint64_t sizeless_addr = 0;
 	size_t sizeless_sym_idx = 0;
+	int sizeless_sym_tab = 0;
 	Elf64_Sym sizeless_sym;
 	// The maximum end address of any symbol starting before the given
 	// address. Any symbol with size 0 starting before this is either
@@ -329,8 +474,9 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 	// over that match, so we can skip local symbols.
 	//
 	// Otherwise, skip the undefined symbol at index 0.
-	for (size_t i = best_sym ? module->elf_symtab.num_local_symbols : 1;
-	     i < module->elf_symtab.num_symbols; i++) {
+	while (sym_tab < array_size(module->elf_symtab) && module->elf_symtab[sym_tab].file) {
+	for (size_t i = best_sym ? module->elf_symtab[sym_tab].num_local_symbols : 1;
+	     i < module->elf_symtab[sym_tab].num_symbols; i++) {
 		Elf64_Sym elf_sym;
 #define visit_elf_sym_members(visit_scalar_member, visit_raw_member) do {	\
 	visit_scalar_member(st_name);						\
@@ -341,7 +487,7 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 	visit_scalar_member(st_size);						\
 } while (0)
 		deserialize_struct64(&elf_sym, Elf32_Sym, visit_elf_sym_members,
-				     module->elf_symtab.data + i * sym_size,
+				     module->elf_symtab[sym_tab].data + i * sym_size,
 				     is_64_bit, bswap);
 #undef visit_elf_sym_members
 
@@ -350,10 +496,10 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 			continue;
 
 		// Ignore symbols with an out-of-bounds name.
-		if (elf_sym.st_name >= module->elf_symtab.strtab->d_size)
+		if (elf_sym.st_name >= module->elf_symtab[sym_tab].strtab->d_size)
 			continue;
 		const char *elf_sym_name =
-			(const char *)module->elf_symtab.strtab->d_buf
+			(const char *)module->elf_symtab[sym_tab].strtab->d_buf
 			+ elf_sym.st_name;
 
 		if ((flags & DRGN_FIND_SYMBOL_NAME)
@@ -381,7 +527,7 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 		}
 
 		uint64_t elf_sym_addr;
-		if (!elf_symbol_address(module, i, &elf_sym, &elf_sym_addr))
+		if (!elf_symbol_address(module, sym_tab, i, &elf_sym, &elf_sym_addr))
 			continue;
 
 		if (flags & DRGN_FIND_SYMBOL_ADDR) {
@@ -430,17 +576,19 @@ drgn_module_elf_symbols_search(struct drgn_module *module, const char *name,
 				// Otherwise, if we're searching by address and
 				// we find a matching local symbol, then we can
 				// skip past the remaining local symbols.
-				if (i < module->elf_symtab.num_local_symbols)
-					i = module->elf_symtab.num_local_symbols - 1;
+				if (i < module->elf_symtab[sym_tab].num_local_symbols)
+					i = module->elf_symtab[sym_tab].num_local_symbols - 1;
 			}
 		}
+	}
+	sym_tab++;
 	}
 
 	if (sizeless_name
 	    && drgn_symbol_result_builder_count(builder) == 0
 	    && sizeless_addr >= max_end_addr
-	    && addr_in_sym_section(module, sizeless_sym_idx, &sizeless_sym,
-				   addr - module->elf_symtab.bias)
+	    && addr_in_sym_section(module, sizeless_sym_tab, sizeless_sym_idx, &sizeless_sym,
+				   addr - module->elf_symtab[sizeless_sym_tab].bias)
 	    && !drgn_symbol_result_builder_add_from_elf(builder, sizeless_name,
 							sizeless_addr,
 							&sizeless_sym))

--- a/libdrgn/python/error.c
+++ b/libdrgn/python/error.c
@@ -73,6 +73,29 @@ void clear_drgn_in_python(void)
 	drgn_in_python = false;
 }
 
+struct drgn_error *drgn_fault_error_from_python(PyObject *exc_value)
+{
+	struct drgn_error *err = NULL;
+	PyObject *message = NULL, *address = NULL;
+
+	message = PyObject_GetAttrString(exc_value, "message");
+	if (!message) {
+		PyErr_Clear();
+		goto out;
+	}
+	address = PyObject_GetAttrString(exc_value, "address");
+	if (!message) {
+		PyErr_Clear();
+		goto out;
+	}
+	err = drgn_error_create_fault(PyUnicode_AsUTF8(message), PyLong_AsUint64(address));
+
+out:
+	Py_XDECREF(message);
+	Py_XDECREF(address);
+	return err;
+}
+
 struct drgn_error *drgn_error_from_python(void)
 {
 	PyObject *exc_type, *exc_value, *exc_traceback, *exc_message;
@@ -86,6 +109,11 @@ struct drgn_error *drgn_error_from_python(void)
 	if (drgn_in_python) {
 		PyErr_Restore(exc_type, exc_value, exc_traceback);
 		return &drgn_error_python;
+	}
+
+	if ((PyTypeObject *)exc_type == &FaultError_type && exc_value) {
+		err = drgn_fault_error_from_python(exc_value);
+		goto out;
 	}
 
 	type = ((PyTypeObject *)exc_type)->tp_name;

--- a/libdrgn/python/module.c
+++ b/libdrgn/python/module.c
@@ -347,6 +347,20 @@ static PyObject *Module_get_loaded_file_bias(Module *self, void *arg)
 	return PyLong_FromUint64(drgn_module_loaded_file_bias(self->module));
 }
 
+static int Module_set_loaded_file_bias(Module *self, PyObject *value, void *arg)
+{
+	if (!drgn_module_loaded_file_path(self->module)) {
+		PyErr_Format(PyExc_ValueError,
+			     "module does not have a loaded file");
+		return -1;
+	}
+	uint64_t new_bias = PyLong_AsUint64(value);
+	if (PyErr_Occurred())
+		return -1;
+	self->module->loaded_file_bias = new_bias;
+	return 0;
+}
+
 static PyObject *Module_get_debug_file_path(Module *self, void *arg)
 {
 	const char *path = drgn_module_debug_file_path(self->module);
@@ -360,6 +374,20 @@ static PyObject *Module_get_debug_file_bias(Module *self, void *arg)
 	if (!drgn_module_debug_file_path(self->module))
 		Py_RETURN_NONE;
 	return PyLong_FromUint64(drgn_module_debug_file_bias(self->module));
+}
+
+static int Module_set_debug_file_bias(Module *self, PyObject *value, void *arg)
+{
+	if (!drgn_module_debug_file_path(self->module)) {
+		PyErr_Format(PyExc_ValueError,
+			     "module does not have a debug file");
+		return -1;
+	}
+	uint64_t new_bias = PyLong_AsUint64(value);
+	if (PyErr_Occurred())
+		return -1;
+	self->module->debug_file_bias = new_bias;
+	return 0;
 }
 
 static PyObject *Module_get_supplementary_debug_file_kind(Module *self,
@@ -408,14 +436,16 @@ static PyGetSetDef Module_getset[] = {
 	 drgn_Module_loaded_file_status_DOC},
 	{"loaded_file_path", (getter)Module_get_loaded_file_path, NULL,
 	 drgn_Module_loaded_file_path_DOC},
-	{"loaded_file_bias", (getter)Module_get_loaded_file_bias, NULL,
+	{"loaded_file_bias", (getter)Module_get_loaded_file_bias,
+	 (setter)Module_set_loaded_file_bias,
 	 drgn_Module_loaded_file_bias_DOC},
 	{"debug_file_status", (getter)Module_get_debug_file_status,
 	 (setter)Module_set_debug_file_status,
 	 drgn_Module_debug_file_status_DOC},
 	{"debug_file_path", (getter)Module_get_debug_file_path, NULL,
 	 drgn_Module_debug_file_path_DOC},
-	{"debug_file_bias", (getter)Module_get_debug_file_bias, NULL,
+	{"debug_file_bias", (getter)Module_get_debug_file_bias,
+	 (setter)Module_set_debug_file_bias,
 	 drgn_Module_debug_file_bias_DOC},
 	{"supplementary_debug_file_kind",
 	 (getter)Module_get_supplementary_debug_file_kind, NULL,

--- a/libdrgn/stack_trace.c
+++ b/libdrgn/stack_trace.c
@@ -1205,14 +1205,14 @@ static struct drgn_error *drgn_get_stack_trace(struct drgn_program *prog,
 		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
 					 "cannot unwind stack without platform");
 	}
-	if (drgn_program_is_userspace_process(prog)) {
-		return drgn_error_create(DRGN_ERROR_NOT_IMPLEMENTED,
-					 "stack unwinding is not yet supported for live processes");
-	} else if (!(prog->flags & DRGN_PROGRAM_IS_LINUX_KERNEL)
-		   && !drgn_program_is_userspace_core(prog)) {
-		return drgn_error_create(DRGN_ERROR_NOT_IMPLEMENTED,
-					 "stack unwinding is not supported for this program");
-	}
+	//if (drgn_program_is_userspace_process(prog)) {
+	//	return drgn_error_create(DRGN_ERROR_NOT_IMPLEMENTED,
+	//				 "stack unwinding is not yet supported for live processes");
+	//} else if (!(prog->flags & DRGN_PROGRAM_IS_LINUX_KERNEL)
+	//	   && !drgn_program_is_userspace_core(prog)) {
+	//	return drgn_error_create(DRGN_ERROR_NOT_IMPLEMENTED,
+	//				 "stack unwinding is not supported for this program");
+	//}
 
 	size_t trace_capacity = 1;
 	struct drgn_stack_trace *trace =


### PR DESCRIPTION
This has always been a bit of a far-off idea, but with the module API it's working, some of the time (definitely not all of the time). So I thought I'd share it to see if some of the tweaks necessary to make it happen would be reasonable.

Basically, there's a GDB script called `pstack` that attaches GDB and takes a stack trace of a program. You can also use `/proc/$PID/stack` to get the kernel stack (assuming it's running in kernel mode or blocked). I was hoping to come up with a way to replicate that behavior in drgn, in a way that would work against `/proc/kcore` or `/proc/vmcore`. Essentially, it would allow you to get userspace stack traces from the crashed kernel (but not necessarily the whole core dump, like `contrib/gcore.py`) in the kdump kernel just before or after dumping the vmcore. (Presumably, userspace pages are filtered for 99.9% of all kdump configurations, so you'd need to run this while `/proc/kcore` is still available).

The main part of this requires creating a custom program that has a memory reader, as well as specifying all the required Modules, their biases, and their address ranges. From there, you can get the userspace `struct pt_regs` from the kernel program, copy it to the user program, and then unwind the stack.

To do this, I've needed to tweak drgn a bit:

1. Python memory readers may return FaultError, but the resulting `drgn_error` has the wrong error code. So I added a special-case to pass through fault-errors back to the drgn error. This could be made more general, but I don't actually think it would be good to do that generally.
2. I made loaded & debug file biases writable, so that I could update the biases.
3. I included a crude patch to support `.gnu_debugdata` which is helpful for my use case.
4. I needed to rip out the compatibility checks for stack tracing, because otherwise drgn would fail saying that stack tracing is not supported for this program.

At the end of the day, I'm quite confident that none of this is ready for merge, but I did wonder if any of the individual changes make sense to include? 

For fun, here's the result of running the `contrib/pstack.py` script against the current bash process:
```
$ python -m drgn -q --kernel-dir ~/vmlinux_repo/$(uname -r) -k contrib/pstack.py $$
#0  context_switch (kernel/sched/core.c:5328:2)
#1  __schedule (kernel/sched/core.c:6693:8)
#2  __schedule_loop (kernel/sched/core.c:6770:3)
#3  schedule (kernel/sched/core.c:6785:2)
#4  do_wait (kernel/exit.c:1697:3)
#5  kernel_wait4 (kernel/exit.c:1851:8)
#6  __do_sys_wait4 (kernel/exit.c:1879:13)
#7  do_syscall_x64 (arch/x86/entry/common.c:52:14)
#8  do_syscall_64 (arch/x86/entry/common.c:89:7)
#9  entry_SYSCALL_64+0xaf/0x14c (arch/x86/entry/entry_64.S:121)
#10 0x7ff5ba4d8b7a
------ userspace ---------
#0  wait4+0x1a/0xab
#1  waitchld.constprop.0+0xbb/0xa5f
#2  wait_for+0x4ca/0xc0e
#3  execute_command_internal+0x2768/0x2ef6
#4  execute_command+0xc8/0x1b8
#5  reader_loop+0x289/0x3d9
#6  main+0x15be/0x198b
#7  __libc_start_call_main+0x80/0xac
#8  __libc_start_main@@GLIBC_2.34+0x80/0x148
#9  _start+0x25/0x26
#10 ???
```