### PR TITLE
format thread_info value as hex in sys.py

### DIFF
--- a/drgn/commands/_builtin/crash/sys.py
+++ b/drgn/commands/_builtin/crash/sys.py
@@ -276,7 +276,7 @@ from drgn.helpers.linux.sched import task_thread_info
 
 thread_info = task_thread_info(task)
 """
-        return f"{self.task.value_():x}  [THREAD_INFO: {task_thread_info(self.task).value_()}]"
+        return f"{self.task.value_():x}  [THREAD_INFO: {task_thread_info(self.task).value_():x}]"
 
     def _get_cpu(self) -> str:
         if self.drgn:


### PR DESCRIPTION
Make the thread_info address output consistent with the task address output by formatting it as hexadecimal (using :x) in the string representation.
```

TASK: ffff8a7c9c5cb500  [THREAD_INFO: 18446614866536740096] 
->
TASK: ffff8a7cf10e3500  [THREAD_INFO: ffff8a7cf10e3500]
```