### PR TITLE
drgn.helpers.linux.net: add netdev_ipv6_addrs

### DIFF
--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -39,6 +39,7 @@ __all__ = (
     "skb_shinfo",
     "is_pp_page",
     "netdev_ipv4_addrs",
+    "netdev_ipv6_addrs",
 )
 
 
@@ -347,4 +348,27 @@ def netdev_ipv4_addrs(dev: Object) -> List[ipaddress.IPv4Address]:
             )
             ips.append(ipaddress.IPv4Address(addr_bytes))
             ifa = ifa.ifa_next.read_()
+    return ips
+
+
+def netdev_ipv6_addrs(dev: Object) -> List[ipaddress.IPv6Address]:
+    """
+    Get the list of IPV6 addresses associated with a network device.
+
+    :param dev: ``struct net_device *``
+    """
+    ips = []
+    prog = dev.prog_
+    ip_ptr = dev.ip6_ptr.read_()
+    if ip_ptr:
+        for addr in list_for_each_entry(
+            "struct inet6_ifaddr",
+            dev.ip6_ptr.addr_list.address_of_(),
+            "if_list",
+        ):
+            addr_bytes = prog.read(
+                addr.addr.in6_u.u6_addr8.address_,  # type: ignore[arg-type]  # address can't be None.
+                16,
+            )
+            ips.append(ipaddress.IPv6Address(addr_bytes))
     return ips

--- a/tests/linux_kernel/helpers/test_net.py
+++ b/tests/linux_kernel/helpers/test_net.py
@@ -22,6 +22,7 @@ from drgn.helpers.linux.net import (
     netdev_get_by_index,
     netdev_get_by_name,
     netdev_ipv4_addrs,
+    netdev_ipv6_addrs,
     netdev_name,
     netdev_priv,
     sk_fullsock,
@@ -169,5 +170,18 @@ class TestNet(LinuxKernelTestCase):
             ]
         self.assertCountEqual(
             netdev_ipv4_addrs(netdev_get_by_name(self.prog, "lo")),
+            expected,
+        )
+
+    @unittest.skipUnless(have_pyroute2, "pyroute2 not found")
+    def test_netdev_ipv6_addrs(self):
+        with pyroute2.IPRoute() as ipr:
+            idx = ipr.link_lookup(ifname="lo")[0]
+            addrs = ipr.get_addr(index=idx, family=socket.AF_INET6)
+            expected = [
+                ipaddress.IPv6Address(addr.get_attr("IFA_ADDRESS")) for addr in addrs
+            ]
+        self.assertCountEqual(
+            netdev_ipv6_addrs(netdev_get_by_name(self.prog, "lo")),
             expected,
         )


### PR DESCRIPTION
This helper will be used to obtain the list of IPv6 addresses associated with a network device.