### PR TITLE
libdrgn: python: fix reference leak for held types

### DIFF
--- a/libdrgn/python/object.c
+++ b/libdrgn/python/object.c
@@ -1635,6 +1635,12 @@ static PyMappingMethods DrgnObject_as_mapping = {
 	.mp_subscript = (binaryfunc)DrgnObject_subscript,
 };
 
+static int DrgnObject_traverse(DrgnObject *self, visitproc visit, void *arg)
+{
+	Py_VISIT(DrgnObject_prog(self));
+	return 0;
+}
+
 PyTypeObject DrgnObject_type = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	.tp_name = "_drgn.Object",
@@ -1645,7 +1651,8 @@ PyTypeObject DrgnObject_type = {
 	.tp_as_mapping = &DrgnObject_as_mapping,
 	.tp_str = (reprfunc)DrgnObject_str,
 	.tp_getattro = (getattrofunc)DrgnObject_getattro,
-	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse = (traverseproc)DrgnObject_traverse,
 	.tp_doc = drgn_Object_DOC,
 	.tp_richcompare = DrgnObject_richcompare,
 	.tp_iter = (getiterfunc)DrgnObject_iter,

--- a/libdrgn/python/type.c
+++ b/libdrgn/python/type.c
@@ -809,6 +809,12 @@ static PyMemberDef TypeEnumerator_members[] = {
 	{},
 };
 
+static int LazyObject_traverse(LazyObject *self, visitproc visit, void *arg)
+{
+	Py_VISIT(self->obj);
+	return 0;
+}
+
 PyTypeObject TypeEnumerator_type = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	.tp_name = "_drgn.TypeEnumerator",
@@ -816,7 +822,8 @@ PyTypeObject TypeEnumerator_type = {
 	.tp_dealloc = (destructor)TypeEnumerator_dealloc,
 	.tp_repr = (reprfunc)TypeEnumerator_repr,
 	.tp_as_sequence = &TypeEnumerator_as_sequence,
-	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse = (traverseproc)LazyObject_traverse,
 	.tp_doc = drgn_TypeEnumerator_DOC,
 	.tp_richcompare = (richcmpfunc)TypeEnumerator_richcompare,
 	.tp_members = TypeEnumerator_members,
@@ -1099,7 +1106,8 @@ PyTypeObject TypeMember_type = {
 	.tp_basicsize = sizeof(TypeMember),
 	.tp_dealloc = (destructor)TypeMember_dealloc,
 	.tp_repr = (reprfunc)TypeMember_repr,
-	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse = (traverseproc)LazyObject_traverse,
 	.tp_doc = drgn_TypeMember_DOC,
 	.tp_members = TypeMember_members,
 	.tp_getset = TypeMember_getset,
@@ -1182,7 +1190,8 @@ PyTypeObject TypeParameter_type = {
 	.tp_basicsize = sizeof(TypeParameter),
 	.tp_dealloc = (destructor)TypeParameter_dealloc,
 	.tp_repr = (reprfunc)TypeParameter_repr,
-	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse = (traverseproc)LazyObject_traverse,
 	.tp_doc = drgn_TypeParameter_DOC,
 	.tp_members = TypeParameter_members,
 	.tp_getset = TypeParameter_getset,
@@ -1288,7 +1297,8 @@ PyTypeObject TypeTemplateParameter_type = {
 	.tp_basicsize = sizeof(TypeTemplateParameter),
 	.tp_dealloc = (destructor)TypeTemplateParameter_dealloc,
 	.tp_repr = (reprfunc)TypeTemplateParameter_repr,
-	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+	.tp_traverse = (traverseproc)LazyObject_traverse,
 	.tp_doc = drgn_TypeTemplateParameter_DOC,
 	.tp_members = TypeTemplateParameter_members,
 	.tp_getset = TypeTemplateParameter_getset,


### PR DESCRIPTION
Python "LazyObjects" (e.g. TypeMember) contain a callable or an object, either of which may contain a reference to the Program. When cached on the program, these references form a cycle. Add tp_traverse methods to help detect these cycles and avoid resource leakages.