### PR TITLE
Administrative followups for .gnu_debugdata support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,13 +162,13 @@ First, install dependencies:
 
   .. code-block:: console
 
-      $ sudo dnf install autoconf automake check-devel elfutils-debuginfod-client-devel elfutils-devel gcc git libkdumpfile-devel libtool make pkgconf python3 python3-devel python3-pip python3-setuptools
+      $ sudo dnf install autoconf automake check-devel elfutils-debuginfod-client-devel elfutils-devel gcc git libkdumpfile-devel libtool make pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
 
 * RHEL/CentOS < 9, Oracle Linux
 
   .. code-block:: console
 
-      $ sudo dnf install autoconf automake check-devel elfutils-devel gcc git libtool make pkgconf python3 python3-devel python3-pip python3-setuptools
+      $ sudo dnf install autoconf automake check-devel elfutils-devel gcc git libtool make pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
 
   Optionally, install ``libkdumpfile-devel`` from EPEL on RHEL/CentOS >= 8 or
   install `libkdumpfile <https://github.com/ptesarik/libkdumpfile>`_ from
@@ -197,19 +197,19 @@ First, install dependencies:
 
   .. code-block:: console
 
-      $ sudo pacman -S --needed autoconf automake check gcc git libelf libkdumpfile libtool make pkgconf python python-pip python-setuptools
+      $ sudo pacman -S --needed autoconf automake check gcc git libelf libkdumpfile libtool make pkgconf python python-pip python-setuptools xz
 
 * Gentoo
 
   .. code-block:: console
 
-      $ sudo emerge --noreplace --oneshot dev-build/autoconf dev-build/automake dev-libs/check dev-libs/elfutils sys-devel/gcc dev-vcs/git dev-libs/libkdumpfile dev-build/libtool dev-build/make dev-python/pip virtual/pkgconfig dev-lang/python dev-python/setuptools
+      $ sudo emerge --noreplace --oneshot dev-build/autoconf dev-build/automake dev-libs/check dev-libs/elfutils sys-devel/gcc dev-vcs/git dev-libs/libkdumpfile dev-build/libtool dev-build/make dev-python/pip virtual/pkgconfig dev-lang/python dev-python/setuptools app-arch/xz-utils
 
 * openSUSE
 
   .. code-block:: console
 
-      $ sudo zypper install autoconf automake check-devel gcc git libdebuginfod-devel libdw-devel libelf-devel libkdumpfile-devel libtool make pkgconf python3 python3-devel python3-pip python3-setuptools
+      $ sudo zypper install autoconf automake check-devel gcc git libdebuginfod-devel libdw-devel libelf-devel libkdumpfile-devel libtool make pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
 
 Then, run:
 

--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -3677,6 +3677,7 @@ _elfutils_version: str
 _have_debuginfod: bool
 _enable_dlopen_debuginfod: bool
 _with_libkdumpfile: bool
+_with_lzma: bool
 
 def _linux_helper_direct_mapping_offset(__prog: Program) -> int: ...
 def _linux_helper_read_vm(

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,6 +16,9 @@ It optionally depends on:
 - `libkdumpfile <https://github.com/ptesarik/libkdumpfile>`_ for `makedumpfile
   <https://github.com/makedumpfile/makedumpfile>`_ compressed kernel core dump
   format support
+- `liblzma <https://tukaani.org/xz/>`_ for `MiniDebuginfo
+  <https://sourceware.org/gdb/current/onlinedocs/gdb.html/MiniDebugInfo.html>`_
+  support
 
 The build requires:
 

--- a/drgn/__init__.py
+++ b/drgn/__init__.py
@@ -115,6 +115,7 @@ from _drgn import (  # noqa: F401
     _enable_dlopen_debuginfod as _enable_dlopen_debuginfod,
     _have_debuginfod as _have_debuginfod,
     _with_libkdumpfile as _with_libkdumpfile,
+    _with_lzma as _with_lzma,
 )
 from drgn.internal.version import __version__ as __version__  # noqa: F401
 

--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -114,7 +114,8 @@ def version_header() -> str:
     if drgn._enable_dlopen_debuginfod:
         debuginfod += " (dlopen)"
     libkdumpfile = f'with{"" if drgn._with_libkdumpfile else "out"} libkdumpfile'
-    return f"drgn {drgn.__version__} (using Python {python_version}, elfutils {drgn._elfutils_version}, {debuginfod}, {libkdumpfile})"
+    lzma = f'with{"" if drgn._with_lzma else "out"} lzma'
+    return f"drgn {drgn.__version__} (using Python {python_version}, elfutils {drgn._elfutils_version}, {debuginfod}, {libkdumpfile}, {lzma})"
 
 
 def default_globals(prog: drgn.Program) -> Dict[str, Any]:

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -117,17 +117,17 @@ AS_CASE(["x$with_libkdumpfile"],
 AM_CONDITIONAL([WITH_LIBKDUMPFILE], [test "x$with_libkdumpfile" = xyes])
 AM_COND_IF([WITH_LIBKDUMPFILE], [AC_DEFINE(WITH_LIBKDUMPFILE)])
 
-AC_ARG_WITH([liblzma],
-	    [AS_HELP_STRING([--with-liblzma],
+AC_ARG_WITH([lzma],
+	    [AS_HELP_STRING([--with-lzma],
 			    [build with support for lzma decompression of ELF sections
 			     @<:@default=auto@:>@])],
-			     [], [with_liblzma=auto])
-AS_CASE(["x$with_liblzma"],
+			     [], [with_lzma=auto])
+AS_CASE(["x$with_lzma"],
 	[xyes], [PKG_CHECK_MODULES(lzma, [liblzma])],
 	[xauto], [PKG_CHECK_MODULES(lzma, [liblzma],
-				    [with_liblzma=yes],
-				    [with_liblzma=no])])
-AM_CONDITIONAL([WITH_LZMA], [test "x$with_liblzma" != xno])
+				    [with_lzma=yes],
+				    [with_lzma=no])])
+AM_CONDITIONAL([WITH_LZMA], [test "x$with_lzma" != xno])
 AM_COND_IF([WITH_LZMA], [AC_DEFINE(WITH_LZMA)])
 
 dnl We need check for running tests, but we don't want to fail the build over

--- a/libdrgn/python/main.c
+++ b/libdrgn/python/main.c
@@ -23,6 +23,16 @@ static int add_type(PyObject *module, PyTypeObject *type)
 	return ret;
 }
 
+static int add_bool(PyObject *module, const char *name, bool value)
+{
+	PyObject *obj = value ? Py_True : Py_False;
+	Py_INCREF(obj);
+	int ret = PyModule_AddObject(module, name, obj);
+	if (ret)
+		Py_DECREF(obj);
+	return ret;
+}
+
 PyObject *MissingDebugInfoError;
 static PyObject *NoDefaultProgramError;
 PyObject *ObjectAbsentError;
@@ -344,36 +354,26 @@ DRGNPY_PUBLIC PyMODINIT_FUNC PyInit__drgn(void)
 				       dwfl_version(NULL)))
 		goto err;
 
-	PyObject *have_debuginfod = PyBool_FromLong(drgn_have_debuginfod());
-	if (PyModule_AddObject(m, "_have_debuginfod", have_debuginfod)) {
-		Py_XDECREF(have_debuginfod);
+	if (add_bool(m, "_have_debuginfod", drgn_have_debuginfod()))
 		goto err;
-	}
 
-	PyObject *enable_dlopen_debuginfod;
+	if (add_bool(m, "_enable_dlopen_debuginfod",
 #if ENABLE_DLOPEN_DEBUGINFOD
-	enable_dlopen_debuginfod = Py_True;
+		     true
 #else
-	enable_dlopen_debuginfod = Py_False;
+		     false
 #endif
-	Py_INCREF(enable_dlopen_debuginfod);
-	if (PyModule_AddObject(m, "_enable_dlopen_debuginfod",
-			       enable_dlopen_debuginfod)) {
-		Py_DECREF(enable_dlopen_debuginfod);
+		    ))
 		goto err;
-	}
 
-	PyObject *with_libkdumpfile;
+	if (add_bool(m, "_with_libkdumpfile",
 #ifdef WITH_LIBKDUMPFILE
-	with_libkdumpfile = Py_True;
+		     true
 #else
-	with_libkdumpfile = Py_False;
+		     false
 #endif
-	Py_INCREF(with_libkdumpfile);
-	if (PyModule_AddObject(m, "_with_libkdumpfile", with_libkdumpfile)) {
-		Py_DECREF(with_libkdumpfile);
+		    ))
 		goto err;
-	}
 
 	return m;
 

--- a/libdrgn/python/main.c
+++ b/libdrgn/python/main.c
@@ -375,6 +375,15 @@ DRGNPY_PUBLIC PyMODINIT_FUNC PyInit__drgn(void)
 		    ))
 		goto err;
 
+	if (add_bool(m, "_with_lzma",
+#ifdef WITH_LZMA
+		     true
+#else
+		     false
+#endif
+		    ))
+		goto err;
+
 	return m;
 
 err:

--- a/scripts/build_manylinux_in_docker.sh
+++ b/scripts/build_manylinux_in_docker.sh
@@ -81,7 +81,7 @@ build_for_python() {
 
 for pybin in /opt/python/cp*/bin; do
 	if build_for_python "$pybin/python"; then
-		CONFIGURE_FLAGS="--with-debuginfod --disable-dlopen-debuginfod --with-libkdumpfile" \
+		CONFIGURE_FLAGS="--with-debuginfod --disable-dlopen-debuginfod --with-libkdumpfile --with-lzma" \
 			"$pybin/pip" wheel . --no-deps -w /tmp/wheels/
 	fi
 done

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -4,8 +4,10 @@
 import itertools
 import lzma
 import tempfile
+import unittest
 
 from _drgn_util.elf import ET, PT, SHF, SHT, STB, STT
+import drgn
 from drgn import Program, Symbol, SymbolBinding, SymbolIndex, SymbolKind
 from tests import TestCase
 from tests.dwarfwriter import create_dwarf_file
@@ -566,6 +568,7 @@ class TestElfSymbol(TestCase):
         self.assertEqual(prog.symbol(0xFFFF0004), full)
 
 
+@unittest.skipUnless(drgn._with_lzma, "built without lzma support")
 class TestGnuDebugdata(TestCase):
 
     def assert_all_symbols_found_by_name(self, prog, symbols):

--- a/vmtest/rootfsbuild.py
+++ b/vmtest/rootfsbuild.py
@@ -28,6 +28,7 @@ _ROOTFS_PACKAGES = [
     "libdw-dev",
     "libelf-dev",
     "libkdumpfile-dev",
+    "liblzma-dev",
     "libtool",
     "make",
     "pkgconf",


### PR DESCRIPTION
A few minor followups:

* Document the new liblzma dependency.
* Install/enable it for vmtest and manylinux.
* Add it to the CLI version string.
* Skip the tests if not built with support.

@brenns10, mind skimming these?