### PR TITLE
add new script for stack trace and local variables

### DIFF
--- a/contrib/bt_by_pid_and_frame.py
+++ b/contrib/bt_by_pid_and_frame.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env drgn
+# Copyright (c) 2025, Kylin Software, Inc. and affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import sys
+import argparse
+from drgn.helpers.linux import find_task
+from drgn import stack_trace
+
+def main():
+    parser = argparse.ArgumentParser(description="Show stack trace and optionally local variables of a specific frame")
+    parser.add_argument("pid", type=int, help="Target process PID")
+    parser.add_argument("frameid", type=int, nargs="?", help="Stack frame index (optional)")
+    args = parser.parse_args()
+
+    task = find_task(args.pid)
+    print(f"PID {args.pid} process name: {task.comm.string_().decode(errors='replace')}")
+    trace = stack_trace(task)
+    print(trace)
+    if args.frameid is not None:
+        frame = trace[int(args.frameid)]
+        print(frame)
+        locals_ = frame.locals()
+        print(locals_)
+        for var in locals_:
+            try:
+                value = frame[var]
+                print(f"{var}: {value}")
+            except KeyError:
+                print(f"{var}: Not found")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Print process name for given pid and show stack trace with optional frame local variables.

example: 
./bt_by_pid_and_frame.py 1 1
```
`PID 1 process name: systemd
#0  context_switch (kernel/sched/core.c:5313:2)
#1  __schedule (kernel/sched/core.c:6696:8)
#2  __schedule_loop (kernel/sched/core.c:6774:3)
#3  schedule (kernel/sched/core.c:6789:2)
#4  schedule_hrtimeout_range_clock (kernel/time/sleep_timeout.c:207:3)
#5  ep_poll (fs/eventpoll.c:2116:6)
#6  do_epoll_wait (fs/eventpoll.c:2532:9)
#7  __do_sys_epoll_wait (fs/eventpoll.c:2540:9)
#8  __se_sys_epoll_wait (fs/eventpoll.c:2535:1)
#9  __x64_sys_epoll_wait (fs/eventpoll.c:2535:1)
#10 do_syscall_x64 (arch/x86/entry/syscall_64.c:63:14)
#11 do_syscall_64 (arch/x86/entry/syscall_64.c:94:7)
#12 entry_SYSCALL_64+0xaf/0x14c (arch/x86/entry/entry_64.S:121)
#13 0x7f1913b2aaa7
#1 at 0xffffffffb4861b24 (__schedule+0x2c4/0x6b0) in __schedule at kernel/sched/core.c:6696:8
['sched_mode', 'prev', 'next', 'preempt', 'is_switch', 'switch_count', 'prev_state', 'rf', 'rq', 'cpu']
sched_mode: (int)0
prev: *(struct task_struct *)0xffff8b6500b80000 = {
        .thread_info = (struct thread_info){
                .flags = (unsigned long)16386,
                .syscall_work = (unsigned long)0,
                .status = (u32)0,
                .cpu = (u32)2,
...`
```