### PR TITLE
libdrgn: linux kernel: restore THREAD_SIZE object finder

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -394,6 +394,18 @@ core dumps. These special objects include:
 
     This is *not* available without debugging information.
 
+``THREAD_SIZE``
+    Object type: ``unsigned long``
+
+    This corresponds to the macro of the same name in the Linux kernel source
+    code. The thread size is the number of bytes used for kernel stacks. It's
+    important to note that for many architectures, there may be additional
+    stacks used when handling interrupts, excetpions, or faults. These may have
+    a different, architecture-dependent size. ``THREAD_SIZE`` refers only to the
+    kernel stacks associated with each task.
+
+    This is *not* available without debugging information.
+
 ``vmemmap``
     Object type: ``struct page *``
 

--- a/libdrgn/linux_kernel_object_find.inc.strswitch
+++ b/libdrgn/linux_kernel_object_find.inc.strswitch
@@ -22,6 +22,10 @@ linux_kernel_object_find(const char *name, size_t name_len,
 			if (flags & DRGN_FIND_OBJECT_CONSTANT)
 				return linux_kernel_get_page_mask(prog, ret);
 			break;
+		@case "THREAD_SIZE"@
+			if (flags & DRGN_FIND_OBJECT_CONSTANT)
+				return linux_kernel_get_thread_size(prog, ret);
+			break;
 		@case "UTS_RELEASE"@
 			if (flags & DRGN_FIND_OBJECT_CONSTANT)
 				return linux_kernel_get_uts_release(prog, ret);

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -239,6 +239,9 @@ struct drgn_program {
 			 * Whether @ref drgn_program::mod_text has been cached.
 			 */
 			bool mod_text_cached;
+			/**
+			 * Cached value of `THREAD_SIZE` in the kernel. */
+			uint64_t thread_size_cached;
 			/*
 			 * Whether we are currently in address translation. Used
 			 * to prevent address translation from recursing.

--- a/tests/linux_kernel/helpers/test_sched.py
+++ b/tests/linux_kernel/helpers/test_sched.py
@@ -114,3 +114,10 @@ class TestSched(LinuxKernelTestCase):
                 os.sched_setaffinity(pid, other_affinity)
             task = find_task(self.prog, pid)
             self.assertGreaterEqual(task_since_last_arrival_ns(task), 10000000)
+
+    @skip_unless_have_test_kmod
+    def test_thread_size(self):
+        self.assertEqual(
+            self.prog["THREAD_SIZE"].value_(),
+            self.prog["drgn_test_thread_size"].value_(),
+        )

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -1741,6 +1741,11 @@ typedef union {
 } drgn_test_anonymous_union;
 drgn_test_anonymous_union drgn_test_anonymous_union_var;
 
+// thread size
+
+__attribute__((used))
+static unsigned long drgn_test_thread_size = THREAD_SIZE;
+
 static void drgn_test_exit(void)
 {
 	drgn_test_sysfs_exit();


### PR DESCRIPTION
It looks like the linker symbols, in addition to `union thread_union`, are enough to resurrect the `THREAD_SIZE` object for all architectures! I updated the docs and included a test that uses the kmod to properly get the value and verify it. I got a clean vmtest on all architectures, at least for this helper. 

I did encounter some errors in aarch64 tiny/alternative for kernels <= 5.14, on `TestFsRefs.test_btrfs_subvolume` and `TestFsRefs::test_super_block_on_block_device`. I'll share some logs on that in the morning in a Github issue.