### PR TITLE
Handle truncated pr_fname

### DIFF
--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -153,7 +153,7 @@ struct drgn_program {
 		 */
 		struct {
 			/** Cached `pr_fname` from `NT_PRPSINFO` note. */
-			const char *core_dump_fname_cached;
+			char *core_dump_fname_cached;
 			/** Cache of important parts of auxiliary vector. */
 			struct {
 				uint64_t at_phdr;


### PR DESCRIPTION
It appears that some core dumps may have a "pr_fname" which isn't nul-terminated, which leads to the following exception, even if you're not interested in the thread name:

```
>>> next(prog.threads()).stack_trace()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
Exception: pr_fname is not null terminated
```

Handle this by creating a copy and nul-terminating it.

Closes: #483
Fixes: e6cc9b07 ("Add name to drgn.Thread")