### PR TITLE
drgn.helpers.linux.fs: skip cursors in for_each_mount()

### DIFF
--- a/drgn/helpers/linux/fs.py
+++ b/drgn/helpers/linux/fs.py
@@ -374,7 +374,8 @@ def for_each_mount(
         )
     for mnt in mounts:
         if (
-            (src is None or mount_src(mnt) == src)
+            mnt.mnt.mnt_sb  # skip cursors (v5.8 - v6.8)
+            and (src is None or mount_src(mnt) == src)
             and (dst is None or mount_dst(mnt) == dst)
             and (fstype is None or mount_fstype(mnt) == fstype)
         ):


### PR DESCRIPTION
Details are in the commit message. I'm open to a more robust method of detecting cursors, but this did the job and was simple enough.

A follow up for this is to see if I can convert the mount flags to an enum. They are currently held in an `int` so it seems reasonable, but there's only space for 4 more bits. C23 cannot come fast enough for the Linux kernel 🚀 