### PR TITLE
libdrgn: riscv: Add support for stack undwinding

### DIFF
--- a/docs/support_matrix.rst
+++ b/docs/support_matrix.rst
@@ -42,7 +42,7 @@ of this support is:
       - ✓
     * - RISC-V
       - ✓
-      -
+      - ✓
       -
 
 .. rubric:: Key

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -18,6 +18,8 @@ include_HEADERS = drgn.h
 ARCH_DEFS_PYS = arch_aarch64_defs.py \
 		arch_arm_defs.py \
 		arch_ppc64_defs.py \
+		arch_riscv32_defs.py \
+		arch_riscv64_defs.py \
 		arch_s390x_defs.py \
 		arch_x86_64_defs.py
 
@@ -44,7 +46,7 @@ libdrgn_common_la_SOURCES = $(ARCH_DEFS_PYS:_defs.py=.c) \
 			    $(STRSWITCH_INCS) \
 			    accessors.c \
 			    arch_i386.c \
-			    arch_riscv.c \
+			    arch_riscv.h \
 			    array.h \
 			    binary_buffer.c \
 			    binary_buffer.h \

--- a/libdrgn/arch_riscv.h
+++ b/libdrgn/arch_riscv.h
@@ -8,12 +8,237 @@
 #include <elf.h>
 #include <string.h>
 
+#include "cfi.h"
+#include "error.h"
 #include "platform.h" // IWYU pragma: associated
+#include "program.h"
+#include "register_state.h"
 
 /*
  * The ABI specification can be found at:
  * https://github.com/riscv-non-isa/riscv-elf-psabi-doc
  */
+
+static const struct drgn_cfi_row default_dwarf_cfi_row_riscv = DRGN_CFI_ROW(
+	// The psABI defines the CFA as the value of sp in the calling frame.
+	[DRGN_REGISTER_NUMBER(x2)] = { DRGN_CFI_RULE_CFA_PLUS_OFFSET },
+	// Callee-saved registers default to DW_CFA_same_value. This isn't
+	// explicitly documented in the psABI, but it seems to be the consensus.
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x8)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x9)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x18)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x19)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x20)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x21)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x22)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x23)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x24)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x25)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x26)),
+	DRGN_CFI_SAME_VALUE_INIT(DRGN_REGISTER_NUMBER(x27)),
+);
+
+// elf_gregset_t (in PRSTATUS) and struct user_pt_regs have the same layout.
+// This layout is a prefix of the in-kernel struct pt_regs (but we don't care
+// about any of the extra fields).
+static struct drgn_error *
+get_initial_registers_from_struct_riscv(struct drgn_program *prog,
+					const void *buf, size_t size,
+					struct drgn_register_state **ret)
+{
+	size_t reg_size = DRGN_REGISTER_SIZE(pc);
+	if (size < 32 * reg_size) {
+		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+					 "registers are truncated");
+	}
+
+	struct drgn_register_state *regs =
+		drgn_register_state_create(pc, true);
+	if (!regs)
+		return &drgn_enomem;
+
+	drgn_register_state_set_from_buffer(regs, pc, buf);
+	drgn_register_state_set_from_buffer(regs, x2,
+					    (const char *)buf + 2 * reg_size);
+	drgn_register_state_set_range_from_buffer(regs, x5, x31,
+						  (const char *)buf + 5 * reg_size);
+	drgn_register_state_set_pc_from_register(prog, regs, pc);
+
+	*ret = regs;
+	return NULL;
+}
+
+static struct drgn_error *
+fallback_unwind_riscv(struct drgn_program *prog,
+		      struct drgn_register_state *regs,
+		      struct drgn_register_state **ret)
+{
+	struct drgn_error *err;
+	size_t reg_size = DRGN_REGISTER_SIZE(x8);
+
+	// The frame pointer is not required by the psABI, but is used in practice.
+	struct optional_uint64 fp =
+		drgn_register_state_get_u64(prog, regs, x8);
+	if (!fp.has_value)
+		return &drgn_stop;
+
+	// The frame pointer points to a frame record of two values (sized by
+	// register width). The first (lowest addressed) is the address of the
+	// caller's frame record. The second (highest addressed) is the saved
+	// return address.
+	char frame[16]; // Large enough for two 64-bit values
+	err = drgn_program_read_memory(prog, frame, fp.value, 2 * reg_size,
+				       false);
+
+	if (err) {
+		if (err->code == DRGN_ERROR_FAULT) {
+			drgn_error_destroy(err);
+			err = &drgn_stop;
+		}
+		return err;
+	}
+
+	uint64_t unwound_fp;
+	if (reg_size == 8) {
+		unwound_fp = drgn_platform_bswap(&prog->platform) ?
+			bswap_64(*(uint64_t *)frame) : *(uint64_t *)frame;
+	} else {
+		unwound_fp = drgn_platform_bswap(&prog->platform) ?
+			bswap_32(*(uint32_t *)frame) : *(uint32_t *)frame;
+	}
+
+	if (unwound_fp <= fp.value) {
+		// The unwound stack pointer is either 0, indicating the first
+		// stack frame, or invalid.
+		return &drgn_stop;
+	}
+
+	struct drgn_register_state *unwound =
+		drgn_register_state_create(x8, false);
+	if (!unwound)
+		return &drgn_enomem;
+
+	drgn_register_state_set_from_buffer(unwound, x1, frame + reg_size);
+	drgn_register_state_set_from_buffer(unwound, x8, frame);
+	drgn_register_state_set_pc_from_register(prog, unwound, x1);
+	// The psABI says the frame pointer points to the CFA, which is the
+	// stack pointer value on entry to the current procedure. So the
+	// caller's stack pointer at the call site is the current frame's fp.
+	drgn_register_state_set_from_u64(prog, unwound, x2, fp.value);
+	*ret = unwound;
+	return NULL;
+}
+
+// Unwind a single jal or jalr instruction.
+static struct drgn_error *
+bad_call_unwind_riscv(struct drgn_program *prog,
+		      struct drgn_register_state *regs,
+		      struct drgn_register_state **ret)
+{
+	struct drgn_error *err;
+
+	// The ABI does not require the return address to be in x1, but it generally
+	// is by convention.
+	struct optional_uint64 ra = drgn_register_state_get_u64(prog, regs, x1);
+	if (!ra.has_value)
+		return &drgn_stop;
+
+	struct drgn_register_state *tmp = drgn_register_state_dup(regs);
+	if (!tmp)
+		return &drgn_enomem;
+
+	// Get size of previous instruction by reading the instruction packet (previous 2 bytes)
+	// before ra.
+	uint16_t inst_packet;
+	err = drgn_program_read_memory(prog, &inst_packet, ra.value - 2, sizeof(inst_packet),
+				 false);
+	if (err) {
+		if (err->code == DRGN_ERROR_FAULT) {
+			drgn_error_destroy(err);
+			err = &drgn_stop;
+		}
+		return err;
+	}
+
+	// Instruction is 4 bytes if opcode ends in 0b11 and 2 bytes otherwise
+	uint32_t inst_size = (inst_packet & 0b11) == 0b11 ? 4 : 2;
+	// ra contains the old pc + size of instruction at old pc.
+	drgn_register_state_set_pc(prog, tmp, ra.value - inst_size);
+	// We don't know the old ra.
+	drgn_register_state_unset_has_register(tmp, DRGN_REGISTER_NUMBER(x1));
+	// The interrupted pc is no longer applicable.
+	drgn_register_state_unset_has_register(tmp, DRGN_REGISTER_NUMBER(pc));
+	*ret = tmp;
+	return NULL;
+}
+
+static struct drgn_error *
+pt_regs_get_initial_registers_riscv(const struct drgn_object *obj,
+				    struct drgn_register_state **ret)
+{
+	return get_initial_registers_from_struct_riscv(drgn_object_program(obj),
+						       drgn_object_buffer(obj),
+						       drgn_object_size(obj),
+						       ret);
+}
+
+static struct drgn_error *
+prstatus_get_initial_registers_riscv(struct drgn_program *prog,
+				     const void *prstatus, size_t size,
+				     struct drgn_register_state **ret)
+{
+	// offsetof(struct elf_prstatus, pr_reg)
+	static const size_t pr_reg_offset = 112;
+	if (size < pr_reg_offset) {
+		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+					 "NT_PRSTATUS is truncated");
+	}
+	return get_initial_registers_from_struct_riscv(prog,
+						       (const char *)prstatus + pr_reg_offset,
+						       size - pr_reg_offset,
+						       ret);
+}
+
+// The Linux kernel saves the callee-saved registers in
+// struct task_struct.thread.
+static struct drgn_error *
+linux_kernel_get_initial_registers_riscv(const struct drgn_object *task_obj,
+					 struct drgn_register_state **ret)
+{
+	struct drgn_error *err;
+	struct drgn_program *prog = drgn_object_program(task_obj);
+	size_t reg_size = DRGN_REGISTER_SIZE(x1);
+
+	DRGN_OBJECT(thread_obj, prog);
+
+	err = drgn_object_member_dereference(&thread_obj, task_obj,
+					     "thread");
+	if (err)
+		return err;
+
+	if (thread_obj.encoding != DRGN_OBJECT_ENCODING_BUFFER ||
+	    drgn_object_size(&thread_obj) < 14 * reg_size) {
+		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+					 "thread is truncated");
+	}
+	err = drgn_object_read(&thread_obj, &thread_obj);
+	if (err)
+		return err;
+
+	const char *buf = drgn_object_buffer(&thread_obj);
+	struct drgn_register_state *regs =
+		drgn_register_state_create(x27, false);
+	if (!regs)
+		return &drgn_enomem;
+
+	drgn_register_state_set_from_buffer(regs, x1, buf);
+	drgn_register_state_set_from_buffer(regs, x2, buf + reg_size);
+	drgn_register_state_set_range_from_buffer(regs, x8, x9, buf + 2 * reg_size);
+	drgn_register_state_set_range_from_buffer(regs, x18, x27, buf + 4 * reg_size);
+	drgn_register_state_set_pc_from_register(prog, regs, x1);
+	*ret = regs;
+	return NULL;
+}
 
 static struct drgn_error drgn_invalid_rel = {
 	.code = DRGN_ERROR_OTHER,

--- a/libdrgn/arch_riscv.h
+++ b/libdrgn/arch_riscv.h
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#ifndef DRGN_ARCH_RISCV_H
+#define DRGN_ARCH_RISCV_H
+
 #include <byteswap.h>
 #include <elf.h>
 #include <string.h>
@@ -110,21 +113,4 @@ apply_elf_reloc_riscv(const struct drgn_relocating_section *relocating,
 	}
 }
 
-const struct drgn_architecture_info arch_info_riscv64 = {
-	.name = "RISC-V 64",
-	.arch = DRGN_ARCH_RISCV64,
-	.default_flags = (DRGN_PLATFORM_IS_64_BIT |
-			  DRGN_PLATFORM_IS_LITTLE_ENDIAN),
-	.scalar_alignment = { 1, 2, 4, 8, 16 },
-	.register_by_name = drgn_register_by_name_unknown,
-	.apply_elf_reloc = apply_elf_reloc_riscv,
-};
-
-const struct drgn_architecture_info arch_info_riscv32 = {
-	.name = "RISC-V 32",
-	.arch = DRGN_ARCH_RISCV32,
-	.scalar_alignment = { 1, 2, 4, 8, 16 },
-	.default_flags = DRGN_PLATFORM_IS_LITTLE_ENDIAN,
-	.register_by_name = drgn_register_by_name_unknown,
-	.apply_elf_reloc = apply_elf_reloc_riscv,
-};
+#endif /* DRGN_ARCH_RISCV_H */

--- a/libdrgn/arch_riscv32.c
+++ b/libdrgn/arch_riscv32.c
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "platform.h" // IWYU pragma: associated
+
+// Include the defs first so register macros are available to arch_riscv.h
+#include "arch_riscv32_defs.inc"
+#include "arch_riscv.h"
+
+const struct drgn_architecture_info arch_info_riscv32 = {
+	.name = "RISC-V 32",
+	.arch = DRGN_ARCH_RISCV32,
+	.default_flags = DRGN_PLATFORM_IS_LITTLE_ENDIAN,
+	.scalar_alignment = { 1, 2, 4, 8, 16 },
+	DRGN_ARCHITECTURE_REGISTERS,
+};

--- a/libdrgn/arch_riscv32.c
+++ b/libdrgn/arch_riscv32.c
@@ -13,4 +13,11 @@ const struct drgn_architecture_info arch_info_riscv32 = {
 	.default_flags = DRGN_PLATFORM_IS_LITTLE_ENDIAN,
 	.scalar_alignment = { 1, 2, 4, 8, 16 },
 	DRGN_ARCHITECTURE_REGISTERS,
+	.apply_elf_reloc = apply_elf_reloc_riscv,
+	.default_dwarf_cfi_row = &default_dwarf_cfi_row_riscv,
+	.fallback_unwind = fallback_unwind_riscv,
+	.bad_call_unwind = bad_call_unwind_riscv,
+	.pt_regs_get_initial_registers = pt_regs_get_initial_registers_riscv,
+	.prstatus_get_initial_registers = prstatus_get_initial_registers_riscv,
+	.linux_kernel_get_initial_registers = linux_kernel_get_initial_registers_riscv,
 };

--- a/libdrgn/arch_riscv32_defs.py
+++ b/libdrgn/arch_riscv32_defs.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+REGISTERS = [
+    DrgnRegister(["x0", "zero"]),
+    DrgnRegister(["x1", "ra"]),
+    DrgnRegister(["x2", "sp"]),
+    DrgnRegister(["x3", "gp"]),
+    DrgnRegister(["x4", "tp"]),
+    *[DrgnRegister([f"x{i+5}", f"t{i}"]) for i in range(3)],
+    DrgnRegister(["x8", "fp", "s0"]),
+    DrgnRegister(["x9", "s1"]),
+    *[DrgnRegister([f"x{i+10}", f"a{i}"]) for i in range(8)],
+    *[DrgnRegister([f"x{i+18}", f"s{i+2}"]) for i in range(0, 10)],
+    *[DrgnRegister([f"x{i+28}", f"t{i+3}"]) for i in range(0, 3)],
+    DrgnRegister("pc"),
+]
+
+REGISTER_LAYOUT = [
+    *[DrgnRegisterLayout(f"x{i}", size=4, dwarf_number=i) for i in range(0, 32)],
+    DrgnRegisterLayout("pc", size=4, dwarf_number=None),
+]
+
+STACK_POINTER_REGISTER = "x2"

--- a/libdrgn/arch_riscv64.c
+++ b/libdrgn/arch_riscv64.c
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "platform.h" // IWYU pragma: associated
+
+// Include the defs first so register macros are available to arch_riscv.h
+#include "arch_riscv64_defs.inc"
+#include "arch_riscv.h"
+
+const struct drgn_architecture_info arch_info_riscv64 = {
+	.name = "RISC-V 64",
+	.arch = DRGN_ARCH_RISCV64,
+	.default_flags = (DRGN_PLATFORM_IS_64_BIT |
+			  DRGN_PLATFORM_IS_LITTLE_ENDIAN),
+	.scalar_alignment = { 1, 2, 4, 8, 16 },
+	DRGN_ARCHITECTURE_REGISTERS,
+};

--- a/libdrgn/arch_riscv64.c
+++ b/libdrgn/arch_riscv64.c
@@ -14,4 +14,11 @@ const struct drgn_architecture_info arch_info_riscv64 = {
 			  DRGN_PLATFORM_IS_LITTLE_ENDIAN),
 	.scalar_alignment = { 1, 2, 4, 8, 16 },
 	DRGN_ARCHITECTURE_REGISTERS,
+	.apply_elf_reloc = apply_elf_reloc_riscv,
+	.default_dwarf_cfi_row = &default_dwarf_cfi_row_riscv,
+	.fallback_unwind = fallback_unwind_riscv,
+	.bad_call_unwind = bad_call_unwind_riscv,
+	.pt_regs_get_initial_registers = pt_regs_get_initial_registers_riscv,
+	.prstatus_get_initial_registers = prstatus_get_initial_registers_riscv,
+	.linux_kernel_get_initial_registers = linux_kernel_get_initial_registers_riscv,
 };

--- a/libdrgn/arch_riscv64_defs.py
+++ b/libdrgn/arch_riscv64_defs.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+REGISTERS = [
+    DrgnRegister(["x0", "zero"]),
+    DrgnRegister(["x1", "ra"]),
+    DrgnRegister(["x2", "sp"]),
+    DrgnRegister(["x3", "gp"]),
+    DrgnRegister(["x4", "tp"]),
+    *[DrgnRegister([f"x{i+5}", f"t{i}"]) for i in range(3)],
+    DrgnRegister(["x8", "fp", "s0"]),
+    DrgnRegister(["x9", "s1"]),
+    *[DrgnRegister([f"x{i+10}", f"a{i}"]) for i in range(8)],
+    *[DrgnRegister([f"x{i+18}", f"s{i+2}"]) for i in range(0, 10)],
+    *[DrgnRegister([f"x{i+28}", f"t{i+3}"]) for i in range(0, 3)],
+    DrgnRegister("pc"),
+]
+
+REGISTER_LAYOUT = [
+    *[DrgnRegisterLayout(f"x{i}", size=8, dwarf_number=i) for i in range(0, 32)],
+    DrgnRegisterLayout("pc", size=8, dwarf_number=None),
+]
+
+STACK_POINTER_REGISTER = "x2"

--- a/libdrgn/platform.h
+++ b/libdrgn/platform.h
@@ -163,7 +163,7 @@ typedef struct drgn_error *
  * - Add a `DRGN_ARCH_FOO` enumerator to @ref drgn_architecture.
  * - Add the constant to `class Architecture` in `_drgn.pyi`.
  * - Create a new `libdrgn/arch_foo.c` file and add it to
- *   `libdrgnimpl_la_SOURCES` in `libdrgn/Makefile.am`.
+ *   `libdrgn_common_la_SOURCES` in `libdrgn/Makefile.am`.
  * - Define `struct drgn_architecture_info arch_info_foo` in
  *   `libdrgn/arch_foo.c` with the following members:
  *     - @ref name
@@ -187,7 +187,7 @@ typedef struct drgn_error *
  * - Create a new `libdrgn/arch_foo_defs.py` file. See
  *   `libdrgn/build-aux/gen_arch_inc_strswitch.py`.
  * - Add `arch_foo_defs.py` to `ARCH_DEFS_PYS` and remove `libdrgn/arch_foo.c`
- *   from `libdrgnimpl_la_SOURCES` in `libdrgn/Makefile.am`.
+ *   from `libdrgn_common_la_SOURCES` in `libdrgn/Makefile.am`.
  * - Add `#include "arch_foo_defs.inc"` to `libdrgn/arch_foo.c`.
  * - Add `DRGN_ARCHITECTURE_REGISTERS` to `arch_info_foo` and remove @ref
  *   register_by_name.

--- a/tests/linux_kernel/__init__.py
+++ b/tests/linux_kernel/__init__.py
@@ -168,7 +168,8 @@ skip_if_highpte = skip_if_highmem
 
 # Please keep this in sync with docs/support_matrix.rst.
 skip_unless_have_stack_tracing = unittest.skipUnless(
-    NORMALIZED_MACHINE_NAME in {"aarch64", "arm", "ppc64", "s390x", "x86_64"},
+    NORMALIZED_MACHINE_NAME
+    in {"aarch64", "arm", "ppc64", "s390x", "x86_64", "riscv64"},
     f"stack tracing is not implemented for {NORMALIZED_MACHINE_NAME}",
 )
 

--- a/tests/linux_kernel/crash_commands/test_bt.py
+++ b/tests/linux_kernel/crash_commands/test_bt.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from tests.linux_kernel import (
+    HAVE_FULL_MM_SUPPORT,
     fork_and_stop,
     skip_unless_have_stack_tracing,
     skip_unless_have_test_kmod,
@@ -59,12 +60,13 @@ class TestBt(CrashCommandTestCase):
         self.assertIn("drgn_test_kthread_fn+", cmd.stdout)
         self.assertIn("drgn_test_kthread_fn2+", cmd.stdout)
         self.assertIn("drgn_test_kthread_fn3+", cmd.stdout)
-        # We also know we will find the drgn small slab object, but whether it
-        # can be identified depends on kernel configuration (non-SLOB)
-        if self.prog["drgn_test_slob"]:
-            self.assertIn("[unknown slab object]", cmd.stdout)
-        else:
-            self.assertIn("[drgn_test_small]", cmd.stdout)
+        if HAVE_FULL_MM_SUPPORT:
+            # We also know we will find the drgn small slab object, but whether it
+            # can be identified depends on kernel configuration (non-SLOB)
+            if self.prog["drgn_test_slob"]:
+                self.assertIn("[unknown slab object]", cmd.stdout)
+            else:
+                self.assertIn("[drgn_test_small]", cmd.stdout)
 
     @skip_unless_have_test_kmod
     def test_frame_data_verbose(self):
@@ -74,12 +76,13 @@ class TestBt(CrashCommandTestCase):
         self.assertIn("drgn_test_kthread_fn+", cmd.stdout)
         self.assertIn("drgn_test_kthread_fn2+", cmd.stdout)
         self.assertIn("drgn_test_kthread_fn3+", cmd.stdout)
-        # We also know we will find the drgn small slab object, but whether it
-        # can be identified depends on kernel configuration (non-SLOB)
-        if self.prog["drgn_test_slob"]:
-            self.assertRegex(cmd.stdout, r"\[[0-9a-f]+:unknown slab object\]")
-        else:
-            self.assertRegex(cmd.stdout, r"\[[0-9a-f]+:drgn_test_small\]")
+        if HAVE_FULL_MM_SUPPORT:
+            # We also know we will find the drgn small slab object, but whether it
+            # can be identified depends on kernel configuration (non-SLOB)
+            if self.prog["drgn_test_slob"]:
+                self.assertRegex(cmd.stdout, r"\[[0-9a-f]+:unknown slab object\]")
+            else:
+                self.assertRegex(cmd.stdout, r"\[[0-9a-f]+:drgn_test_small\]")
 
     @skip_unless_have_test_kmod
     def test_line_numbers(self):

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -1970,6 +1970,54 @@ static inline void drgn_test_get_pt_regs(struct pt_regs *regs)
 	asm volatile("movl %%cs, %%eax;" :"=a"(regs->cs));
 	asm volatile("pushfq; popq %0" :"=m"(regs->flags));
 	regs->ip = _THIS_IP_;
+#elif defined(__riscv)
+	unsigned long tmp;
+
+	asm volatile (
+		"auipc %1, 0x0\n"
+		REG_S " %1,  %0"
+		: "=m"(regs->epc), "=&r" (tmp)
+	);
+	asm volatile (REG_S " ra,  %0" : "=m"(regs->ra));
+	asm volatile (REG_S " sp,  %0" : "=m"(regs->sp));
+	asm volatile (REG_S " gp,  %0" : "=m"(regs->gp));
+	asm volatile (REG_S " tp,  %0" : "=m"(regs->tp));
+	asm volatile (REG_S " t0,  %0" : "=m"(regs->t0));
+	asm volatile (REG_S " t1,  %0" : "=m"(regs->t1));
+	asm volatile (REG_S " t2,  %0" : "=m"(regs->t2));
+	asm volatile (REG_S " s0,  %0" : "=m"(regs->s0));
+	asm volatile (REG_S " s1,  %0" : "=m"(regs->s1));
+	asm volatile (REG_S " a0,  %0" : "=m"(regs->a0));
+	asm volatile (REG_S " a1,  %0" : "=m"(regs->a1));
+	asm volatile (REG_S " a2,  %0" : "=m"(regs->a2));
+	asm volatile (REG_S " a3,  %0" : "=m"(regs->a3));
+	asm volatile (REG_S " a4,  %0" : "=m"(regs->a4));
+	asm volatile (REG_S " a5,  %0" : "=m"(regs->a5));
+	asm volatile (REG_S " a6,  %0" : "=m"(regs->a6));
+	asm volatile (REG_S " a7,  %0" : "=m"(regs->a7));
+	asm volatile (REG_S " s2,  %0" : "=m"(regs->s2));
+	asm volatile (REG_S " s3,  %0" : "=m"(regs->s3));
+	asm volatile (REG_S " s4,  %0" : "=m"(regs->s4));
+	asm volatile (REG_S " s5,  %0" : "=m"(regs->s5));
+	asm volatile (REG_S " s6,  %0" : "=m"(regs->s6));
+	asm volatile (REG_S " s7,  %0" : "=m"(regs->s7));
+	asm volatile (REG_S " s8,  %0" : "=m"(regs->s8));
+	asm volatile (REG_S " s9,  %0" : "=m"(regs->s9));
+	asm volatile (REG_S " s10, %0" : "=m"(regs->s10));
+	asm volatile (REG_S " s11, %0" : "=m"(regs->s11));
+	asm volatile (REG_S " t3,  %0" : "=m"(regs->t3));
+	asm volatile (REG_S " t4,  %0" : "=m"(regs->t4));
+	asm volatile (REG_S " t5,  %0" : "=m"(regs->t5));
+	asm volatile (REG_S " t6,  %0" : "=m"(regs->t6));
+
+	unsigned long status = csr_read(CSR_STATUS);
+	asm volatile (REG_S " %1,  %0" : "=m"(regs->status) : "r" (status));
+
+	unsigned long badaddr = csr_read(CSR_TVAL);
+	asm volatile (REG_S " %1,  %0" : "=m"(regs->badaddr) : "r" (badaddr));
+
+	unsigned long cause = csr_read(CSR_CAUSE);
+	asm volatile (REG_S " %1,  %0" : "=m"(regs->cause) : "r" (cause));
 #endif
 }
 


### PR DESCRIPTION
Introduce riscv register definitions and add the helper functions to support stack unwinding.