### PR TITLE
drgn.helpers.linux.net: add neigh_table_for_each_neigh

### DIFF
--- a/drgn/helpers/linux/net.py
+++ b/drgn/helpers/linux/net.py
@@ -40,6 +40,7 @@ __all__ = (
     "is_pp_page",
     "netdev_ipv4_addrs",
     "netdev_ipv6_addrs",
+    "neigh_table_for_each_neighbor",
 )
 
 
@@ -372,3 +373,28 @@ def netdev_ipv6_addrs(dev: Object) -> List[ipaddress.IPv6Address]:
             )
             ips.append(ipaddress.IPv6Address(addr_bytes))
     return ips
+
+
+def neigh_table_for_each_neighbor(table: Object) -> Iterator[Object]:
+    """
+    Get the neighbour object from the neighbour hash table
+
+    :param dev: ``struct neigh_hash_table *``
+    """
+    n_buckets = 1 << table.hash_shift.value_()
+    # Since Linux kernel commit 41b3caa7c076 ("neighbour: Add hlist_node to
+    # struct neighbour") (in v6.13), neighbors are in an hlist in struct
+    # neigh_hash_table::hash_heads. Before that, they are in a manual linked
+    # list in struct neigh_hash_table::hash_buckets.
+    try:
+        hash_heads = table.hash_heads
+    except AttributeError:
+        for neigh in table.hash_buckets[:n_buckets]:
+            while neigh := neigh.read_():
+                yield neigh
+                neigh = neigh.next
+    else:
+        for head in hash_heads[:n_buckets]:
+            yield from hlist_for_each_entry(
+                "struct neighbour", head.address_of_(), "hash"
+            )

--- a/tests/linux_kernel/helpers/test_net.py
+++ b/tests/linux_kernel/helpers/test_net.py
@@ -17,6 +17,7 @@ from drgn.helpers.linux.net import (
     for_each_netdev,
     get_net_ns_by_fd,
     is_pp_page,
+    neigh_table_for_each_neighbor,
     netdev_for_each_tx_queue,
     netdev_get_by_index,
     netdev_get_by_name,
@@ -33,6 +34,7 @@ from tests.linux_kernel import (
     create_socket,
     skip_unless_have_pyroute2,
     skip_unless_have_test_kmod,
+    temp_netns,
 )
 from util import KernelVersion
 
@@ -182,3 +184,33 @@ class TestNet(LinuxKernelTestCase):
             netdev_ipv6_addrs(netdev_get_by_name(self.prog, "lo")),
             expected,
         )
+
+    @skip_unless_have_pyroute2
+    def test_neigh_table_for_each_neighbor(self):
+        import pyroute2
+        import pyroute2.netlink.rtnl.ndmsg
+
+        with temp_netns() as (_, ns):
+            try:
+                ns.link("add", ifname="dummy0", kind="dummy")
+            except pyroute2.NetlinkError:
+                self.skipTest("kernel does not support dummy interface (CONFIG_DUMMY)")
+
+            try:
+                idx = ns.link_lookup(ifname="dummy0")[0]
+                # Add a permanent neighbor entry so there's something to find
+                ns.neigh(
+                    "add",
+                    dst="192.0.2.1",
+                    lladdr="00:11:22:33:44:55",
+                    ifindex=idx,
+                    state=pyroute2.netlink.rtnl.ndmsg.states["permanent"],
+                )
+                nht = self.prog["arp_tbl"].nht.read_()
+                neighbor_addrs = [
+                    ipaddress.IPv4Address(self.prog.read(n.primary_key.address_, 4))
+                    for n in neigh_table_for_each_neighbor(nht)
+                ]
+                self.assertIn(ipaddress.IPv4Address("192.0.2.1"), neighbor_addrs)
+            finally:
+                ns.link("delete", ifname="dummy0")


### PR DESCRIPTION
This helper is used to obtain neighbour objects from the neighbour hash table.