### PR TITLE
kdump: add knob to prefer built-in pgtable walk

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -319,6 +319,14 @@ Some of drgn's behavior can be modified through environment variables:
     Whether drgn should use libkdumpfile for ELF vmcores (0 or 1). The default
     is 0. This functionality will be removed in the future.
 
+.. envvar:: DRGN_PREFER_PGTABLE_READER
+
+    Whether drgn should prefer reading virtual memory addresses by doing its own
+    page table translation, instead of relying on libkdumpfile and libaddrxlat.
+    This can be useful in unusual debugging circumstances, such as debugging the
+    dump capture kernel from a vmcore created by a hypervisor. This setting is
+    only respected when using libkdumpfile to debug a core dump file.
+
 .. envvar:: DRGN_USE_SYS_MODULE
 
     Whether drgn should use ``/sys/module`` to find information about loaded

--- a/libdrgn/kdump.c
+++ b/libdrgn/kdump.c
@@ -125,6 +125,12 @@ static struct drgn_error *drgn_read_kdump(void *buf, uint64_t address,
 	return NULL;
 }
 
+static bool prefer_drgn_vaddr_reader(void)
+{
+	const char *env = getenv("DRGN_PREFER_PGTABLE_READER");
+	return (env && atoi(env));
+}
+
 struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 {
 	struct drgn_error *err;
@@ -255,8 +261,21 @@ struct drgn_error *drgn_program_set_kdump(struct drgn_program *prog)
 		drgn_program_set_platform(prog, &platform);
 	}
 
-	err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,
-					      drgn_read_kdump, ctx, false);
+	// Drgn has fallback logic for some architectures which allows it to
+	// figure out the virtual memory mappings of the kernel. Sometimes
+	// libkdumpfile gets it wrong, for example when we're trying to debug
+	// the dump capture kernel itself: libkdumpfile will still attempt to
+	// use the original kernel's virtual memory mapping, while drgn knows
+	// the correct mapping from the kdump kernel's vmcoreinfo. Use an
+	// environment variable knob to opt-in to drgn's virtual memory reading
+	// logic instead of libkdumpfile's.
+	if (prefer_drgn_vaddr_reader())
+		err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,
+						      read_memory_via_pgtable,
+						      prog, false);
+	else
+		err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,
+						      drgn_read_kdump, ctx, false);
 	if (err)
 		goto err_platform;
 	err = drgn_program_add_memory_segment(prog, 0, UINT64_MAX,


### PR DESCRIPTION
I had an interesting request come in for debugging why a kdump capture was taking too long. (It's probably memory pressure. It's seemingly _always_ memory pressure!)

We have a vmcore generated by QEMU during the dump capture process. Opening it with `drgn --architecture x86_64 ...` works to debug the original kernel. But of course I wanted to debug the dump capture kernel. I used the [dumpphys tool](https://github.com/brenns10/kernel_stuff/blob/master/vmcoreinfo/dumpphys.c) to find all the pages that looked like vmcoreinfo notes and determined the one corresponding to the dump capture kernel. But pointing drgn at that gave me `Page table not present` fault errors.

Turns out that drgn was using the libkdumpfile memory reader for virtual addresses, and libkdumpfile was (helpfully) providing virtual memory reading using the original kernel's mappings. Which is of course not what we want in this case, because we want the dump capture kernel's virtual address space.

Given that we've added fallbacks for x86_64 and aarch64 now, which allow bootstrapping virtual address translation from just the vmcoreinfo and physical memory, it seems like we should have a way to ignore the virtual memory mappings provided in the vmcore and just use our own bootstrapped logic.

This is a first pass at it, which solved my immediate issue. It is only for libkdumpfile, but it seems like it could be useful for ELF too. We've had some issues where there are bugs in /proc/kcore, and while we can work around them manually with the `access_remote_vm(...init_mm..)` construct, this approach would allow us to flip a global switch that makes all memory reads directly rely on page tables rather than external virtual memory mappings. But I wanted to get your thoughts before I implemented the other side.