### PR TITLE
tests: tools: fsrefs: set sector size to PAGE_SIZE

### DIFF
--- a/tests/linux_kernel/tools/test_fsrefs.py
+++ b/tests/linux_kernel/tools/test_fsrefs.py
@@ -213,7 +213,7 @@ class TestFsRefs(LinuxKernelTestCase):
         disk = os.environ["DRGN_TEST_DISK"]
         for fstype, mkfs in (
             ("ext2", ("mke2fs", "-qF")),
-            ("btrfs", ("mkfs.btrfs", "-qf")),
+            ("btrfs", ("mkfs.btrfs", "-qf", "-s", str(mmap.PAGESIZE))),
         ):
             with self.subTest(fstype=fstype):
                 subprocess.check_call([*mkfs, disk])
@@ -237,7 +237,7 @@ class TestFsRefs(LinuxKernelTestCase):
     def test_btrfs_subvolume(self):
         disk = os.environ["DRGN_TEST_DISK"]
         with contextlib.ExitStack() as exit_stack:
-            subprocess.check_call(["mkfs.btrfs", "-qf", disk])
+            subprocess.check_call(["mkfs.btrfs", "-qf", "-s", str(mmap.PAGESIZE), disk])
 
             mount(disk, self._tmp, "btrfs")
             exit_stack.callback(umount, self._tmp)


### PR DESCRIPTION
With btrfs-progs >=6.7, the default sector size is now 4096, rather than the system page size. This results in filesystems that may not be mountable, at least on some older kernels where we run vmtest. Avoid this by explicitly setting the sectorsize to the page size. Fixes #544.