### PR TITLE
tests: crash: rd: fix annotation tests

### DIFF
--- a/drgn/commands/_builtin/crash/_rd.py
+++ b/drgn/commands/_builtin/crash/_rd.py
@@ -32,15 +32,18 @@ def _crash_annotate(
             "slab",
             "verbose",
         ):
-            slab_cache = identified.slab_object_info.slab_cache
-            if slab_cache:
-                cache_name = escape_ascii_string(slab_cache.name.string_())
-                if level == "slab":
-                    return f"[{cache_name}]"
-                else:
-                    # Crash does not pad the address at all, which can help with
-                    # output alignment on some architectures.
-                    return f"[{addr:x}:{cache_name}]"
+            if identified.slab_object_info.address:
+                cache_name = escape_ascii_string(
+                    identified.slab_object_info.slab_cache.name.string_()
+                )
+            else:  # SLOB
+                cache_name = "unknown slab object"
+            if level == "slab":
+                return f"[{cache_name}]"
+            else:
+                # Crash does not pad the address at all, which can help with
+                # output alignment on some architectures.
+                return f"[{addr:x}:{cache_name}]"
     return None
 
 


### PR DESCRIPTION
The test_annotate_slab() and test_annotate_slab_verbose() cases rely on the slab_caches variable to contain pointers to slab objects (those allocated from the kmem_cache slab). This is normally the case, but it can't be relied upon:

1. Some of the alternative configurations have "kmem_cache_boot" as the head or the tail of this list. Since this is a symbol and not a slab object, the test fails.
2. Kernel configurations with SLOB cannot detect which slab cache a pointer belongs to, so they should output "unknown slab object". While I would refer to crash's implementation to determine what it would output,
I cannot get crash to run on a relevant SLOB-enabled kernel. So, we'll just define our own output - "unknown slab object".


Fixes: d6d9feb2 ("crash: port rd command")

---

Sorry, I missed that this test was broken on the full vmtest - tiny and alternative kernels. This fixes the mentioned tests on all architectures.