### PR TITLE
s390x: Correct kdump address translation loop

### DIFF
--- a/libdrgn/arch_s390x.c
+++ b/libdrgn/arch_s390x.c
@@ -395,6 +395,19 @@ linux_kernel_pgtable_iterator_next_s390x(struct drgn_program *prog,
 	const uint64_t va = it->it.virt_addr;
 	uint64_t table = _it->pgtable & ~UINT64_C(0xfff);
 	bool table_physical = false;
+	if (table == prog->vmcoreinfo.swapper_pg_dir) {
+		// Since Linux kernel commits 378e32aa8197 ("s390/vmcoreinfo:
+		// Store virtual memory layout") and c98d2ecae08f ("s390/mm:
+		// Uncouple physical vs virtual address spaces") (in v6.10), we
+		// can translate the kernel page table address to a physical
+		// address using VMCOREINFO. Before that, kernel virtual and
+		// physical addresses are equal.
+		if (prog->vmcoreinfo.have_kaslr_offset_phys) {
+			table -= prog->vmcoreinfo.kaslr_offset;
+			table += prog->vmcoreinfo.kaslr_offset_phys;
+		}
+		table_physical = true;
+	}
 	int level, length = 2048, offset = 0;
 	uint64_t entry;
 
@@ -404,7 +417,7 @@ linux_kernel_pgtable_iterator_next_s390x(struct drgn_program *prog,
 	 * the linux kernel does: read the first level entry, and deduct the
 	 * number of levels from the TT bits.
 	 */
-	struct drgn_error *err = drgn_program_read_u64(prog, table, false,
+	struct drgn_error *err = drgn_program_read_u64(prog, table, table_physical,
 						       &entry);
 	if (err)
 		return err;

--- a/libdrgn/drgn_program_parse_vmcoreinfo.inc.strswitch
+++ b/libdrgn/drgn_program_parse_vmcoreinfo.inc.strswitch
@@ -105,6 +105,13 @@ struct drgn_error *drgn_program_parse_vmcoreinfo(struct drgn_program *prog,
 			if (err)
 				return err;
 			break;
+		@case "KERNELOFFPHYS"@
+			err = parse_vmcoreinfo_u64(value, newline, 16,
+						   &prog->vmcoreinfo.kaslr_offset_phys);
+			if (err)
+				return err;
+			prog->vmcoreinfo.have_kaslr_offset_phys = true;
+			break;
 		@case "SYMBOL(swapper_pg_dir)"@
 			err = parse_vmcoreinfo_u64(value, newline, 16,
 						   &prog->vmcoreinfo.swapper_pg_dir);

--- a/libdrgn/program.h
+++ b/libdrgn/program.h
@@ -196,6 +196,11 @@ struct drgn_program {
 				 * layout randomization (KASLR) is enabled.
 				 */
 				uint64_t kaslr_offset;
+				/**
+				 * The offset from physical memory address 0 of
+				 * the kernel image on s390x.
+				 */
+				uint64_t kaslr_offset_phys;
 				/** Kernel page table. */
 				uint64_t swapper_pg_dir;
 				/**
@@ -233,6 +238,8 @@ struct drgn_program {
 				bool have_crashtime;
 				/** Whether `phys_base` was in the VMCOREINFO. */
 				bool have_phys_base;
+				/** Whether `kaslr_offset_phys` was in the VMCOREINFO. */
+				bool have_kaslr_offset_phys;
 				/** Length of build ID. */
 				unsigned int build_id_len;
 				/**


### PR DESCRIPTION
The kernel uses a virtual memory address for the `swapper_pg_dir` on s390x, and this is placed in an offset defined by the `kaslr_offset` and `kaslr_offset_phys`. Since we don't have virtal memory enabled when we're translating the virtual memory address, we have to use this offset instead of translation.

Resolves #566

Note that `DRGN_PREFER_PGTABLE_READER=1` is required to use this logic.