### PR TITLE
commands/crash: include PID in LookupError message in crash_get_conte…

### DIFF
--- a/drgn/commands/crash.py
+++ b/drgn/commands/crash.py
@@ -213,7 +213,7 @@ def crash_get_context(
         if arg[0] == "pid":
             task = find_task(prog, arg[1])
             if not task:
-                raise LookupError("no such process")
+                raise LookupError("no such process with PID {}".format(arg[1]))
             return task
         else:
             return Object(prog, "struct task_struct *", arg[1])


### PR DESCRIPTION
Improve the error message for missing process IDs to include the requested PID, which makes it easier to debug.

When I developed the 'vm' command, I found that there was no prompt for the specific PID.

Before:
```
%crash> vm 1 2 3 4 5 6 7 8 9 
drgn: crash: error: no such process
%crash> 
```
After:
```
%crash> vm 1 2 3 4 5 6 7 8 9 
drgn: crash: error: no such process with PID 9
%crash> 
```
