### PR TITLE
linux/mm: make decode_page_flags() handle memdesc_flags_t

### DIFF
--- a/drgn/helpers/linux/mm.py
+++ b/drgn/helpers/linux/mm.py
@@ -121,7 +121,25 @@ __all__ = (
     "PageWriteback",
     "PageXenRemapped",
     "PageYoung",
+    "get_page_flags",
 )
+
+
+def get_page_flags(page: Object) -> int:
+    """
+    Return the integer representation of a page's flags.
+    Handles both legacy unsigned long flags and memdesc_flags_t (flags.f).
+
+    :param page: ``struct page *``
+    """
+
+    # Since Linux kernel 6.18 (linux-next，"mm: introduce memdesc_flags_t")
+    # struct page->flags is no longer an unsigned long, but a memdesc_flags_t
+    # containing the actual flags in '.f'.
+    try:
+        return int(page.flags.f)
+    except AttributeError:
+        return int(page.flags)
 
 
 def PageActive(page: Object) -> bool:
@@ -134,7 +152,7 @@ def PageActive(page: Object) -> bool:
         flag = page.prog_["PG_active"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageChecked(page: Object) -> bool:
@@ -147,7 +165,7 @@ def PageChecked(page: Object) -> bool:
         flag = page.prog_["PG_checked"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageDirty(page: Object) -> bool:
@@ -160,7 +178,7 @@ def PageDirty(page: Object) -> bool:
         flag = page.prog_["PG_dirty"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageDoubleMap(page: Object) -> bool:
@@ -173,7 +191,7 @@ def PageDoubleMap(page: Object) -> bool:
         flag = page.prog_["PG_double_map"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageError(page: Object) -> bool:
@@ -186,7 +204,7 @@ def PageError(page: Object) -> bool:
         flag = page.prog_["PG_error"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageForeign(page: Object) -> bool:
@@ -199,7 +217,7 @@ def PageForeign(page: Object) -> bool:
         flag = page.prog_["PG_foreign"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageHWPoison(page: Object) -> bool:
@@ -212,7 +230,7 @@ def PageHWPoison(page: Object) -> bool:
         flag = page.prog_["PG_hwpoison"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageHasHWPoisoned(page: Object) -> bool:
@@ -225,7 +243,7 @@ def PageHasHWPoisoned(page: Object) -> bool:
         flag = page.prog_["PG_has_hwpoisoned"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageIdle(page: Object) -> bool:
@@ -238,7 +256,7 @@ def PageIdle(page: Object) -> bool:
         flag = page.prog_["PG_idle"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageIsolated(page: Object) -> bool:
@@ -251,7 +269,7 @@ def PageIsolated(page: Object) -> bool:
         flag = page.prog_["PG_isolated"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageLRU(page: Object) -> bool:
@@ -264,7 +282,7 @@ def PageLRU(page: Object) -> bool:
         flag = page.prog_["PG_lru"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageLocked(page: Object) -> bool:
@@ -277,7 +295,7 @@ def PageLocked(page: Object) -> bool:
         flag = page.prog_["PG_locked"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageMappedToDisk(page: Object) -> bool:
@@ -290,7 +308,7 @@ def PageMappedToDisk(page: Object) -> bool:
         flag = page.prog_["PG_mappedtodisk"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageMlocked(page: Object) -> bool:
@@ -303,7 +321,7 @@ def PageMlocked(page: Object) -> bool:
         flag = page.prog_["PG_mlocked"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageOwnerPriv1(page: Object) -> bool:
@@ -316,7 +334,7 @@ def PageOwnerPriv1(page: Object) -> bool:
         flag = page.prog_["PG_owner_priv_1"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PagePinned(page: Object) -> bool:
@@ -329,7 +347,7 @@ def PagePinned(page: Object) -> bool:
         flag = page.prog_["PG_pinned"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PagePrivate(page: Object) -> bool:
@@ -342,7 +360,7 @@ def PagePrivate(page: Object) -> bool:
         flag = page.prog_["PG_private"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PagePrivate2(page: Object) -> bool:
@@ -355,7 +373,7 @@ def PagePrivate2(page: Object) -> bool:
         flag = page.prog_["PG_private_2"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageReadahead(page: Object) -> bool:
@@ -368,7 +386,7 @@ def PageReadahead(page: Object) -> bool:
         flag = page.prog_["PG_readahead"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageReclaim(page: Object) -> bool:
@@ -381,7 +399,7 @@ def PageReclaim(page: Object) -> bool:
         flag = page.prog_["PG_reclaim"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageReferenced(page: Object) -> bool:
@@ -394,7 +412,7 @@ def PageReferenced(page: Object) -> bool:
         flag = page.prog_["PG_referenced"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageReported(page: Object) -> bool:
@@ -407,7 +425,7 @@ def PageReported(page: Object) -> bool:
         flag = page.prog_["PG_reported"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageReserved(page: Object) -> bool:
@@ -420,7 +438,7 @@ def PageReserved(page: Object) -> bool:
         flag = page.prog_["PG_reserved"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageSavePinned(page: Object) -> bool:
@@ -433,7 +451,7 @@ def PageSavePinned(page: Object) -> bool:
         flag = page.prog_["PG_savepinned"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageSkipKASanPoison(page: Object) -> bool:
@@ -446,7 +464,7 @@ def PageSkipKASanPoison(page: Object) -> bool:
         flag = page.prog_["PG_skip_kasan_poison"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageSlobFree(page: Object) -> bool:
@@ -459,7 +477,7 @@ def PageSlobFree(page: Object) -> bool:
         flag = page.prog_["PG_slob_free"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageSwapBacked(page: Object) -> bool:
@@ -472,7 +490,7 @@ def PageSwapBacked(page: Object) -> bool:
         flag = page.prog_["PG_swapbacked"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageUncached(page: Object) -> bool:
@@ -485,7 +503,7 @@ def PageUncached(page: Object) -> bool:
         flag = page.prog_["PG_uncached"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageUnevictable(page: Object) -> bool:
@@ -498,7 +516,7 @@ def PageUnevictable(page: Object) -> bool:
         flag = page.prog_["PG_unevictable"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageUptodate(page: Object) -> bool:
@@ -511,7 +529,7 @@ def PageUptodate(page: Object) -> bool:
         flag = page.prog_["PG_uptodate"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageVmemmapSelfHosted(page: Object) -> bool:
@@ -524,7 +542,7 @@ def PageVmemmapSelfHosted(page: Object) -> bool:
         flag = page.prog_["PG_vmemmap_self_hosted"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageWaiters(page: Object) -> bool:
@@ -537,7 +555,7 @@ def PageWaiters(page: Object) -> bool:
         flag = page.prog_["PG_waiters"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageWorkingset(page: Object) -> bool:
@@ -550,7 +568,7 @@ def PageWorkingset(page: Object) -> bool:
         flag = page.prog_["PG_workingset"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageWriteback(page: Object) -> bool:
@@ -563,7 +581,7 @@ def PageWriteback(page: Object) -> bool:
         flag = page.prog_["PG_writeback"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageXenRemapped(page: Object) -> bool:
@@ -576,7 +594,7 @@ def PageXenRemapped(page: Object) -> bool:
         flag = page.prog_["PG_xen_remapped"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 def PageYoung(page: Object) -> bool:
@@ -589,7 +607,7 @@ def PageYoung(page: Object) -> bool:
         flag = page.prog_["PG_young"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 
 
 # End generated by scripts/generate_page_flag_getters.py.
@@ -618,7 +636,7 @@ def _get_PageSlab_impl(prog: Program) -> Callable[[Object], bool]:
         mask = 1 << prog["PG_slab"]
 
         def PageSlab(page: Object) -> bool:
-            return bool(page.flags & mask)
+            return bool(get_page_flags(page) & mask)
 
     prog.cache["PageSlab"] = PageSlab
     return PageSlab
@@ -651,9 +669,9 @@ def PageCompound(page: Object) -> bool:
     try:
         PG_head = page.prog_["PG_head"]
     except KeyError:
-        return bool(page.flags & (1 << page.prog_["PG_compound"]))
+        return bool(get_page_flags(page) & (1 << page.prog_["PG_compound"]))
     else:
-        flags = page.flags.read_()
+        flags = get_page_flags(page)
         if flags & (1 << PG_head):
             return True
         try:
@@ -686,9 +704,9 @@ def PageHead(page: Object) -> bool:
         PG_compound = page.prog_["PG_compound"]
         PG_head_mask = 1 << PG_compound
         PG_head_tail_mask = PG_head_mask | (1 << page.prog_["PG_reclaim"])
-        return (page.flags & PG_head_tail_mask) == PG_head_mask
+        return (get_page_flags(page) & PG_head_tail_mask) == PG_head_mask
     else:
-        if not (page.flags & (1 << PG_head)):
+        if not (get_page_flags(page) & (1 << PG_head)):
             return False
         try:
             return not _page_is_fake_head(page)
@@ -715,10 +733,10 @@ def PageTail(page: Object) -> bool:
             PG_head_tail_mask = (1 << page.prog_["PG_compound"]) | (
                 1 << page.prog_["PG_reclaim"]
             )
-            return (page.flags & PG_head_tail_mask) == PG_head_tail_mask
+            return (get_page_flags(page) & PG_head_tail_mask) == PG_head_tail_mask
         else:
-            return bool(page.flags & (1 << PG_tail))
-    if page.flags & (1 << page.prog_["PG_head"]):
+            return bool(get_page_flags(page) & (1 << PG_tail))
+    if get_page_flags(page) & (1 << page.prog_["PG_head"]):
         return _page_is_fake_head(page)
     return False
 
@@ -744,7 +762,7 @@ def compound_head(page: Object) -> Object:
     if head & 1:
         return cast(page.type_, head - 1)
     # Handle fake head pages (see _page_is_fake_head()).
-    if page.flags & (1 << page.prog_["PG_head"]):
+    if get_page_flags(page) & (1 << page.prog_["PG_head"]):
         head = page[1].compound_head.read_()
         if head & 1:
             return cast(page.type_, head - 1)
@@ -826,7 +844,7 @@ def decode_page_flags(page: Object) -> str:
     NR_PAGEFLAGS = page.prog_["__NR_PAGEFLAGS"]
     PAGEFLAGS_MASK = (1 << NR_PAGEFLAGS.value_()) - 1
     return decode_enum_type_flags(
-        page.flags.value_() & PAGEFLAGS_MASK, NR_PAGEFLAGS.type_
+        get_page_flags(page) & PAGEFLAGS_MASK, NR_PAGEFLAGS.type_
     )
 
 

--- a/scripts/generate_page_flag_getters.py
+++ b/scripts/generate_page_flag_getters.py
@@ -42,7 +42,7 @@ def Page{uname}(page: Object) -> bool:
         flag = page.prog_["PG_{lname}"]
     except KeyError:
         return False
-    return bool(page.flags & (1 << flag))
+    return bool(get_page_flags(page) & (1 << flag))
 '''
         )
     print()


### PR DESCRIPTION
    Since Linux kernel 6.18 (linux-next，“mm: introduce memdesc_flags_t”)
    struct page->flags is no longer an unsigned long, but a memdesc_flags_t 
    containing the actual flags in '.f'. This helper now handles both the legacy 
    unsigned long flags and the new memdesc_flags_t.

    Add get_page_flags() in drgn helpers to automatically handle both
    cases by trying page.flags.f first and falling back to page.flags.

    This fixes TypeError in drgn 0.0.32+ when running on newer kernels.