### PR TITLE
libdrgn: use arch-specific hook for direct map offset

### DIFF
--- a/libdrgn/arch_x86_64.c
+++ b/libdrgn/arch_x86_64.c
@@ -529,9 +529,9 @@ apply_elf_reloc_x86_64(const struct drgn_relocating_section *relocating,
 }
 
 static struct drgn_error *
-linux_kernel_live_direct_mapping_fallback_x86_64(struct drgn_program *prog,
-						 uint64_t *address_ret,
-						 uint64_t *size_ret)
+linux_kernel_direct_mapping_x86_64(struct drgn_program *prog,
+				   uint64_t *address_ret,
+				   uint64_t *size_ret)
 {
 	struct drgn_error *err;
 
@@ -705,8 +705,8 @@ const struct drgn_architecture_info arch_info_x86_64 = {
 	.linux_kernel_get_initial_registers =
 		linux_kernel_get_initial_registers_x86_64,
 	.apply_elf_reloc = apply_elf_reloc_x86_64,
-	.linux_kernel_live_direct_mapping_fallback =
-		linux_kernel_live_direct_mapping_fallback_x86_64,
+	.linux_kernel_direct_mapping =
+		linux_kernel_direct_mapping_x86_64,
 	.linux_kernel_pgtable_iterator_create =
 		linux_kernel_pgtable_iterator_create_x86_64,
 	.linux_kernel_pgtable_iterator_destroy =

--- a/libdrgn/linux_kernel_helpers.c
+++ b/libdrgn/linux_kernel_helpers.c
@@ -73,6 +73,16 @@ struct drgn_error *linux_helper_direct_mapping_offset(struct drgn_program *prog,
 		return NULL;
 	}
 
+	if (prog->platform.arch->linux_kernel_direct_mapping) {
+		uint64_t size;
+		err = prog->platform.arch->linux_kernel_direct_mapping(
+			prog, &prog->direct_mapping_offset, &size);
+		if (err)
+			return err;
+		prog->direct_mapping_offset_cached = true;
+		*ret = prog->direct_mapping_offset;
+	}
+
 	// The direct mapping offset can vary depending on architecture, kernel
 	// version, configuration options, and KASLR. Rather than dealing with
 	// all of that, get a virtual address in the direct mapping and

--- a/libdrgn/platform.h
+++ b/libdrgn/platform.h
@@ -426,14 +426,17 @@ struct drgn_architecture_info {
 	apply_elf_reloc_fn *apply_elf_reloc;
 	/**
 	 * Return the address and size of the direct mapping virtual address
-	 * range.
+	 * range, if possible.
 	 *
-	 * This is a hack which is only called when debugging a live Linux
-	 * kernel older than v4.11.
+	 * This is only required when debugging a live Linux kernel older than
+	 * v4.11, to work around missing physical addresses in /proc/kcore.
+	 * Otherwise, it is still useful, as it can be a simpler way for @ref
+	 * linux_helper_direct_mapping_offset() to operate, without a page table
+	 * walk.
 	 */
-	struct drgn_error *(*linux_kernel_live_direct_mapping_fallback)(struct drgn_program *prog,
-									uint64_t *address_ret,
-									uint64_t *size_ret);
+	struct drgn_error *(*linux_kernel_direct_mapping)(struct drgn_program *prog,
+							  uint64_t *address_ret,
+							  uint64_t *size_ret);
 	/** Allocate a Linux kernel page table iterator. */
 	struct drgn_error *(*linux_kernel_pgtable_iterator_create)(struct drgn_program *,
 								   struct pgtable_iterator **);

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -593,11 +593,11 @@ drgn_program_set_core_dump_fd_internal(struct drgn_program *prog, int fd,
 	 * pass, as we may need to read virtual memory to determine the mapping.
 	 */
 	if (is_proc_kcore && !have_phys_addrs &&
-	    prog->platform.arch->linux_kernel_live_direct_mapping_fallback) {
+	    prog->platform.arch->linux_kernel_direct_mapping) {
 		uint64_t direct_mapping, direct_mapping_size;
-		err = prog->platform.arch->linux_kernel_live_direct_mapping_fallback(prog,
-										     &direct_mapping,
-										     &direct_mapping_size);
+		err = prog->platform.arch->linux_kernel_direct_mapping(prog,
+								       &direct_mapping,
+								       &direct_mapping_size);
 		if (err)
 			goto out_segments;
 


### PR DESCRIPTION
When debugging a Xen guest, I found that mm helpers relying on linux_helper_direct_mapping_offset() failed, because Xen guest page tables use host physical addresses, which confuses drgn's page table walk.

While supporting the Xen page tables may not be in the cards, we can at least avoid using a page table walk for this specific case. It turns out drgn already has an architecture-specific hook for finding the direct map offset. Apply it and avoid the page table walk here.

Fixes #598.

---
I've already tested this on an x86_64 all-flavors vmtest. I'm going to see about getting access to a similar Xen guest to verify it fixes my issue over in #598, but that doesn't need to block this, as it's a nice improvement regardless.