### PR TITLE
Add a "-e" option to execute code provided as a command-line argument

### DIFF
--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -387,6 +387,12 @@ def _main() -> None:
         help="don't print any logs or download progress",
     )
     parser.add_argument(
+        "-e",
+        dest="exec",
+        metavar="CODE",
+        help="an expression or statement to evaluate, instead of running in interactive mode",
+    )
+    parser.add_argument(
         "script",
         metavar="ARG",
         type=str,
@@ -397,7 +403,7 @@ def _main() -> None:
 
     args = parser.parse_args()
 
-    if args.script:
+    if args.script and not args.exec:
         # A common mistake users make is running drgn $core_dump, which tries
         # to run $core_dump as a Python script. Rather than failing later with
         # some inscrutable syntax or encoding error, try to catch this early
@@ -413,7 +419,7 @@ def _main() -> None:
             )
         elif script_type == "elf":
             sys.exit(f"error: {args.script[0]} is a binary, not a drgn script")
-    else:
+    elif not args.exec:
         print(version, file=sys.stderr, flush=True)
 
     if args.log_level == "none":
@@ -496,7 +502,11 @@ def _main() -> None:
             if new:
                 module.try_file(extra_symbol_path)
 
-    if args.script:
+    if args.exec:
+        sys.path.insert(0, "")
+        sys.argv = ["-e"] + args.script
+        exec(args.exec, default_globals(prog))
+    elif args.script:
         sys.argv = args.script
         script = args.script[0]
         if pkgutil.get_importer(script) is None:


### PR DESCRIPTION
For example:
```
$ python -m drgn -qp0 -e 'print_annotated_memory(prog, id(prog), 256)'
ADDRESS           VALUE
000055cf0b4c4bd0: 0000000000000006
000055cf0b4c4bd8: 00007fa1ae3fbd80 [object symbol: Program_type+0x0]
000055cf0b4c4be0: 000055cf0b4b3780
000055cf0b4c4be8: 0000000000000000
000055cf0b4c4bf0: 000055cf0b4ba560
000055cf0b4c4bf8: 0000000000000000
000055cf0b4c4c00: 0007643700000003
000055cf0b4c4c08: 0000000000000000
000055cf0b4c4c10: 000055cf0b4c4d78
000055cf0b4c4c18: 0000000000000001
000055cf0b4c4c20: 000055cf0b4c4be0
000055cf0b4c4c28: 00007fa1ae3f6400 [object symbol: drgn_language_c+0x0]
000055cf0b4c4c30: 0000000000000000
000055cf0b4c4c38: 0000000000000000
000055cf0b4c4c40: 0000000000000000
000055cf0b4c4c48: 0000000000000001
000055cf0b4c4c50: 000055cf0b4c4be0
000055cf0b4c4c58: 00007fa1ae3f6320 [object symbol: drgn_language_cpp+0x0]
000055cf0b4c4c60: 0000000000000000
000055cf0b4c4c68: 0000000000000000
000055cf0b4c4c70: 0000000000000000
000055cf0b4c4c78: 0000000000000000
000055cf0b4c4c80: 0000000000000000
000055cf0b4c4c88: 0000000000000000
000055cf0b4c4c90: 0000000000000000
000055cf0b4c4c98: 0000000000000000
000055cf0b4c4ca0: 0000000000000000
000055cf0b4c4ca8: 0000000000000000
000055cf0b4c4cb0: 0000000000000000
000055cf0b4c4cb8: 0000000000000000
000055cf0b4c4cc0: 0000000000000000
000055cf0b4c4cc8: 0000000000000000
```

The sys.path has the current working directory added, just like the default CLI. This is unnecessary if you run drgn by `python -m drgn` which I normally do, but for most distro installs, drgn is a script and so the current working directory must be added manually.