### PR TITLE
commands: builtin: add py command

### DIFF
--- a/drgn/commands/_builtin/__init__.py
+++ b/drgn/commands/_builtin/__init__.py
@@ -9,11 +9,14 @@ into drgn should be defined in this package.
 import argparse
 import importlib
 import pkgutil
+import re
 import subprocess
+import sys
+import traceback
 from typing import Any, Dict
 
 from drgn import Program, execscript
-from drgn.commands import argument, command, custom_command
+from drgn.commands import _shell_command, argument, command, custom_command
 
 # Import all submodules, recursively.
 for _module_info in pkgutil.walk_packages(__path__, __name__ + "."):
@@ -35,6 +38,82 @@ def _cmd_sh(prog: Program, name: str, args: str, **kwargs: Any) -> int:
         return subprocess.call(["sh", "-c", "--", args])
     else:
         return subprocess.call(["sh", "-i"])
+
+
+@custom_command(
+    description="execute a python statement and allow shell redirection",
+    usage="**py** [*command*]",
+    long_description="""
+    Execute the given code, up to the first shell redirection or pipeline
+    statement, as Python code.
+
+    For each occurrence of a pipeline operator (``|``) or any redirection
+    operator (``<``, ``>``, ``<<``, ``>>``), attempt to parse the preceding text
+    as Python code. If the preceding text is syntactically valid code, then
+    interpret the remainder of the command as shell redirections or pipelines,
+    and execute the Python code with those redirections and pipelines applied.
+
+    The operators above can be used in syntactically valid Python. This means
+    you need to be careful when using this function, and ensure that you wrap
+    their uses with parentheses.
+
+    For example, consider the command: ``%py field | MY_FLAG | grep foo``. While
+    the intent here may be to execute the Python code ``field | MY_FLAG`` and
+    pass its result to ``grep``, that is not what will happen. The portion of
+    text prior to the first ``|`` is valid Python, so it will be executed, and
+    its output piped to the shell pipeline ``MY_FLAG | grep foo``. Instead,
+    running ``%py (field | MY_FLAG) | grep foo`` ensures that ``field |
+    MY_FLAG`` gets piped to ``grep foo``, because ``(field`` on its own is not
+    valid Python syntax.
+    """,
+)
+def _cmd_py(
+    prog: Program,
+    name: str,
+    args: str,
+    *,
+    globals: Dict[str, Any],
+    **kwargs: Any,
+) -> None:
+
+    def print_exc() -> None:
+        # When printing a traceback, we should not print our own stack frame, as
+        # that would confuse the user. Unfortunately the traceback objects are
+        # linked lists and there's no functionality to drop the last N frames of
+        # a traceback while printing.
+        _, _, tb = sys.exc_info()
+        count = 0
+        while tb:
+            count += 1
+            tb = tb.tb_next
+        traceback.print_exc(limit=1 - count)
+
+    for match in re.finditer(r"[|<>]", args):
+        try:
+            pos = match.start()
+            code = compile(args[:pos], "<input>", "single")
+            break
+        except SyntaxError:
+            pass
+    else:
+        # Fallback for no match: compile all the code as a "single" statement so
+        # exec() still prints out the result. At this point, a syntax error
+        # should be formatted just like a standard Python exception.
+        try:
+            pos = len(args)
+            code = compile(args, "<input>", "single")
+        except SyntaxError:
+            print_exc()
+            return
+
+    with _shell_command(args[pos:]):
+        try:
+            exec(code, globals)
+        except (Exception, KeyboardInterrupt):
+            # Any exception should be formatted just as the interpreter would.
+            # This includes keyboard interrupts, but not things like
+            # SystemExit or GeneratorExit.
+            print_exc()
 
 
 @command(

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+from drgn.commands import DEFAULT_COMMAND_NAMESPACE
+from tests import TestCase
+
+
+class CommandTestCase(TestCase):
+
+    @staticmethod
+    def run_command(source, **kwargs):
+        return DEFAULT_COMMAND_NAMESPACE.run(None, source, globals={}, **kwargs)

--- a/tests/commands/test_builtin.py
+++ b/tests/commands/test_builtin.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+import contextlib
+import os
+from pathlib import Path
+import tempfile
+
+import drgn.commands._builtin  # noqa: F401
+from tests.commands import CommandTestCase
+
+
+@contextlib.contextmanager
+def temporary_working_directory():
+    old_working_directory = os.getcwd()
+    with tempfile.TemporaryDirectory() as f:
+        try:
+            os.chdir(f)
+            yield f
+        finally:
+            os.chdir(old_working_directory)
+
+
+class RedirectedFile:
+    def __init__(self, f):
+        self.tempfile = f
+        self.value = None
+
+
+@contextlib.contextmanager
+def redirect(stdout=False, stderr=False):
+    # To redirect stdout for commands, we need a real file descriptor, not just
+    # a StringIO
+    with contextlib.ExitStack() as stack:
+        f = stack.enter_context(tempfile.TemporaryFile("w+t"))
+        if stdout:
+            stack.enter_context(contextlib.redirect_stdout(f))
+        if stderr:
+            stack.enter_context(contextlib.redirect_stderr(f))
+        redir = RedirectedFile(f)
+        try:
+            yield redir
+        finally:
+            f.seek(0)
+            redir.value = f.read()
+
+
+class TestPyCommand(CommandTestCase):
+
+    def test_py_redirect(self):
+        with temporary_working_directory() as temp_dir:
+            path = Path(temp_dir) / "6"
+            self.run_command("py var = 5; var > 6")
+            self.assertEqual(path.read_text(), "5\n")
+
+    def test_py_paren_avoid_redirect(self):
+        self.run_command("py var = 5; (var > 6)")
+        with redirect(stdout=True) as f:
+            self.run_command("py var = 5; (var > 6)")
+        self.assertEqual(f.value, "False\n")
+
+    def test_py_pipe(self):
+        with redirect(stdout=True) as f:
+            self.run_command("py echo = 5; 2 | echo + 5")
+        self.assertEqual(f.value, "+ 5\n")
+
+    def test_py_avoid_pipe(self):
+        with redirect(stdout=True) as f:
+            self.run_command("py echo = 5; (2 | (echo + 5))")
+        self.assertEqual(f.value, "10\n")
+
+    def test_py_chooses_first_pipe(self):
+        with redirect(stdout=True) as f:
+            # If the first | is used to separate the Python from the pipeline
+            # (the expected behavior), then we'll get the value 5 written into
+            # the "echo" command, which will ignore that and write "+ 6" through
+            # the cat process to stdout. If the second | is used to separate the
+            # Python from the pipeline, then we'll get "15" written into the cat
+            # process. If none of the | were interpreted as a pipeline operator,
+            # then the statement would output 31.
+            self.run_command("py echo = 5; cat = 16; 5 | echo + 6 | cat")
+        self.assertEqual("+ 6\n", f.value)
+
+    def test_py_traceback_on_syntax_error(self):
+        with redirect(stderr=True) as f:
+            self.run_command("py a +")
+        # SyntaxError does not print the "Traceback" header. Rather than trying
+        # to assert too much about the format of the traceback, just assert that
+        # the incorrect code is shown, as it would be for a traceback.
+        self.assertTrue("a +" in f.value)
+        self.assertTrue("SyntaxError" in f.value)
+
+    def test_py_traceback_on_exception(self):
+        with redirect(stderr=True) as f:
+            self.run_command("py raise Exception('text')")
+        self.assertTrue(f.value.startswith("Traceback"))
+        self.assertTrue("Exception" in f.value)


### PR DESCRIPTION
In #537 it was pointed out that the ability to pipe output produced by executing Python statements would be very useful. Unfortunately the shell redirection operators are part of the Python grammar as well, and there are many cases of ambiguity, where a command could be split into python code and shell pipeline in multiple valid ways.

However, these ambiguities may not be a dealbreaker. We can resolve them by always splitting on the first shell operator which produces a valid Python code on the left hand side. In cases where you want to force a different interpretation, you can wrap your Python code in parentheses. These ensure that any shell operator within the parentheses doesn't introduce a pipeline, because the code prior to them is incomplete without the closing parenthesis.

---

I've also gone ahead and added a few tests inside a new subpackage `tests/commands`, for non-crash command tests. I had a bit of fun coming up with thest cases that were (a) valid python, (b) valid bash, and (c) would produce different results if interpreted as different pipelines.