### PR TITLE
crash: port cd command

### DIFF
--- a/drgn/commands/_crash/_cd.py
+++ b/drgn/commands/_crash/_cd.py
@@ -1,0 +1,57 @@
+import argparse
+import os
+from typing import Any, Optional
+
+from drgn.commands import CommandError, argument, drgn_argument
+from drgn.commands._crash.common import crash_command
+
+@crash_command(
+    name="cd",
+    description="change the current working directory",
+    long_description="""
+    Changes the current working directory to the directory specified by 'path'.
+    If no path is given, the command defaults to the user's home directory (~).
+    """,
+    arguments=(
+        argument(
+            "path",
+            nargs="?",
+            help="the path of the directory to change to (optional)",
+        ),
+        drgn_argument,
+    ),
+)
+def _crash_cmd_cd(prog: Any, cmd: str, args: argparse.Namespace, **kwargs: Any) -> None:
+    target = _resolve_path(prog, args.path)
+    _change_directory(prog, target)
+    print(os.getcwd())
+
+def _resolve_path(prog: Any, path: Optional[str]) -> str:
+    # Resolve shell-like path expansions.
+    if path is None:
+        return os.path.expanduser("~")
+
+    if path == "-":
+        prev = prog.config.get("prev_work_path")
+        if not prev:
+            raise CommandError("cd -: previous directory not set")
+        return prev
+
+    # Expand variables ($VAR) and user (~/path)
+    return os.path.expandvars(os.path.expanduser(path))
+
+
+def _change_directory(prog: Any, path: str) -> None:
+    try:
+        oldpwd = os.getcwd()
+    except OSError:
+        # Current directory was deleted ?
+        oldpwd = None
+    try:
+        os.chdir(path)
+    except Exception as e:
+        raise CommandError(f"{e}")
+
+    # Update previous working directory
+    if oldpwd is not None:
+        prog.config["prev_work_path"] = oldpwd

--- a/tests/linux_kernel/crash_commands/test_cd.py
+++ b/tests/linux_kernel/crash_commands/test_cd.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 Oracle and/or its affiliates
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import shutil
+import tempfile
+from unittest import mock
+
+from drgn.commands import CommandError
+from tests.linux_kernel.crash_commands import CrashCommandTestCase
+
+
+class TestCrashCd(CrashCommandTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Create a temporary directory to act as our filesystem
+        self.test_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+
+        # Clear previous directory state
+        self.prog.config.pop("prev_work_path", None)
+
+        # Start inside test directory
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        # Restore CWD
+        os.chdir(self.original_cwd)
+
+        # Clean up prev_work_path
+        self.prog.config.pop("prev_work_path", None)
+
+        shutil.rmtree(self.test_dir)
+        super().tearDown()
+
+    def test_cd_basic_navigation(self):
+        subdir = os.path.join(self.test_dir, "subdir")
+        os.mkdir(subdir)
+
+        self.run_crash_command(f"cd {subdir}")
+
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(subdir))
+
+    def test_cd_no_args_goes_home(self):
+        fake_home = os.path.join(self.test_dir, "fake_home")
+        os.mkdir(fake_home)
+
+        with mock.patch("os.path.expanduser", return_value=fake_home):
+            self.run_crash_command("cd")
+
+            self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(fake_home))
+
+    def test_cd_hyphen_previous_dir(self):
+        dir_a = os.path.join(self.test_dir, "dir_a")
+        dir_b = os.path.join(self.test_dir, "dir_b")
+        os.mkdir(dir_a)
+        os.mkdir(dir_b)
+
+        # Start in A
+        os.chdir(dir_a)
+
+        # Move to B (sets OLDPWD -> A)
+        self.run_crash_command(f"cd {dir_b}")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_b))
+
+        # 'cd -' should go back to A
+        self.run_crash_command("cd -")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_a))
+
+        # 'cd -' should go back to B
+        self.run_crash_command("cd -")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_b))
+
+    def test_cd_error_non_existent(self):
+        bad_path = os.path.join(self.test_dir, "does_not_exist")
+
+        with self.assertRaises(CommandError):
+            self.run_crash_command(f"cd {bad_path}")
+
+    def test_cd_error_not_a_directory(self):
+        some_file = os.path.join(self.test_dir, "file.txt")
+        with open(some_file, "w"):
+            pass
+
+        with self.assertRaises(CommandError):
+            self.run_crash_command(f"cd {some_file}")
+
+    def test_cd_empty_string(self):
+        self.assertRaises(
+            CommandError,
+            self.run_crash_command,
+            'cd ""',
+        )
+
+    def test_cd_stale_oldpwd_handling(self):
+        dir_a = os.path.join(self.test_dir, "dir_a")
+        dir_b = os.path.join(self.test_dir, "dir_b")
+        os.mkdir(dir_a)
+        os.mkdir(dir_b)
+
+        os.chdir(dir_a)
+
+        try:
+            os.rmdir(dir_a)
+        except OSError:
+            self.skipTest("Filesystem does not allow removing current directory")
+
+        self.run_crash_command(f"cd {dir_b}")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_b))
+
+        self.assertRaises(
+            CommandError,
+            self.run_crash_command,
+            "cd -",
+        )

--- a/tests/linux_kernel/helpers/test_cd.py
+++ b/tests/linux_kernel/helpers/test_cd.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 Oracle and/or its affiliates
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import shutil
+import tempfile
+from unittest import mock
+
+from drgn.commands import CommandError
+from tests.linux_kernel.crash_commands import CrashCommandTestCase
+
+
+class TestCrashCd(CrashCommandTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Create a temporary directory to act as our filesystem
+        self.test_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+
+        # Clear previous directory state
+        self.prog.config.pop("prev_work_path", None)
+
+        # Start inside test directory
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        # Restore CWD
+        os.chdir(self.original_cwd)
+
+        # Clean up prev_work_path
+        self.prog.config.pop("prev_work_path", None)
+
+        shutil.rmtree(self.test_dir)
+        super().tearDown()
+
+    def test_cd_basic_navigation(self):
+        subdir = os.path.join(self.test_dir, "subdir")
+        os.mkdir(subdir)
+
+        self.run_crash_command(f"cd {subdir}")
+
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(subdir))
+
+    def test_cd_no_args_goes_home(self):
+        fake_home = os.path.join(self.test_dir, "fake_home")
+        os.mkdir(fake_home)
+
+        with mock.patch("os.path.expanduser", return_value=fake_home):
+            self.run_crash_command("cd")
+
+            self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(fake_home))
+
+    def test_cd_hyphen_previous_dir(self):
+        dir_a = os.path.join(self.test_dir, "dir_a")
+        dir_b = os.path.join(self.test_dir, "dir_b")
+        os.mkdir(dir_a)
+        os.mkdir(dir_b)
+
+        # Start in A
+        os.chdir(dir_a)
+
+        # Move to B (sets OLDPWD -> A)
+        self.run_crash_command(f"cd {dir_b}")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_b))
+
+        # 'cd -' should go back to A
+        self.run_crash_command("cd -")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_a))
+
+        # 'cd -' should go back to B
+        self.run_crash_command("cd -")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_b))
+
+    def test_cd_error_non_existent(self):
+        bad_path = os.path.join(self.test_dir, "does_not_exist")
+
+        with self.assertRaises(CommandError):
+            self.run_crash_command(f"cd {bad_path}")
+
+    def test_cd_error_not_a_directory(self):
+        some_file = os.path.join(self.test_dir, "file.txt")
+        with open(some_file, "w"):
+            pass
+
+        with self.assertRaises(CommandError):
+            self.run_crash_command(f"cd {some_file}")
+
+    def test_cd_empty_string(self):
+        self.assertRaises(
+            CommandError,
+            self.run_crash_command,
+            'cd ""',
+        )
+
+    def test_cd_stale_oldpwd_handling(self):
+        dir_a = os.path.join(self.test_dir, "dir_a")
+        dir_b = os.path.join(self.test_dir, "dir_b")
+        os.mkdir(dir_a)
+        os.mkdir(dir_b)
+
+        os.chdir(dir_a)
+
+        try:
+            os.rmdir(dir_a)
+        except OSError:
+            self.skipTest("Filesystem does not allow removing current directory")
+
+        self.run_crash_command(f"cd {dir_b}")
+        self.assertEqual(os.path.realpath(os.getcwd()), os.path.realpath(dir_b))
+
+        self.assertRaises(
+            CommandError,
+            self.run_crash_command,
+            "cd -",
+        )


### PR DESCRIPTION
The cd command help to change the current working directory. It supports:
- changing to a specified directory.
- defaulting to $HOME when no path is provided.
- if set `cd -` to switch to the previous directory.
- Handle ~ and environment variable expansion.