### PR TITLE
Add helpers to detect & parse stack traces in the kernel log

### DIFF
--- a/contrib/logged_stack_traces.py
+++ b/contrib/logged_stack_traces.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Print all logged stack traces"""
+from drgn.helpers.linux.printk import for_each_dmesg_stack_trace
+
+
+for trace in for_each_dmesg_stack_trace(prog):
+    print("[% 5d.%06d] CPU: %r PID: %r" % (
+        trace.timestamp // 1000000000,
+        trace.timestamp % 1000000000 // 1000,
+        trace.cpu,
+        trace.pid
+    ))
+    print(trace.stack_trace)
+    print()


### PR DESCRIPTION
From the commit message:

> Add helpers to detect stack traces in kernel logs, and convert them to drgn stack traces. Since drgn typically has DWARF debuginfo available, it can provide filenames, line numbers, and inline function frames, which make it much easier to use the logged stack traces.
> 
> The helper is currently only tested on x86_64. It's quite easy to play around with by something like the following:
> 
>     sudo sh -c 'echo l>/proc/sysrq-trigger'
>     sudo drgn contrib/logged_stack_traces.py

I recently was working on a bug and realized that the logged stack traces were not nearly as useful as drgn's. So I cobbled the first version of this together which takes advantage of `Program.stack_trace_from_pcs()`. I'd like to get it working on all the officially supported drgn architectures, which is why I'm filing this as a draft for now. But I'd appreciate any feedback at this stage.