### PR TITLE
ci: run Python 3.14 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         python-version: ${{ (github.event_name == 'push' || inputs.test_all_python_versions)
                             && fromJSON('["3.14", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]')
-                            || fromJSON('["3.13", "3.8"]')}}
+                            || fromJSON('["3.14", "3.8"]')}}
         cc: [gcc, clang]
       fail-fast: false
     env:


### PR DESCRIPTION
Now that Python 3.14 is released and is in the wild with Fedora 43, it is time to make that the default "recent" Python version in CI.