### PR TITLE
cli: fix default program for -e and handle !isatty(stdin)

### DIFF
--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -573,6 +573,7 @@ def _main() -> None:
     if args.exec:
         sys.path.insert(0, "")
         sys.argv = ["-e"] + args.script
+        drgn.set_default_prog(prog)
         exec(args.exec, default_globals(prog))
     elif args.script:
         sys.argv = args.script

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,19 +4,21 @@
 
 import subprocess
 import sys
+import tempfile
 
 from tests import TestCase
 
 
 class TestCli(TestCase):
 
-    def run_cli(self, *args: str):
+    def run_cli(self, *args: str, **kwargs):
         try:
             return subprocess.run(
                 [sys.executable, "-m", "drgn"] + list(args),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=True,
+                **kwargs,
             )
         except subprocess.CalledProcessError as e:
             # With captured output, there's nothing left to debug in CI logs.
@@ -25,8 +27,57 @@ class TestCli(TestCase):
             print(f"STDERR:\n{e.stderr.decode()}")
             raise
 
-    def test_smoke(self):
+    def test_e(self):
+        script = r"""
+import sys
+
+assert drgn.get_default_prog() is prog
+assert __name__ == "__main__"
+assert "__file__" not in globals()
+assert sys.path[0] == ""
+print(sys.argv)
+"""
         proc = self.run_cli(
-            "--quiet", "--pid", "0", "--no-default-symbols", "-e", "print('pass')"
+            "--quiet", "--pid", "0", "--no-default-symbols", "-e", script, "pass"
         )
-        self.assertEqual(proc.stdout, b"pass\n")
+        self.assertEqual(proc.stdout, b"['-e', 'pass']\n")
+
+    def test_script(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(
+                rb"""
+assert "drgn" not in globals()
+
+import drgn
+import os.path
+import sys
+
+assert drgn.get_default_prog() is prog
+assert __name__ == "__main__"
+assert __file__ == sys.argv[0]
+assert sys.path[0] == os.path.dirname(__file__)
+print(sys.argv)
+"""
+            )
+            f.flush()
+            proc = self.run_cli(
+                "--quiet", "--pid", "0", "--no-default-symbols", f.name, "pass"
+            )
+            self.assertEqual(proc.stdout, f"[{f.name!r}, 'pass']\n".encode())
+
+    def test_pipe(self):
+        script = rb"""
+import sys
+
+assert drgn.get_default_prog() is prog
+assert __name__ == "__main__"
+assert __file__ == "<stdin>"
+assert sys.path[0] == ""
+# Dummy if statement to test handling of multi-line blocks.
+if True:
+    print(sys.argv)
+"""
+        proc = self.run_cli(
+            "--quiet", "--pid", "0", "--no-default-symbols", input=script
+        )
+        self.assertEqual(proc.stdout, b"['']\n")


### PR DESCRIPTION
One fix for `-e`, plus a fix for issues with piping into drgn that a couple of people have reported recently (and a small cleanup).