### PR TITLE
crash: add bpf command for displaying eBPF programs and maps

### DIFF
--- a/drgn/commands/_builtin/crash/_bpf.py
+++ b/drgn/commands/_builtin/crash/_bpf.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ebpf-related commands.
+
+import argparse
+from typing import Any, List, Sequence
+
+from drgn import Program
+from drgn.commands import drgn_argument
+from drgn.commands.crash import CrashDrgnCodeBuilder, crash_command
+from drgn.helpers.common.format import CellFormat, print_table
+from drgn.helpers.linux.bpf import (
+    bpf_map_for_each,
+    bpf_prog_for_each,
+    bpf_prog_used_maps,
+)
+
+
+@crash_command(
+    description="display all eBPF programs and maps",
+    arguments=(drgn_argument,),
+)
+def _crash_cmd_bpf(
+    prog: Program, name: str, args: argparse.Namespace, **kwargs: Any
+) -> None:
+    if args.drgn:
+        code = CrashDrgnCodeBuilder(prog)
+        code.add_from_import(
+            "drgn.helpers.linux.bpf",
+            "bpf_map_for_each",
+            "bpf_prog_for_each",
+            "bpf_prog_used_maps",
+        )
+        code.append(
+            """\
+for bpf_prog in bpf_prog_for_each(prog):
+    aux = bpf_prog.aux
+    prog_id = aux.id
+    prog_type = bpf_prog.type
+    tag = bpf_prog.tag
+    for used_map in bpf_prog_used_maps(bpf_prog):
+        map_id = used_map.id
+
+for bpf_map in bpf_map_for_each(prog):
+    map_id = bpf_map.id
+    map_type = bpf_map.map_type
+    try:
+        map_flags = bpf_map.map_flags
+    except AttributeError:
+        # map_flags is only available since Linux 4.6.
+        pass
+    """
+        )
+        code.print()
+        return
+
+    prog_rows: List[Sequence[Any]] = [
+        (
+            CellFormat("ID", "^"),
+            CellFormat("BPF_PROG", "^"),
+            CellFormat("BPF_PROG_AUX", "^"),
+            CellFormat("BPF_PROG_TYPE", "^"),
+            CellFormat("TAG", "^"),
+            CellFormat("USED_MAPS", "^"),
+        )
+    ]
+
+    for bpf_prog in bpf_prog_for_each(prog):
+        prog_id = bpf_prog.aux.id.value_()
+        prog_type_name = bpf_prog.type.format_(type_name=False).split("BPF_PROG_TYPE_")[
+            -1
+        ]
+
+        tag = bpf_prog.tag
+        prog_tag = "".join(f"{b.value_():02x}" for b in tag)
+
+        used_maps = []
+        for map in bpf_prog_used_maps(bpf_prog):
+            used_maps.append(map.id.value_())
+        used_maps_str = ",".join(str(m) for m in used_maps)
+
+        prog_rows.append(
+            (
+                prog_id,
+                CellFormat(bpf_prog.value_(), "^x"),
+                CellFormat(bpf_prog.aux.value_(), "^x"),
+                CellFormat(prog_type_name, "^"),
+                CellFormat(prog_tag, "^"),
+                CellFormat(used_maps_str, "^"),
+            )
+        )
+
+    print_table(prog_rows)
+    print()
+
+    map_rows: List[Sequence[Any]] = [
+        (
+            CellFormat("ID", "^"),
+            CellFormat("BPF_MAP", "^"),
+            CellFormat("BPF_MAP_TYPE", "^"),
+            CellFormat("MAP_FLAGS", "^"),
+        )
+    ]
+
+    for bpf_map in bpf_map_for_each(prog):
+        map_id = bpf_map.id.value_()
+
+        map_type_name = bpf_map.map_type.format_(type_name=False).split(
+            "BPF_MAP_TYPE_"
+        )[-1]
+
+        # The 'map_flags' field was added in Linux kernel commit 6c9059817432
+        # ("bpf: pre-allocate hash map elements") in version 4.6. Older kernels
+        # may not have this field, so we catch LookupError and default to 0.
+        try:
+            map_flags = f"{bpf_map.map_flags.value_():08x}"
+        except AttributeError:
+            map_flags = "00000000"
+
+        map_rows.append(
+            (
+                map_id,
+                CellFormat(bpf_map.value_(), "^x"),
+                CellFormat(map_type_name, "^"),
+                CellFormat(map_flags, "^"),
+            )
+        )
+
+    print_table(map_rows)

--- a/drgn/helpers/linux/bpf.py
+++ b/drgn/helpers/linux/bpf.py
@@ -26,6 +26,7 @@ __all__ = (
     "bpf_prog_for_each",
     "cgroup_bpf_prog_for_each",
     "cgroup_bpf_prog_for_each_effective",
+    "bpf_prog_used_maps",
 )
 
 
@@ -180,3 +181,14 @@ def cgroup_bpf_prog_for_each_effective(
             if not prog:
                 break
             yield prog
+
+
+def bpf_prog_used_maps(bpf_prog: Object) -> Iterator[Object]:
+    """
+    Yield maps used by a BPF program.
+
+    :param bpf_prog: ``struct bpf_prog *``
+    :return: Iterator of ``struct bpf_map *`` objects.
+    """
+    aux = bpf_prog.aux.read_()
+    return iter(aux.used_maps[: aux.used_map_cnt])

--- a/tests/linux_kernel/crash_commands/test_bpf.py
+++ b/tests/linux_kernel/crash_commands/test_bpf.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import contextlib
+import errno
+import os
+from unittest import SkipTest
+
+from tests.linux_kernel.bpf import (
+    BPF_EXIT_INSN,
+    BPF_LD_MAP_FD,
+    BPF_MAP_TYPE_HASH,
+    BPF_MOV64_IMM,
+    BPF_PROG_TYPE_KPROBE,
+    BPF_PROG_TYPE_SOCKET_FILTER,
+    BPF_REG_0,
+    bpf_map_create,
+    bpf_map_get_info_by_fd,
+    bpf_prog_get_info_by_fd,
+    bpf_prog_ids,
+    bpf_prog_load,
+)
+from tests.linux_kernel.crash_commands import CrashCommandTestCase
+
+
+class TestBpf(CrashCommandTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # This command isn't supported before Linux kernel commits dc4bb0e23561
+        # ("bpf: Introduce bpf_prog ID") and f3f1c054c288 ("bpf: Introduce bpf_map
+        # ID") (in v4.13).
+        try:
+            next(bpf_prog_ids())
+        except StopIteration:
+            # Kernel supports BPF IDs but no programs exist yet
+            pass
+        except OSError as e:
+            if e.errno != errno.EINVAL:
+                raise
+            raise SkipTest("This kernel version doesn't support BPF object IDs")
+
+    INSNS = (
+        BPF_MOV64_IMM(BPF_REG_0, 0),
+        BPF_EXIT_INSN(),
+    )
+
+    def test_bpf(self):
+        with contextlib.ExitStack() as exit_stack:
+            map_fd = bpf_map_create(BPF_MAP_TYPE_HASH, 8, 8, 8)
+            exit_stack.callback(os.close, map_fd)
+
+            prog1_fd = bpf_prog_load(BPF_PROG_TYPE_KPROBE, self.INSNS, b"GPL")
+            exit_stack.callback(os.close, prog1_fd)
+
+            prog2_insns = BPF_LD_MAP_FD(BPF_REG_0, map_fd) + self.INSNS
+            prog2_fd = bpf_prog_load(BPF_PROG_TYPE_SOCKET_FILTER, prog2_insns, b"GPL")
+            exit_stack.callback(os.close, prog2_fd)
+
+            map_id = bpf_map_get_info_by_fd(map_fd).id
+            prog1_id = bpf_prog_get_info_by_fd(prog1_fd).id
+            prog2_info = bpf_prog_get_info_by_fd(prog2_fd)
+            prog2_id = prog2_info.id
+            prog2_tag = "".join(f"{b:02x}" for b in prog2_info.tag)
+
+            cmd = self.check_crash_command("bpf")
+
+            self.assertIn("BPF_PROG_TYPE", cmd.stdout)
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)BPF_PROG.*^\s*{prog1_id}\s+.*KPROBE\s+[0-9a-f]{{16}}\s*$",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)BPF_PROG.*^\s*{prog2_id}\s+.*SOCKET_FILTER\s+.*{prog2_tag}\s+{map_id}$",
+            )
+            self.assertIn("BPF_MAP_TYPE", cmd.stdout)
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)BPF_MAP.*^\s*{map_id}\s+.*HASH\s+",
+            )


### PR DESCRIPTION
Introduce a new crash command 'bpf' to list eBPF programs and maps from the kernel. The command enumerates over all loaded BPF programs and maps, showing each program’s ID, addresses, type, tag, and the maps it uses.