### PR TITLE
helpers/linux: add sysfs lookup and directory traversal helpers

### DIFF
--- a/drgn/helpers/linux/sysfs.py
+++ b/drgn/helpers/linux/sysfs.py
@@ -1,0 +1,128 @@
+# (C) Copyright IBM Corp. 2026
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Sysfs
+-----
+
+The ``drgn.helpers.linux.sysfs`` module provides helpers for working with
+the sysfs interface built on top of kernfs.
+"""
+
+from typing import List, Optional
+
+from drgn import NULL, Object, Program, cast, container_of
+from drgn.helpers.common.prog import takes_program_or_default
+from drgn.helpers.linux.kernfs import (
+    _kernfs_node_type,
+    kernfs_children,
+    kernfs_parent,
+    kernfs_walk,
+)
+
+__all__ = (
+    "sysfs_lookup_node",
+    "sysfs_lookup_kobject",
+    "sysfs_lookup",
+    "sysfs_listdir",
+)
+
+
+@takes_program_or_default
+def sysfs_lookup_node(prog: Program, path: str) -> Object:
+    """
+    Look up a ``struct kernfs_node *`` for a given sysfs path.
+
+    The path may be provided either relative to ``/sys`` (e.g.,
+    ``devices/system/cpu``) or as an absolute path beginning with
+    ``/sys``.
+
+    If the path is empty or refers to ``/sys`` itself, this returns
+    the sysfs root node.
+
+    :param path: Sysfs path (absolute or relative to ``/sys``)
+    :return: ``struct kernfs_node *`` or ``NULL``
+    """
+    root_kn = prog["sysfs_root_kn"]
+
+    if path.startswith("/"):
+        path = path.lstrip("/")
+        if path == "sys":
+            path = ""
+        elif path.startswith("sys/"):
+            path = path[4:].lstrip("/")
+        else:
+            return NULL(prog, "struct kernfs_node *")
+
+    return kernfs_walk(root_kn, path)
+
+
+@takes_program_or_default
+def sysfs_lookup_kobject(prog: Program, path: str) -> Optional[Object]:
+    """
+    Look up the ``struct kobject *`` corresponding to a sysfs path.
+
+    If the path refers to a directory, this returns ``kn->priv``.
+    If the path refers to a file (attribute), this returns the
+    parent kobject (i.e., the parent node’s ``priv``)
+
+    :param path: Sysfs path (absolute or relative to ``/sys``)
+    :return: ``struct kobject *`` or ``NULL``
+    """
+    kn = sysfs_lookup_node(prog, path)
+    if not kn:
+        return NULL(prog, "struct kobject *")
+
+    if _kernfs_node_type(kn, "KERNFS_DIR"):
+        return cast("struct kobject *", kn.priv)
+
+    parent = kernfs_parent(kn)
+    if not parent:
+        return NULL(prog, "struct kobject *")
+
+    return cast("struct kobject *", parent.priv)
+
+
+@takes_program_or_default
+def sysfs_lookup(prog: Program, path: str) -> Optional[Object]:
+    """
+    Look up the object represented by a sysfs path.
+
+    If the resolved kobject corresponds to a ``struct device``,
+    return the containing ``struct device *``. Otherwise, return
+    the ``struct kobject *``.
+
+    Note: This may return more specific types for other cases in the future.
+
+    :param path: Sysfs path (absolute or relative to ``/sys``)
+    :return: ``struct device *`` or ``struct kobject *`` or ``NULL``
+    """
+    kobj = sysfs_lookup_kobject(prog, path)
+    if not kobj:
+        return NULL(prog, "struct kobject *")
+
+    try:
+        device_ktype = prog["device_ktype"].address_of_()
+    except KeyError:
+        pass
+    else:
+        if kobj.ktype == device_ktype:
+            return container_of(kobj, "struct device", "kobj")
+
+    return kobj
+
+
+@takes_program_or_default
+def sysfs_listdir(prog: Program, path: str) -> List[bytes]:
+    """
+    List the children of a sysfs directory.
+
+    :param path: Sysfs directory path (absolute or relative to ``/sys``)
+    :return: List of child entry names
+    :raises ValueError: If path is not found or not a directory
+    """
+    kn = sysfs_lookup_node(prog, path)
+    if not kn:
+        raise ValueError(f"{path}: not found")
+
+    return [child.name.string_() for child in kernfs_children(kn)]

--- a/drgn/helpers/linux/sysfs.py
+++ b/drgn/helpers/linux/sysfs.py
@@ -88,19 +88,32 @@ def sysfs_lookup(prog: Program, path: str) -> Optional[Object]:
     """
     Look up the object represented by a sysfs path.
 
-    If the resolved kobject corresponds to a ``struct device``,
-    return the containing ``struct device *``. Otherwise, return
-    the ``struct kobject *``.
+    Resolve the ``struct kobject`` corresponding to a sysfs entry and,
+    when possible, return the kernel structure which contains that
+    kobject.
 
     Note: This may return more specific types for other cases in the future.
 
+    Depending on the kobject type, this helper may return:
+
+    - ``struct device *``
+    - ``struct class *``
+    - ``struct bus_type *``
+    - ``struct device_driver *``
+    - ``struct module_kobject *``
+
+    If the kobject type does not correspond to a known container
+    structure, the function returns the ``struct kobject *``.
+
     :param path: Sysfs path (absolute or relative to ``/sys``)
-    :return: ``struct device *`` or ``struct kobject *`` or ``NULL``
+    :return: Corresponding container structure pointer or
+        ``struct kobject *`` or ``NULL``
     """
     kobj = sysfs_lookup_kobject(prog, path)
     if not kobj:
         return NULL(prog, "struct kobject *")
 
+    # device
     try:
         device_ktype = prog["device_ktype"].address_of_()
     except KeyError:
@@ -108,6 +121,47 @@ def sysfs_lookup(prog: Program, path: str) -> Optional[Object]:
     else:
         if kobj.ktype == device_ktype:
             return container_of(kobj, "struct device", "kobj")
+
+    # module
+    try:
+        module_ktype = prog["module_ktype"].address_of_()
+    except KeyError:
+        pass
+    else:
+        if kobj.ktype == module_ktype:
+            return container_of(kobj, "struct module_kobject", "kobj")
+
+    # driver
+    try:
+        driver_ktype = prog["driver_ktype"].address_of_()
+    except KeyError:
+        pass
+    else:
+        if kobj.ktype == driver_ktype:
+            drv_priv = container_of(kobj, "struct driver_private", "kobj")
+            return drv_priv.driver
+
+    # class
+    try:
+        class_ktype = prog["class_ktype"].address_of_()
+    except KeyError:
+        pass
+    else:
+        if kobj.ktype == class_ktype:
+            kset = container_of(kobj, "struct kset", "kobj")
+            subsys = container_of(kset, "struct subsys_private", "subsys")
+            return getattr(subsys, "class")
+
+    # bus
+    try:
+        bus_ktype = prog["bus_ktype"].address_of_()
+    except KeyError:
+        pass
+    else:
+        if kobj.ktype == bus_ktype:
+            kset = container_of(kobj, "struct kset", "kobj")
+            subsys = container_of(kset, "struct subsys_private", "subsys")
+            return subsys.bus
 
     return kobj
 

--- a/tests/linux_kernel/helpers/test_sysfs.py
+++ b/tests/linux_kernel/helpers/test_sysfs.py
@@ -16,14 +16,15 @@ from tests.linux_kernel import LinuxKernelTestCase
 class TestSysfs(LinuxKernelTestCase):
     @classmethod
     def kernfs_node_from_fd(cls, fd):
+        import os
+
+        from drgn import cast
         from drgn.helpers.linux.fs import fget
         from drgn.helpers.linux.pid import find_task
-        from drgn import cast
-        import os
 
         file = fget(find_task(cls.prog, os.getpid()), fd)
         return cast("struct kernfs_node *", file.f_inode.i_private)
-    
+
     def test_sysfs_lookup_node(self):
         fds = []
         try:
@@ -165,6 +166,60 @@ class TestSysfs(LinuxKernelTestCase):
                         dev = sysfs_lookup(self.prog, entry.path[5:])
                         self.assertTrue(dev)
                         self.assertEqual(dev.type_.type_name(), "struct device *")
+
+        # Module case
+        if "module_ktype" in self.prog:
+            path = "/sys/module"
+            if os.path.exists(path):
+                with os.scandir(path) as entries:
+                    entry = next((e for e in entries if e.is_dir()), None)
+                    if entry:
+                        mod = sysfs_lookup(self.prog, entry.path[5:])
+                        self.assertTrue(mod)
+                        self.assertEqual(
+                            mod.type_.type_name(), "struct module_kobject *"
+                        )
+
+        # Driver case
+        if "driver_ktype" in self.prog:
+            path = "/sys/bus"
+            if os.path.exists(path):
+                with os.scandir(path) as buses:
+                    bus = next((b for b in buses if b.is_dir()), None)
+                    if bus:
+                        drv_dir = os.path.join(bus.path, "drivers")
+                        if os.path.exists(drv_dir):
+                            with os.scandir(drv_dir) as drivers:
+                                drv = next((d for d in drivers if d.is_dir()), None)
+                                if drv:
+                                    driver = sysfs_lookup(self.prog, drv.path[5:])
+                                    self.assertTrue(driver)
+                                    self.assertEqual(
+                                        driver.type_.type_name(),
+                                        "struct device_driver *",
+                                    )
+
+        # Class case
+        if "class_ktype" in self.prog:
+            path = "/sys/class"
+            if os.path.exists(path):
+                with os.scandir(path) as entries:
+                    entry = next((e for e in entries if e.is_dir()), None)
+                    if entry:
+                        cls = sysfs_lookup(self.prog, entry.path[5:])
+                        self.assertTrue(cls)
+                        self.assertIn("struct class *", cls.type_.type_name())
+
+        # Bus case
+        if "bus_ktype" in self.prog:
+            path = "/sys/bus"
+            if os.path.exists(path):
+                with os.scandir(path) as entries:
+                    entry = next((e for e in entries if e.is_dir()), None)
+                    if entry:
+                        bus = sysfs_lookup(self.prog, entry.path[5:])
+                        self.assertTrue(bus)
+                        self.assertIn("struct bus_type *", bus.type_.type_name())
 
     def test_sysfs_listdir(self):
         expected = os.listdir(b"/sys/kernel")

--- a/tests/linux_kernel/helpers/test_sysfs.py
+++ b/tests/linux_kernel/helpers/test_sysfs.py
@@ -1,0 +1,183 @@
+# (C) Copyright IBM Corp. 2026
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+
+from drgn import NULL
+from drgn.helpers.linux.sysfs import (
+    sysfs_listdir,
+    sysfs_lookup,
+    sysfs_lookup_kobject,
+    sysfs_lookup_node,
+)
+from tests.linux_kernel import LinuxKernelTestCase
+
+
+class TestSysfs(LinuxKernelTestCase):
+    @classmethod
+    def kernfs_node_from_fd(cls, fd):
+        from drgn.helpers.linux.fs import fget
+        from drgn.helpers.linux.pid import find_task
+        from drgn import cast
+        import os
+
+        file = fget(find_task(cls.prog, os.getpid()), fd)
+        return cast("struct kernfs_node *", file.f_inode.i_private)
+    
+    def test_sysfs_lookup_node(self):
+        fds = []
+        try:
+            for path in ("/sys", "/sys/kernel", "/sys/kernel/vmcoreinfo"):
+                fds.append(os.open(path, os.O_RDONLY))
+
+            kns = [self.kernfs_node_from_fd(fd) for fd in fds]
+
+            self.assertEqual(sysfs_lookup_node(self.prog, ""), kns[0])
+            self.assertEqual(sysfs_lookup_node(self.prog, "/sys"), kns[0])
+            self.assertEqual(sysfs_lookup_node(self.prog, "/sys/"), kns[0])
+
+            self.assertEqual(sysfs_lookup_node(self.prog, "kernel"), kns[1])
+            self.assertEqual(sysfs_lookup_node(self.prog, "/sys/kernel"), kns[1])
+            self.assertEqual(
+                sysfs_lookup_node(self.prog, "sys/kernel"),
+                NULL(self.prog, "struct kernfs_node *"),
+            )
+
+            self.assertEqual(sysfs_lookup_node(self.prog, "kernel/vmcoreinfo"), kns[2])
+            self.assertEqual(
+                sysfs_lookup_node(self.prog, "/sys/kernel/vmcoreinfo"), kns[2]
+            )
+            self.assertEqual(
+                sysfs_lookup_node(self.prog, "sys/kernel/vmcoreinfo"),
+                NULL(self.prog, "struct kernfs_node *"),
+            )
+
+            self.assertEqual(
+                sysfs_lookup_node(self.prog, "/kernel"),
+                NULL(self.prog, "struct kernfs_node *"),
+            )
+            self.assertEqual(
+                sysfs_lookup_node(self.prog, "kernel/foobar"),
+                NULL(self.prog, "struct kernfs_node *"),
+            )
+
+        finally:
+            for fd in fds:
+                os.close(fd)
+
+    def test_sysfs_lookup_kobject(self):
+        kernel_kobj = self.prog["kernel_kobj"]
+
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, ""), NULL(self.prog, "struct kobject *")
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "/sys"), NULL(self.prog, "struct kobject *")
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "/sys/"),
+            NULL(self.prog, "struct kobject *"),
+        )
+
+        self.assertEqual(sysfs_lookup_kobject(self.prog, "kernel"), kernel_kobj)
+        self.assertEqual(sysfs_lookup_kobject(self.prog, "/sys/kernel"), kernel_kobj)
+
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "kernel/vmcoreinfo"), kernel_kobj
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "/sys/kernel/vmcoreinfo"), kernel_kobj
+        )
+
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "kernel"),
+            sysfs_lookup_kobject(self.prog, "kernel/vmcoreinfo"),
+        )
+
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "sys/kernel"),
+            NULL(self.prog, "struct kobject *"),
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "sys/kernel/vmcoreinfo"),
+            NULL(self.prog, "struct kobject *"),
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "/"),
+            NULL(self.prog, "struct kobject *"),
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "/kernel"),
+            NULL(self.prog, "struct kobject *"),
+        )
+        self.assertEqual(
+            sysfs_lookup_kobject(self.prog, "kernel/foobar"),
+            NULL(self.prog, "struct kobject *"),
+        )
+
+    def test_sysfs_lookup(self):
+        kernel_kobj = self.prog["kernel_kobj"]
+
+        self.assertEqual(
+            sysfs_lookup(self.prog, ""), NULL(self.prog, "struct kobject *")
+        )
+        self.assertEqual(
+            sysfs_lookup(self.prog, "/sys"), NULL(self.prog, "struct kobject *")
+        )
+        self.assertEqual(
+            sysfs_lookup(self.prog, "/sys/"), NULL(self.prog, "struct kobject *")
+        )
+
+        self.assertEqual(sysfs_lookup(self.prog, "kernel"), kernel_kobj)
+        self.assertEqual(sysfs_lookup(self.prog, "/sys/kernel"), kernel_kobj)
+
+        self.assertEqual(sysfs_lookup(self.prog, "kernel/vmcoreinfo"), kernel_kobj)
+        self.assertEqual(sysfs_lookup(self.prog, "/sys/kernel/vmcoreinfo"), kernel_kobj)
+
+        self.assertEqual(
+            sysfs_lookup(self.prog, "kernel"),
+            sysfs_lookup(self.prog, "kernel/vmcoreinfo"),
+        )
+
+        self.assertEqual(
+            sysfs_lookup(self.prog, "sys/kernel"),
+            NULL(self.prog, "struct kobject *"),
+        )
+        self.assertEqual(
+            sysfs_lookup(self.prog, "sys/kernel/vmcoreinfo"),
+            NULL(self.prog, "struct kobject *"),
+        )
+        self.assertEqual(
+            sysfs_lookup(self.prog, "/kernel"), NULL(self.prog, "struct kobject *")
+        )
+        self.assertEqual(
+            sysfs_lookup(self.prog, "kernel/foobar"),
+            NULL(self.prog, "struct kobject *"),
+        )
+
+        # Device case
+        if "device_ktype" in self.prog:
+            path = "/sys/block"
+            if os.path.exists(path):
+                with os.scandir(path) as entries:
+                    entry = next((e for e in entries if e.is_dir()), None)
+                    if entry:
+                        dev = sysfs_lookup(self.prog, entry.path[5:])
+                        self.assertTrue(dev)
+                        self.assertEqual(dev.type_.type_name(), "struct device *")
+
+    def test_sysfs_listdir(self):
+        expected = os.listdir(b"/sys/kernel")
+
+        self.assertCountEqual(sysfs_listdir(self.prog, "kernel"), expected)
+        self.assertCountEqual(sysfs_listdir(self.prog, "/sys/kernel"), expected)
+
+        self.assertRaisesRegex(
+            ValueError, r": not found$", sysfs_listdir, self.prog, "sys/kernel"
+        )
+        self.assertRaisesRegex(
+            ValueError, r": not found$", sysfs_listdir, self.prog, "kernel/foobar"
+        )
+        self.assertRaisesRegex(
+            ValueError, "not a directory", sysfs_listdir, self.prog, "kernel/vmcoreinfo"
+        )


### PR DESCRIPTION
Add helper functions for resolving and traversing sysfs (kernfs) nodes from a drgn program.

Introduce sysfs_lookup_node() to resolve a sysfs path to a ``struct kernfs_node *`` starting from ``sysfs_root`` with proper handling of absolute and relative paths. Add sysfs_lookup_kobject() to return the corresponding ``struct kobject *`` for a path, returning the parent kobject for attribute files. Add sysfs_lookup() to return the containing ``struct device *`` when the kobject represents a device, and sysfs_listdir() to list child entries of a sysfs directory.

These helpers abstract common sysfs traversal logic and simplify inspection of sysfs objects from kernel memory.

Fixes: #443

Signed-off-by: Muskan Goyal <muskan@linux.ibm.com>
