### PR TITLE
contrib: Add script to display mutex owner and waiters

### DIFF
--- a/contrib/mutex_owner.py
+++ b/contrib/mutex_owner.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env drgn
+# Copyright (c) Cloudflare
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""List the task holding a mutex and which tasks are waiting."""
+
+import sys
+import drgn
+from drgn import FaultError, NULL, Object, cast, container_of, execscript, offsetof, reinterpret, sizeof, stack_trace
+from drgn.helpers.common import *
+from drgn.helpers.linux import *
+
+def main(mutex_name):
+	print("Mutex details for '%s'" % mutex_name)
+	print("="*40)
+
+	m = prog[mutex_name]
+	addr = cast("unsigned long", m.owner.counter) & ~0x7
+	if addr != 0:
+		t = cast("struct task_struct *", addr)
+		owner = "{}-{}".format(t.comm.string_().decode(), int(t.pid))
+		print("\tOwner: {}".format(owner))
+		for e in stack_trace(t):
+			print("\t\t{}".format(e))
+	else:
+		print("\tOwner: none")
+
+	print("\tWaiters:")
+	for waiter in list_for_each(m.wait_list.address_of_()):
+		t = container_of(waiter, prog.type('struct mutex_waiter'), 'list').task
+		print("\t\t{}-{}".format(t.comm.string_().decode(), int(t.pid)))
+		for e in stack_trace(t):
+			print("\t\t\t{}".format(e))
+
+if __name__ == '__main__':
+	if len(sys.argv) < 2:
+		print("Usage: %s <mutex name>" % (sys.argv[0]))
+		sys.exit(1)
+
+	main(sys.argv[1])


### PR DESCRIPTION
Knowing which tasks are holding or waiting on a mutex can be particularly helpful during a debugging session, e.g. when simple commands like cat /proc/$foo start to block forever because some other task is holding the mutex and will not release it:
```
   mfleming@machine:~$ sudo ./mutex-owner event_mutex
   Mutex details for 'event_mutex'
   ========================================
           Owner: prometheus-ebpf-340210
           Waiters:
                   wc-346534
                   cat-2945595
```