### PR TITLE
vmtest: install e2fsprogs in rootfs

### DIFF
--- a/vmtest/rootfsbuild.py
+++ b/vmtest/rootfsbuild.py
@@ -31,6 +31,7 @@ _ROOTFS_PACKAGES = [
     "python3-setuptools",
     # Test dependencies.
     "btrfs-progs",
+    "e2fsprogs",
     "check",
     "iproute2",
     "kexec-tools",


### PR DESCRIPTION
It's necessary for fsrefs and swap tests, but when I recently rebuilt a rootfs, it was not present.
