### PR TITLE
libdrgn: Add set_linux_kernel_custom()

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -816,6 +816,24 @@ class Program:
         """
         ...
 
+    def set_linux_kernel_custom(self, vmcoreinfo: Union[str, bytes]) -> None:
+        """
+        Set the program to a custom Linux kernel target.
+
+        This enables debugging a Linux kernel via a custom memory transport
+        (e.g., RDMA, TCP/IP, or VMM introspection). It sets up page table
+        walking for virtual address translation. It does not load any
+        debugging symbols; see :meth:`load_default_debug_info()`.
+
+        Physical memory segments must be registered via
+        :meth:`add_memory_segment()` with ``physical=True`` before reading
+        memory. Platform must be provided when creating the :class:`Program`.
+
+        :param vmcoreinfo: Raw vmcoreinfo data. If vmcoreinfo was already set
+            when creating the :class:`Program`, this is ignored.
+        """
+        ...
+
     def set_pid(self, pid: int) -> None:
         """
         Set the program to a running process.

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -810,6 +810,27 @@ struct drgn_error *drgn_program_set_core_dump_fd(struct drgn_program *prog, int 
 struct drgn_error *drgn_program_set_kernel(struct drgn_program *prog);
 
 /**
+ * Set a @ref drgn_program to a custom Linux kernel target.
+ *
+ * This enables debugging a Linux kernel via a custom memory transport
+ * (e.g., RDMA, TCP/IP, or VMM introspection). It sets up page table walking
+ * for virtual address translation.
+ *
+ * Physical memory segment(s) must be registered via @ref
+ * drgn_program_add_memory_segment() with physical=true before reading memory.
+ * Platform must be set when creating the program.
+ *
+ * @param[in] vmcoreinfo Raw vmcoreinfo data. If vmcoreinfo was already set
+ * when creating the program, this is ignored.
+ * @param[in] vmcoreinfo_size Size of vmcoreinfo data in bytes.
+ * @return @c NULL on success, non-@c NULL on error.
+ */
+struct drgn_error *
+drgn_program_set_linux_kernel_custom(struct drgn_program *prog,
+				     const char *vmcoreinfo,
+				     size_t vmcoreinfo_size);
+
+/**
  * Set a @ref drgn_program to a running process.
  *
  * @sa drgn_program_from_pid()

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -986,6 +986,26 @@ static PyObject *Program_set_kernel(Program *self)
 	Py_RETURN_NONE;
 }
 
+static PyObject *Program_set_linux_kernel_custom(Program *self, PyObject *args,
+						  PyObject *kwds)
+{
+	static char *keywords[] = {"vmcoreinfo", NULL};
+	struct drgn_error *err;
+	const char *vmcoreinfo;
+	Py_ssize_t vmcoreinfo_size;
+
+	if (!PyArg_ParseTupleAndKeywords(args, kwds,
+					 "s#:set_linux_kernel_custom", keywords,
+					 &vmcoreinfo, &vmcoreinfo_size))
+		return NULL;
+
+	err = drgn_program_set_linux_kernel_custom(&self->prog, vmcoreinfo,
+						   vmcoreinfo_size);
+	if (err)
+		return set_drgn_error(err);
+	Py_RETURN_NONE;
+}
+
 static PyObject *Program_set_pid(Program *self, PyObject *args, PyObject *kwds)
 {
 	static char *keywords[] = {"pid", NULL};
@@ -2230,6 +2250,8 @@ static PyMethodDef Program_methods[] = {
 	 METH_VARARGS | METH_KEYWORDS, drgn_Program_set_core_dump_DOC},
 	{"set_kernel", (PyCFunction)Program_set_kernel, METH_NOARGS,
 	 drgn_Program_set_kernel_DOC},
+	{"set_linux_kernel_custom", (PyCFunction)Program_set_linux_kernel_custom,
+	 METH_VARARGS | METH_KEYWORDS, drgn_Program_set_linux_kernel_custom_DOC},
 	{"set_pid", (PyCFunction)Program_set_pid, METH_VARARGS | METH_KEYWORDS,
 	 drgn_Program_set_pid_DOC},
 	{"modules", (PyCFunction)Program_modules, METH_NOARGS,


### PR DESCRIPTION
## Context

There are cases where a `drgn` user wants to signify that the program being debugged is a Linux Kernel target. Currently there's no way of doing that. Linux kernel targets are only created by `set_kernel()` and `set_core_dump()` so if your target is not a live system nor a proper ELF dump/kdump you can't do anything about it so you're stuck (address translation doesn't work even if you pass a valid platform+vmcoreinfo_data and vmlinux is not loaded at the right offset).

The API introduced here provides a way to set the kernel target flag in drgn accordingly.

## References To Past Discussions

https://github.com/osandov/drgn/pull/246

https://github.com/osandov/drgn/issues/463

(also search for discussions on Matrix)

## Alternatives That I Considered

(1) Making the Program Flags mutable per the referenced PR above - this seems to go against the immutable creation idea.
(2) If anyone passes the `vmcoreinfo` in the `drgn.Program()` constructor then just assume that this is a linux kernel target and set the `is_linux_kernel` flag - I hesitated on this one because I'm afraid of breaking any existing scripts/behavior
(3) Pass an `is_linux_kernel=True` flag in the `drgn.Program()` as discussed in issue 463 - I didn't implement this because it seemed like Omar had some concerns.