### PR TITLE
crash: handle KeyboardInterrupt

### DIFF
--- a/drgn/commands/_builtin/crash/__init__.py
+++ b/drgn/commands/_builtin/crash/__init__.py
@@ -100,9 +100,12 @@ def _cmd_crash(
                 while True:
                     try:
                         line = input("%crash> ")
+                        if not line or line.isspace():
+                            continue
                     except EOFError:
                         break
-                    if not line or line.isspace():
+                    except KeyboardInterrupt:
+                        print("^C")
                         continue
                     try:
                         CRASH_COMMAND_NAMESPACE.run(
@@ -111,6 +114,9 @@ def _cmd_crash(
                             globals=globals,
                             onerror=_crash_interactive_onerror,
                         )
+                    except KeyboardInterrupt:
+                        print()
+                        continue
                     except _ExitToCrash:
                         continue
         finally:


### PR DESCRIPTION
Crash and the Python REPL handle KeyboardInterrupt by interrupting the current command and returning to the prompt. Currently drgn does not handle it, leading to the following case when running a long-running search in drgn-crash:

    drgn-crash
    crash> search 0xdeafbeef
    Ctrl-C
    # crashes the whole program

If running within the "%crash" invoked from drgn, the failure case is less severe, because the outer REPL will catch the interrupt, but it's still confusing.

Let's handle this the way that crash does: a Ctrl-C in the middle of the "crash>" input generates the message "^C" and a new prompt. A Ctrl-C in the middle of a built-in command execution triggers a newline and a new prompt.