### PR TITLE
Fix CLI failure on Python < 3.10 and add smoke test

### DIFF
--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -190,24 +190,24 @@ def _displayhook(value: Any) -> None:
     setattr(builtins, "_", value)
 
 
+def _bool_options(value: bool) -> Dict[str, Tuple[str, bool]]:
+    return {
+        option: ("try_" + option.replace("-", "_"), value)
+        for option in (
+            "module-name",
+            "build-id",
+            "debug-link",
+            "procfs",
+            "embedded-vdso",
+            "reuse",
+            "supplementary",
+        )
+    }
+
+
 class _TrySymbolsByBaseAction(argparse.Action):
     _enable: bool
     _finder = ("disable_debug_info_finders", "enable_debug_info_finders")
-
-    @staticmethod
-    def _bool_options(value: bool) -> Dict[str, Tuple[str, bool]]:
-        return {
-            option: ("try_" + option.replace("-", "_"), value)
-            for option in (
-                "module-name",
-                "build-id",
-                "debug-link",
-                "procfs",
-                "embedded-vdso",
-                "reuse",
-                "supplementary",
-            )
-        }
 
     _options = (
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025, Oracle and/or its affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+
+import subprocess
+import sys
+
+from tests import TestCase
+
+
+class TestCli(TestCase):
+
+    def run_cli(self, *args: str):
+        try:
+            return subprocess.run(
+                [sys.executable, "-m", "drgn"] + list(args),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            # With captured output, there's nothing left to debug in CI logs.
+            # Print output on a failure so we can debug.
+            print(f"STDOUT:\n{e.stdout.decode()}")
+            print(f"STDERR:\n{e.stderr.decode()}")
+            raise
+
+    def test_smoke(self):
+        proc = self.run_cli(
+            "--quiet", "--pid", "0", "--no-default-symbols", "-e", "print('pass')"
+        )
+        self.assertEqual(proc.stdout, b"pass\n")


### PR DESCRIPTION
Looks like the CLI broke on Python < 3.10 with 4a6a9f33.

```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/stepbren/repos/drgn/drgn/__main__.py", line 14, in <module>
    from drgn.cli import _main
  File "/home/stepbren/repos/drgn/drgn/cli.py", line 193, in <module>
    class _TrySymbolsByBaseAction(argparse.Action):
  File "/home/stepbren/repos/drgn/drgn/cli.py", line 214, in _TrySymbolsByBaseAction
    **_bool_options(False),
TypeError: 'staticmethod' object is not callable
```

The fix is straightforward (though if you prefer a different way that's fine). I went ahead and added a smoke test that just runs the CLI in the simplest possible way. I verified it failed on 3.9. Then I added the fix.

The CLI is fun because we don't have any test coverage, which is fine because it's easy to manually test, but we don't get the variety of Python versions when we manually test.