### PR TITLE
libdrgn: debug_info: clear primitive types on main module load

### DIFF
--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -1580,6 +1580,14 @@ drgn_module_maybe_use_elf_file(struct drgn_module *module,
 		prog->tried_main_language = false;
 		module->elf_symtab_pending_files |=
 			DRGN_MODULE_FILE_MASK_DEBUG;
+		// In case primitive types have been created by drgn before
+		// loading the main debug file (e.g. by reading VMCOREINFO),
+		// clear this cache so we can look them up from the debug info.
+		// See https://github.com/osandov/drgn/issues/569 for more
+		// details.
+		if (module->kind == DRGN_MODULE_MAIN)
+			memset(module->prog->primitive_types, 0,
+			       sizeof(module->prog->primitive_types));
 	}
 	if (!prog->has_platform) {
 		drgn_log_debug(prog, "setting program platform from %s",


### PR DESCRIPTION
With 0.0.34 pending I thought it might be nice to slip this fix in. I can't think of any reason why this would be a bad idea. Fixing this would at least allow the tests to pass when our Oracle debuginfo finder is installed, which is a nice benefit for my development laptop :)

---

When a primitive type is created prior to loading debuginfo, it gets cached for the duration of the program's lifetime. However, a "char" may be signed or unsigned, and drgn's choice may conflict with the one set in the debuginfo. This can cause errors down the line, for example with the kmodify helpers:

    TypeError: cannot convert 'char *' to incompatible type 'char *'

As a simple workaround, clear the cached primitive types when a runtime or debug file is loaded for the main module. In the worst case, this needlessly adds a small runtime overhead for accessing primitive types twice: once after loading a runtime file, and once after loading a debug file. The newly cached types will come from the debug info.

Fixes #569