### PR TITLE
Fix exception handling in `for_each_child_dentry`

### DIFF
--- a/contrib/negdentdelete.py
+++ b/contrib/negdentdelete.py
@@ -37,7 +37,7 @@ def for_each_child_dentry(dentry: Object) -> Iterator[Object]:
             dentry.d_children.address_of_(),
             "d_sib",
         )
-    except LookupError:
+    except AttributeError:
         return list_for_each_entry(
             "struct dentry", dentry.d_subdirs.address_of_(), "d_child"
         )


### PR DESCRIPTION
Accessing `dentry.d_children` fails before the lookup of `d_sib` on `struct dentry`.

```txt
  File "negdentdelete.py", line 119, in main
    for batch in yield_negative_dentries(prog, directory, args.chunk_size):
                 ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "negdentdelete.py", line 52, in yield_negative_dentries
    for child in for_each_child_dentry(parent):
                 ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "negdentdelete.py", line 37, in for_each_child_dentry
    dentry.d_children.address_of_(),
    ^^^^^^^^^^^^^^^^^
AttributeError: 'struct dentry' has no member 'd_children'. Did you mean: 'd_child'?
```