### PR TITLE
drgn: crash: Add -s flag to bpf command for struct inspection

### DIFF
--- a/drgn/commands/_crash/_bpf.py
+++ b/drgn/commands/_crash/_bpf.py
@@ -9,7 +9,11 @@ from typing import Any, List, Sequence
 
 from drgn import Program
 from drgn.commands import argument, drgn_argument
-from drgn.commands._crash.common import CrashDrgnCodeBuilder, crash_command
+from drgn.commands._crash.common import (
+    CrashDrgnCodeBuilder,
+    _object_format_options,
+    crash_command,
+)
 from drgn.helpers.common.format import (
     CellFormat,
     double_quote_ascii_string,
@@ -44,6 +48,29 @@ from drgn.helpers.linux.user import kuid_val
             dest="map_id",
             type=int,
             help="display additional information for the specified BPF map ID",
+        ),
+        argument(
+            "-s",
+            dest="show_struct",
+            action="store_true",
+            default=False,
+            help="display the full struct bpf_map (with -m) or struct bpf_prog and "
+            "struct bpf_prog_aux (with -p); combine with -x or -d to control "
+            "integer formatting in the struct dump",
+        ),
+        argument(
+            "-x",
+            dest="integer_base",
+            action="store_const",
+            const=16,
+            help="output integers in hexadecimal format in the -s struct dump",
+        ),
+        argument(
+            "-d",
+            dest="integer_base",
+            action="store_const",
+            const=10,
+            help="output integers in decimal format in the -s struct dump",
         ),
         drgn_argument,
     ),
@@ -164,6 +191,15 @@ for bpf_map in bpf_map_for_each(prog):
 
         print(f"     GPL_COMPATIBLE: {gpl_compat}  NAME: {prog_name}  UID: {uid}")
 
+        if args.show_struct:
+            print()
+            format_options = _object_format_options(prog, args.integer_base)
+            print(bpf_prog[0].format_(**format_options))
+
+            print()
+
+            print(aux[0].format_(**format_options))
+
         return
 
     if args.map_id is not None:
@@ -258,6 +294,11 @@ for bpf_map in bpf_map_for_each(prog):
                 uid_str = "(unknown)"
 
         print(f"     NAME: {map_name}  UID: {uid_str}")
+
+        if args.show_struct:
+            print()
+            format_options = _object_format_options(prog, args.integer_base)
+            print(bpf_map[0].format_(**format_options))
 
         return
 

--- a/drgn/commands/_crash/_bpf.py
+++ b/drgn/commands/_crash/_bpf.py
@@ -5,11 +5,16 @@
 
 import argparse
 from datetime import datetime
-from typing import Any, List, Sequence
+import re
+from typing import Any, Dict, List, Sequence
 
-from drgn import Program
+from drgn import Object, Program
 from drgn.commands import argument, drgn_argument
-from drgn.commands._crash.common import CrashDrgnCodeBuilder, crash_command
+from drgn.commands._crash.common import (
+    CrashDrgnCodeBuilder,
+    _object_format_options,
+    crash_command,
+)
 from drgn.helpers.common.format import (
     CellFormat,
     double_quote_ascii_string,
@@ -30,6 +35,28 @@ from drgn.helpers.linux.timekeeping import (
 from drgn.helpers.linux.user import kuid_val
 
 
+def _format_crash_struct(
+    obj: Object,
+    type_name: str,
+    format_options: Dict[str, Any],
+) -> str:
+    opts = dict(format_options)
+    opts["type_name"] = False
+    opts["member_type_names"] = False
+    opts["symbolize"] = False
+
+    raw = obj.format_(**opts)
+    s = raw.replace("{", f"struct {type_name} {{", 1)
+
+    def repl_tab(m: Any) -> str:
+        return "  " * len(m.group(1))
+
+    s = re.sub(r"^(\t+)", repl_tab, s, flags=re.MULTILINE)
+    s = re.sub(r"^( +)\.", r"\1", s, flags=re.MULTILINE)
+
+    return s
+
+
 @crash_command(
     description="display loaded eBPF programs and maps",
     arguments=(
@@ -44,6 +71,13 @@ from drgn.helpers.linux.user import kuid_val
             dest="map_id",
             type=int,
             help="display additional information for the specified BPF map ID",
+        ),
+        argument(
+            "-s",
+            dest="show_struct",
+            action="store_true",
+            default=False,
+            help="display the full struct bpf_map (with -m) or struct bpf_prog (with -p)",
         ),
         drgn_argument,
     ),
@@ -164,6 +198,17 @@ for bpf_map in bpf_map_for_each(prog):
 
         print(f"     GPL_COMPATIBLE: {gpl_compat}  NAME: {prog_name}  UID: {uid}")
 
+        if args.show_struct:
+            print()
+            format_options = _object_format_options(prog, None)
+            struct_obj = Object(prog, "struct bpf_prog", address=bpf_prog.value_())
+            print(_format_crash_struct(struct_obj, "bpf_prog", format_options))
+
+            print()
+
+            aux_obj = Object(prog, "struct bpf_prog_aux", address=aux.value_())
+            print(_format_crash_struct(aux_obj, "bpf_prog_aux", format_options))
+
         return
 
     if args.map_id is not None:
@@ -258,6 +303,12 @@ for bpf_map in bpf_map_for_each(prog):
                 uid_str = "(unknown)"
 
         print(f"     NAME: {map_name}  UID: {uid_str}")
+
+        if args.show_struct:
+            print()
+            format_options = _object_format_options(prog, None)
+            struct_obj = Object(prog, "struct bpf_map", address=bpf_map.value_())
+            print(_format_crash_struct(struct_obj, "bpf_map", format_options))
 
         return
 

--- a/tests/linux_kernel/crash_commands/test_bpf.py
+++ b/tests/linux_kernel/crash_commands/test_bpf.py
@@ -192,3 +192,36 @@ class TestBpf(CrashCommandTestCase, BpfTestCase):
                 cmd.stdout,
                 rf"(?sm)^\s*{map_id}\s+.*HASH\s+",
             )
+
+    def test_bpf_map_show_struct(self):
+        with contextlib.ExitStack() as exit_stack:
+            map_fd = bpf_map_create(BPF_MAP_TYPE_HASH, 4, 8, 256)
+            exit_stack.callback(os.close, map_fd)
+
+            map_info = bpf_map_get_info_by_fd(map_fd)
+            map_id = map_info.id
+
+            cmd = self.check_crash_command(f"bpf -m {map_id} -s")
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\(struct bpf_map\){",
+            )
+
+    def test_bpf_prog_show_struct(self):
+        with contextlib.ExitStack() as exit_stack:
+            prog_fd = bpf_prog_load(BPF_PROG_TYPE_KPROBE, self.INSNS, b"GPL")
+            exit_stack.callback(os.close, prog_fd)
+
+            prog_info = bpf_prog_get_info_by_fd(prog_fd)
+            prog_id = prog_info.id
+
+            cmd = self.check_crash_command(f"bpf -p {prog_id} -s")
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\(struct bpf_prog\){",
+            )
+
+    def test_bpf_map_show_struct_invalid_id(self):
+        cmd = self.check_crash_command("bpf -m 99999999999999999 -s")
+        self.assertIn("invalid BPF map ID", cmd.stdout)
+        self.assertNotIn("struct bpf_map", cmd.stdout)


### PR DESCRIPTION
Introduce a `-s` flag for the `bpf` crash command to dump the full underlying runtime structures of loaded BPF maps (`struct bpf_map`) and BPF programs (`struct bpf_prog`), along with their associated metadata structures (`struct bpf_prog_aux`).