### PR TITLE
libdrgn: enable PCRE2 for Oracle Linux 8

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -4083,6 +4083,7 @@ _enable_dlopen_debuginfod: bool
 _with_libkdumpfile: bool
 _with_lzma: bool
 _with_pcre2: bool
+_with_pcre2_utf: bool
 
 def _linux_helper_direct_mapping_offset(__prog: Program) -> int: ...
 def _linux_helper_read_vm(

--- a/drgn/__init__.py
+++ b/drgn/__init__.py
@@ -121,6 +121,7 @@ from _drgn import (  # noqa: F401
     _with_libkdumpfile as _with_libkdumpfile,
     _with_lzma as _with_lzma,
     _with_pcre2 as _with_pcre2,
+    _with_pcre2_utf as _with_pcre2_utf,
 )
 from drgn.internal.version import __version__ as __version__  # noqa: F401
 

--- a/libdrgn/python/main.c
+++ b/libdrgn/python/main.c
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <elfutils/libdwfl.h>
+#ifdef WITH_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#endif
 
 #include "drgnpy.h"
 #include "../error.h"
@@ -445,6 +449,17 @@ DRGNPY_PUBLIC PyMODINIT_FUNC PyInit__drgn(void)
 
 	if (add_bool(m, "_with_pcre2",
 #ifdef WITH_PCRE2
+		     true
+#else
+		     false
+#endif
+		    ))
+		goto err;
+
+	// Allow tests to detect whether PCRE2 supports UTF-8 patterns within
+	// invalid UTF.
+	if (add_bool(m, "_with_pcre2_utf",
+#if WITH_PCRE2 && (PCRE2_MAJOR > 10 || (PCRE2_MAJOR == 10 && PCRE2_MINOR >= 34))
 		     true
 #else
 		     false

--- a/tests/test_search_memory.py
+++ b/tests/test_search_memory.py
@@ -904,6 +904,7 @@ class TestSearchMemoryRegex(TestCase):
             [(0x3FFFFFFE, b"foo")],
         )
 
+    @unittest.skipUnless(drgn._with_pcre2_utf, "PCRE2 does not support UTF-8")
     def test_str_valid_utf8(self):
         # 'ñ' is \xc3\xb1 in UTF-8. '±' is \xc2\xb1 in UTF-8. A Unicode search
         # for the former shouldn't match the \xb1 byte in the latter.
@@ -912,6 +913,7 @@ class TestSearchMemoryRegex(TestCase):
             list(prog.search_memory_regex(r"[a-zñ]+")), [(0x1000, "piñata")]
         )
 
+    @unittest.skipUnless(drgn._with_pcre2_utf, "PCRE2 does not support UTF-8")
     def test_invalid_utf8(self):
         prog = mock_search_memory_program(
             MockMemorySegment(b"\xc3\x28abcdef\xa0\xa1", 0x1000)
@@ -925,13 +927,13 @@ class TestSearchMemoryRegex(TestCase):
             ValueError,
             "lookbehind",
             mock_search_memory_program().search_memory_regex,
-            r"(?<=foo)bar",
+            rb"(?<=foo)bar",
         )
         self.assertRaisesRegex(
             ValueError,
             "lookbehind",
             mock_search_memory_program().search_memory_regex,
-            r"(?<!foo)bar",
+            rb"(?<!foo)bar",
         )
 
     def test_default_program(self):
@@ -942,7 +944,8 @@ class TestSearchMemoryRegex(TestCase):
                 list(search_memory_regex(rb"foo|bar")),
                 [(0x1000, b"foo"), (0x1004, b"bar")],
             )
-            self.assertEqual(
-                list(search_memory_regex(r"foo|bar")),
-                [(0x1000, "foo"), (0x1004, "bar")],
-            )
+            if drgn._with_pcre2_utf:
+                self.assertEqual(
+                    list(search_memory_regex(r"foo|bar")),
+                    [(0x1000, "foo"), (0x1004, "bar")],
+                )


### PR DESCRIPTION
PCRE2_MATCH_INVALID_UTF was added in PCRE 10.34, and Oracle Linux 8 has 10.32. This flag seems to be an enhancement but not required functionality. Don't use it when drgn is built against an old version, so we can still enable PCRE2 there.

---

While OL8 & friends are Python 3.6, they have a 3.12 interpreter available in the appstream repositories, so it's good to keep things buildable there too.

I did try another way of doing this, if you prefer, with this in `libdrgn/configure.ac`:
```
AC_MSG_CHECKING([for PCRE2_MATCH_INVALID_UTF])
AC_COMPILE_IFELSE(
	[AC_LANG_PROGRAM(
		[[
			#define PCRE2_CODE_UNIT_WIDTH 8
			#include <pcre2.h>
		]],
		[[uint32_t test = PCRE2_MATCH_INVALID_UTF;]]
	)],
	[
		AC_MSG_RESULT([yes])
		AC_DEFINE([HAVE_PCRE2_MATCH_INVALID_UTF], [1], [Define if PCRE2_MATCH_INVALID_UTF exists])
	],
	[
		AC_MSG_RESULT([no])
	]
)
```
But then I saw there were defines for the PCRE2 major/minor versions!

I tested this on Oracle Linux 8 rather quickly - prior to the patch, build fails, but with the patch, it succeeds, and the unit tests pass. I didn't go through to test specific unicode regexes, but I can do that tomorrow if you have concerns. I just wanted to post this so I could unstick our OL8 CI builds :)