### PR TITLE
drgn: kmodify: add little-endian ppc64 (ELFv2) support

### DIFF
--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -876,6 +876,29 @@ class _CodeGen_ppc64le:
     def _mtctr(self, t: int) -> int:
         return 0x7C0903A6 | self._rt(t)
 
+    def _load_imm(self, reg: int, value: int) -> None:
+        # Materialize the full 64-bit two's-complement of value (ELFv2 requires
+        # the caller to sign-/zero-extend sub-doubleword arguments to the whole
+        # register, and the callee reads all 64 bits). Never mask to a smaller
+        # width.
+        v = value & 0xFFFFFFFFFFFFFFFF
+        if -0x8000 <= value < 0x8000:
+            self._emit(self._addi(reg, 0, value))  # li (sign-extends)
+            return
+        if -0x80000000 <= value < 0x80000000:
+            self._emit(self._addis(reg, 0, (value >> 16) & 0xFFFF))  # lis
+            if value & 0xFFFF:
+                self._emit(self._ori(reg, reg, value & 0xFFFF))
+            return
+        self._emit(self._addis(reg, 0, (v >> 48) & 0xFFFF))  # lis  -> bits 48-63
+        if (v >> 32) & 0xFFFF:
+            self._emit(self._ori(reg, reg, (v >> 32) & 0xFFFF))  # ori -> bits 32-47
+        self._emit(self._rldicr32(reg, reg))  # << 32
+        if (v >> 16) & 0xFFFF:
+            self._emit(self._oris(reg, reg, (v >> 16) & 0xFFFF))  # oris -> bits 16-31
+        if v & 0xFFFF:
+            self._emit(self._ori(reg, reg, v & 0xFFFF))  # ori -> bits 0-15
+
 
 def _ppc64_stubs_section() -> _ElfSection:
     # The ppc64 module loader (arch/powerpc/kernel/module_64.c) rejects any

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -29,6 +29,7 @@ import sys
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     List,
     Mapping,
     NamedTuple,
@@ -723,6 +724,12 @@ class _Arch_X86_64:
     ELF_MACHINE = 62  # EM_X86_64
     RELA = True
     ABSOLUTE_ADDRESS_RELOCATION_TYPE = 1  # R_X86_64_64
+    # x86-64 needs no extra ELF flags, sections, or symbols. These are declared
+    # so that every _Arch exposes the same interface (see _Arch_PPC64, which
+    # overrides them) and callers don't need getattr() with defaults.
+    ELF_FLAGS = 0
+    MODULE_SECTIONS: Sequence[Callable[[], _ElfSection]] = ()
+    MODULE_SYMBOLS: Sequence[_ElfSymbol] = ()
 
     @staticmethod
     def code_gen(
@@ -1381,7 +1388,7 @@ class _Kmodify:
 
         # Add any sections the architecture requires unconditionally (e.g. the
         # mandatory empty .stubs section on ppc64).
-        for section_factory in getattr(self.arch, "MODULE_SECTIONS", ()):
+        for section_factory in self.arch.MODULE_SECTIONS:
             sections.append(section_factory())
 
         # Add the Table of Contents section if the code generator produced one
@@ -1425,7 +1432,7 @@ class _Kmodify:
             ),
             # Symbols the architecture requires (e.g. ppc64's ".TOC."). These are
             # global, so they go after the local symbols above.
-            *getattr(self.arch, "MODULE_SYMBOLS", ()),
+            *self.arch.MODULE_SYMBOLS,
         ]
 
         relocations = {
@@ -1449,7 +1456,7 @@ class _Kmodify:
                 is_little_endian=self.is_little_endian,
                 is_64_bit=self.is_64_bit,
                 rela=self.arch.RELA,
-                flags=getattr(self.arch, "ELF_FLAGS", 0),
+                flags=self.arch.ELF_FLAGS,
                 sections=sections,
                 symbols=symbols,
                 relocations=relocations,

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -770,6 +770,33 @@ class _Arch_X86_64:
         return _CodeGenResult(bytes(code_gen.code), code_gen.relocations)
 
 
+def _ppc64_stubs_section() -> _ElfSection:
+    # The ppc64 module loader (arch/powerpc/kernel/module_64.c) rejects any
+    # module that does not contain a .stubs section. We never emit a
+    # stub-needing relocation, so an empty section is enough; the loader sizes
+    # it itself.
+    return _ElfSection(
+        name=".stubs",
+        type=SHT.PROGBITS,
+        flags=SHF.ALLOC | SHF.EXECINSTR,
+        data=b"",
+        addralign=8,
+    )
+
+
+class _Arch_PPC64:
+    ELF_MACHINE = 21  # EM_PPC64
+    RELA = True
+    ABSOLUTE_ADDRESS_RELOCATION_TYPE = 38  # R_PPC64_ADDR64
+    MODULE_SECTIONS = (_ppc64_stubs_section,)
+
+    @staticmethod
+    def code_gen(
+        func: _Function, symbol_addresses: Optional[Mapping[str, int]] = None
+    ) -> _CodeGenResult:
+        raise NotImplementedError("ppc64le code generation not yet implemented")
+
+
 def _find_exported_symbol_in_section(
     prog: Program, name: bytes, start: int, stop: int
 ) -> int:
@@ -877,10 +904,15 @@ class _Kmodify:
         self.is_little_endian = bool(platform.flags & PlatformFlags.IS_LITTLE_ENDIAN)
         self.is_64_bit = bool(platform.flags & PlatformFlags.IS_64_BIT)
 
+        self.arch: Any
         if platform.arch == Architecture.X86_64:
-            # When we add support for another architecture, we're going to need
-            # an _Arch Protocol.
             self.arch = _Arch_X86_64
+        elif platform.arch == Architecture.PPC64:
+            if not self.is_little_endian:
+                raise NotImplementedError(
+                    "kmodify is only implemented for little-endian ppc64"
+                )
+            self.arch = _Arch_PPC64
         else:
             raise NotImplementedError(
                 f"kmodify not implemented for {platform.arch.name} architecture"

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -782,7 +782,9 @@ class _Arch_X86_64:
 class _CodeGen_ppc64le:
     # ELFv2, little-endian. Instruction encodings mirror the kernel's PPC_RAW_*
     # macros (arch/powerpc/include/asm/ppc-opcode.h); each 32-bit instruction is
-    # emitted as 4 little-endian bytes.
+    # emitted as 4 little-endian bytes. The unit tests pin structure and
+    # composition; the raw encodings are validated end-to-end by the kmodify
+    # integration tests under vmtest on ppc64le.
 
     _r0 = 0
     _r1 = 1
@@ -962,14 +964,16 @@ class _CodeGen_ppc64le:
                 # The LI field is signed 26 bits (scaled by 4).
                 if not -0x2000000 <= disp < 0x2000000:
                     raise OverflowError(
-                        f"branch displacement {disp} out of range for b"
+                        f"branch displacement {disp} out of range for b "
+                        "(generated helper is too large)"
                     )
                 word = (word & ~0x03FFFFFC) | (disp & 0x03FFFFFC)
             else:  # conditional bc
                 # The BD field is signed 14 bits (scaled by 4).
                 if not -0x8000 <= disp < 0x8000:
                     raise OverflowError(
-                        f"branch displacement {disp} out of range for bc"
+                        f"branch displacement {disp} out of range for bc "
+                        "(generated helper is too large)"
                     )
                 word = (word & ~0xFFFC) | (disp & 0xFFFC)
             self.code[offset : offset + 4] = (word & 0xFFFFFFFF).to_bytes(4, "little")
@@ -1026,8 +1030,12 @@ class _CodeGen_ppc64le:
             self._emit(self._std(self._r11, self._r1, 32 + 8 * i))
         for i in range(min(len(args), n_reg)):
             self._materialize(self._argument_registers[i], args[i])
-        # Materialize the call target into r12 last so building it can't clobber
-        # an argument register.
+        # Unlike x86-64, which emits a loader-resolved relocation, ppc64le bakes
+        # the target in as an immediate, so it must be a live, stable kallsyms
+        # address (kmodify only ever modifies a running kernel). r12 must also
+        # hold the callee's global entry point, from which the callee computes
+        # its own TOC. Materialize it last so building it can't clobber an
+        # argument register.
         self._load_imm(self._r12, target_address)
         self._emit(self._mtctr(self._r12))
         self._emit(self._BCTRL)
@@ -1151,7 +1159,10 @@ class _Arch_PPC64:
                     # ppc64le bakes the target into the code as an immediate, so
                     # a zero address (e.g. an unresolved symbol) can't be fixed
                     # up by the loader the way an x86-64 relocation would be.
-                    raise ValueError(f"no address for call target {node.func.name!r}")
+                    raise ValueError(
+                        f"no address for call target {node.func.name!r} "
+                        "(unresolved kernel symbol)"
+                    )
                 cg.call(target_address, node.args)
             elif isinstance(node, _StoreReturnValue):
                 cg.store_return_value(node.size, node.dst)

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -156,6 +156,7 @@ def _write_elf(
     sections: Sequence[_ElfSection],
     symbols: Sequence[_ElfSymbol],
     relocations: Mapping[str, Sequence[_ElfRelocation]],
+    flags: int = 0,
 ) -> None:
     endian = "<" if is_little_endian else ">"
     if is_64_bit:
@@ -356,7 +357,7 @@ def _write_elf(
             0,  # e_entry
             0,  # e_phoff
             ehdr_struct.size,  # e_shoff
-            0,  # e_flags
+            flags,  # e_flags
             ehdr_struct.size,  # e_ehsize
             0,  # e_phentsize
             0,  # e_phnum
@@ -1077,7 +1078,24 @@ class _Arch_PPC64:
     ELF_MACHINE = 21  # EM_PPC64
     RELA = True
     ABSOLUTE_ADDRESS_RELOCATION_TYPE = 38  # R_PPC64_ADDR64
+    # The ppc64le loader's module_elf_check_arch() requires the ELFv2 ABI level
+    # in e_flags (e_flags & 0x3 == 2); otherwise the module is rejected.
+    ELF_FLAGS = 2
     MODULE_SECTIONS = (_ppc64_stubs_section,)
+    # The global-entry prologue references the TOC base through the special
+    # ".TOC." symbol. The kernel's dedotify() (arch/powerpc/kernel/module_64.c)
+    # converts a SHN_UNDEF ".TOC." symbol to SHN_ABS and sets its value to the
+    # module's TOC pointer; the symbol must be present for that to happen.
+    MODULE_SYMBOLS = (
+        _ElfSymbol(
+            name=".TOC.",
+            value=0,
+            size=0,
+            type=STT.NOTYPE,
+            binding=STB.GLOBAL,
+            section=SHN.UNDEF,
+        ),
+    )
 
     @staticmethod
     def code_gen(
@@ -1386,6 +1404,9 @@ class _Kmodify:
                 binding=STB.GLOBAL,
                 section=".codetag.alloc_tags",
             ),
+            # Symbols the architecture requires (e.g. ppc64's ".TOC."). These are
+            # global, so they go after the local symbols above.
+            *getattr(self.arch, "MODULE_SYMBOLS", ()),
         ]
 
         relocations = {
@@ -1409,6 +1430,7 @@ class _Kmodify:
                 is_little_endian=self.is_little_endian,
                 is_64_bit=self.is_64_bit,
                 rela=self.arch.RELA,
+                flags=getattr(self.arch, "ELF_FLAGS", 0),
                 sections=sections,
                 symbols=symbols,
                 relocations=relocations,

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -952,8 +952,18 @@ class _CodeGen_ppc64le:
             word = int.from_bytes(self.code[offset : offset + 4], "little")
             disp = target - offset
             if (word & 0xFC000000) == 0x48000000:  # unconditional b
+                # The LI field is signed 26 bits (scaled by 4).
+                if not -0x2000000 <= disp < 0x2000000:
+                    raise OverflowError(
+                        f"branch displacement {disp} out of range for b"
+                    )
                 word = (word & ~0x03FFFFFC) | (disp & 0x03FFFFFC)
             else:  # conditional bc
+                # The BD field is signed 14 bits (scaled by 4).
+                if not -0x8000 <= disp < 0x8000:
+                    raise OverflowError(
+                        f"branch displacement {disp} out of range for bc"
+                    )
                 word = (word & ~0xFFFC) | (disp & 0xFFFC)
             self.code[offset : offset + 4] = (word & 0xFFFFFFFF).to_bytes(4, "little")
         self._emit(self._addi(self._r1, self._r1, self._frame))
@@ -1052,7 +1062,9 @@ class _CodeGen_ppc64le:
             self._emit(self._andc(self._r0, self._r0, self._r4))
         self._emit(self._stdcx(self._r0, 0, self._r3))
         disp = start - len(self.code)
-        self._emit(self._BNE_CR0 | (disp & 0xFFFC))  # bne- back to ldarx
+        # bne back to ldarx if the reservation was lost (stdcx. cleared CR0[EQ]).
+        # The backward displacement is tiny, so it always fits the 14-bit field.
+        self._emit(self._BNE_CR0 | (disp & 0xFFFC))
 
     def atomic_set_bit(self, nr: int, address: _Integer) -> None:
         self._atomic_bit(nr, address.value, True)

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -989,6 +989,31 @@ class _CodeGen_ppc64le:
         if offset:
             self._emit(self._addi(reg, reg, offset))
 
+    def _materialize(self, reg: int, arg: Union[_Integer, _Symbol]) -> None:
+        if isinstance(arg, _Integer):
+            self._load_imm(reg, arg.value)
+        else:
+            # The only symbols passed as arguments are .data references.
+            self._load_data_ptr(reg, arg.offset)
+
+    def call(
+        self, target_address: int, args: Sequence[Union[_Integer, _Symbol]]
+    ) -> None:
+        n_reg = len(self._argument_registers)
+        # Stage stack arguments first, using r11 as scratch so we don't clobber
+        # the argument registers.
+        for i in range(n_reg, len(args)):
+            self._materialize(self._r11, args[i])
+            self._emit(self._std(self._r11, self._r1, 32 + 8 * i))
+        for i in range(min(len(args), n_reg)):
+            self._materialize(self._argument_registers[i], args[i])
+        # Materialize the call target into r12 last so building it can't clobber
+        # an argument register.
+        self._load_imm(self._r12, target_address)
+        self._emit(self._mtctr(self._r12))
+        self._emit(self._BCTRL)
+        self._restore_toc()
+
 
 def _ppc64_stubs_section() -> _ElfSection:
     # The ppc64 module loader (arch/powerpc/kernel/module_64.c) rejects any

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -10,7 +10,8 @@ The ``drgn.helpers.experimental.kmodify`` module provides experimental helpers
 for modifying the state of the running kernel. This works by loading a
 temporary kernel module, so the kernel must support loadable kernel modules
 (``CONFIG_MODULES=y``) and allow loading unsigned modules
-(``CONFIG_MODULE_SIG_FORCE=n``). It is currently only implemented for x86-64.
+(``CONFIG_MODULE_SIG_FORCE=n``). It is currently implemented for x86-64 and
+ppc64le.
 
 .. warning::
     These helpers are powerful but **extremely** dangerous. Use them with care.

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -899,6 +899,96 @@ class _CodeGen_ppc64le:
         if v & 0xFFFF:
             self._emit(self._ori(reg, reg, v & 0xFFFF))  # ori -> bits 0-15
 
+    def enter_frame(self, size: int) -> None:
+        if size < 0:
+            raise ValueError("invalid stack frame size")
+        # 32-byte ELFv2 linkage area plus the parameter save area; 16-aligned.
+        self._frame = (max(size, 32) + 15) & ~15
+        # Global-entry prologue: set the module TOC (r2) from r12 using REL16
+        # relocations against .TOC. (the kernel calls init_module with r12 set
+        # to its address). Both the @ha and @l relocations must compute
+        # (.TOC. - entry) relative to the same anchor (the addis); since the
+        # kernel evaluates each as (sym + addend - location), the addi (4 bytes
+        # after the addis) carries an addend of +4 to cancel its location offset.
+        entry = len(self.code)
+        self.relocations.append(
+            _ElfRelocation(
+                offset=entry,
+                type=self._R_PPC64_REL16_HA,
+                symbol_name=".TOC.",
+                section_symbol=False,
+                addend=0,
+            )
+        )
+        self._emit(self._addis(self._r2, self._r12, 0))
+        self.relocations.append(
+            _ElfRelocation(
+                offset=len(self.code),
+                type=self._R_PPC64_REL16_LO,
+                symbol_name=".TOC.",
+                section_symbol=False,
+                addend=len(self.code) - entry,
+            )
+        )
+        self._emit(self._addi(self._r2, self._r2, 0))
+        self._emit(self._mflr(self._r0))
+        # LR save doubleword lives in the caller's frame (offset 16), written
+        # before we allocate our own frame.
+        self._emit(self._std(self._r0, self._r1, 16))
+        self._emit(self._stdu(self._r1, self._r1, -self._frame))
+        # TOC save doubleword lives in our own frame (offset 24), reloaded after
+        # each call clobbers r2.
+        self._emit(self._std(self._r2, self._r1, 24))
+
+    def _restore_toc(self) -> None:
+        self._emit(self._ld(self._r2, self._r1, 24))
+
+    def leave_frame(self) -> None:
+        # Fix up the branches to the (now known) epilogue.
+        target = len(self.code)
+        for offset in self._epilogue_branches:
+            word = int.from_bytes(self.code[offset : offset + 4], "little")
+            disp = target - offset
+            if (word & 0xFC000000) == 0x48000000:  # unconditional b
+                word = (word & ~0x03FFFFFC) | (disp & 0x03FFFFFC)
+            else:  # conditional bc
+                word = (word & ~0xFFFC) | (disp & 0xFFFC)
+            self.code[offset : offset + 4] = (word & 0xFFFFFFFF).to_bytes(4, "little")
+        self._emit(self._addi(self._r1, self._r1, self._frame))
+        self._emit(self._ld(self._r0, self._r1, 16))
+        self._emit(self._mtlr(self._r0))
+        self._emit(self._BLR)
+
+    def _ensure_data_toc_slot(self) -> int:
+        # A single TOC slot holds the .data base, filled by R_PPC64_ADDR64. All
+        # .data references reuse it (offsets are added with addi).
+        if not self.toc:
+            self.toc_relocations.append(
+                _ElfRelocation(
+                    offset=0,
+                    type=self._R_PPC64_ADDR64,
+                    symbol_name=".data",
+                    section_symbol=True,
+                )
+            )
+            self.toc.extend(b"\0" * 8)
+        return 0
+
+    def _load_data_ptr(self, reg: int, offset: int) -> None:
+        slot = self._ensure_data_toc_slot()
+        self.relocations.append(
+            _ElfRelocation(
+                offset=len(self.code),
+                type=self._R_PPC64_TOC16_DS,
+                symbol_name=".toc",
+                section_symbol=True,
+                addend=slot,
+            )
+        )
+        self._emit(self._ld(reg, self._r2, 0))  # ld reg, .data@toc(r2)
+        if offset:
+            self._emit(self._addi(reg, reg, offset))
+
 
 def _ppc64_stubs_section() -> _ElfSection:
     # The ppc64 module loader (arch/powerpc/kernel/module_64.c) rejects any

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -1139,7 +1139,13 @@ class _Arch_PPC64:
 
         for i, node in enumerate(func.body):
             if isinstance(node, _Call):
-                cg.call(symbol_addresses[node.func.name], node.args)
+                target_address = symbol_addresses[node.func.name]
+                if not target_address:
+                    # ppc64le bakes the target into the code as an immediate, so
+                    # a zero address (e.g. an unresolved symbol) can't be fixed
+                    # up by the loader the way an x86-64 relocation would be.
+                    raise ValueError(f"no address for call target {node.func.name!r}")
+                cg.call(target_address, node.args)
             elif isinstance(node, _StoreReturnValue):
                 cg.store_return_value(node.size, node.dst)
             elif isinstance(node, _Return):

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -1014,6 +1014,50 @@ class _CodeGen_ppc64le:
         self._emit(self._BCTRL)
         self._restore_toc()
 
+    # bne cr0, ... (BO=4 branch-if-false, BI=2 = CR0[EQ]); offset filled later.
+    _BNE_CR0 = 0x40820000
+
+    def store_return_value(self, size: int, dst: _Symbol) -> None:
+        self._load_data_ptr(self._r11, dst.offset)
+        op = {1: self._stb, 2: self._sth, 4: self._stw, 8: self._std}[size]
+        self._emit(op(self._r3, self._r11, 0))
+
+    def return_(self, value: _Integer, last: bool) -> None:
+        self._load_imm(self._r3, value.value)
+        # Jump to the epilogue, unless this is the last node (fall through).
+        if not last:
+            self._epilogue_branches.append(len(self.code))
+            self._emit(0x48000000)  # b epilogue (fixed up in leave_frame)
+
+    def return_if_last_return_value_nonzero(self, value: _Integer) -> None:
+        # The previous call's result is still in r3; test it before overwriting.
+        self._emit(self._cmpdi(self._r3, 0))
+        self._load_imm(self._r3, value.value)
+        self._epilogue_branches.append(len(self.code))
+        self._emit(self._BNE_CR0)  # bne cr0, epilogue (fixed up in leave_frame)
+
+    def _atomic_bit(self, nr: int, address: int, set_bit: bool) -> None:
+        aligned = address & ~7
+        # Place the bit in the correct little-endian byte lane of the doubleword.
+        mask = (1 << nr) << (8 * (address & 7))
+        self._load_imm(self._r3, aligned)
+        self._load_imm(self._r4, mask)
+        start = len(self.code)
+        self._emit(self._ldarx(self._r0, 0, self._r3))
+        if set_bit:
+            self._emit(self._or(self._r0, self._r0, self._r4))
+        else:
+            self._emit(self._andc(self._r0, self._r0, self._r4))
+        self._emit(self._stdcx(self._r0, 0, self._r3))
+        disp = start - len(self.code)
+        self._emit(self._BNE_CR0 | (disp & 0xFFFC))  # bne- back to ldarx
+
+    def atomic_set_bit(self, nr: int, address: _Integer) -> None:
+        self._atomic_bit(nr, address.value, True)
+
+    def atomic_clear_bit(self, nr: int, address: _Integer) -> None:
+        self._atomic_bit(nr, address.value, False)
+
 
 def _ppc64_stubs_section() -> _ElfSection:
     # The ppc64 module loader (arch/powerpc/kernel/module_64.c) rejects any

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -800,6 +800,7 @@ class _CodeGen_ppc64le:
     _R_PPC64_REL16_LO = 250
     _R_PPC64_TOC16_DS = 63
 
+    _B = 0x48000000
     _BCTRL = 0x4E800421
     _BLR = 0x4E800020
 
@@ -960,7 +961,7 @@ class _CodeGen_ppc64le:
         for offset in self._epilogue_branches:
             word = int.from_bytes(self.code[offset : offset + 4], "little")
             disp = target - offset
-            if (word & 0xFC000000) == 0x48000000:  # unconditional b
+            if (word & 0xFC000000) == self._B:  # unconditional b
                 # The LI field is signed 26 bits (scaled by 4).
                 if not -0x2000000 <= disp < 0x2000000:
                     raise OverflowError(
@@ -1054,7 +1055,7 @@ class _CodeGen_ppc64le:
         # Jump to the epilogue, unless this is the last node (fall through).
         if not last:
             self._epilogue_branches.append(len(self.code))
-            self._emit(0x48000000)  # b epilogue (fixed up in leave_frame)
+            self._emit(self._B)  # b epilogue (fixed up in leave_frame)
 
     def return_if_last_return_value_nonzero(self, value: _Integer) -> None:
         # The previous call's result is still in r3; test it before overwriting.

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -1083,7 +1083,54 @@ class _Arch_PPC64:
     def code_gen(
         func: _Function, symbol_addresses: Optional[Mapping[str, int]] = None
     ) -> _CodeGenResult:
-        raise NotImplementedError("ppc64le code generation not yet implemented")
+        if symbol_addresses is None:
+            raise ValueError("ppc64le code_gen requires symbol_addresses")
+
+        cg = _CodeGen_ppc64le()
+
+        has_call = False
+        max_args = 0
+        for node in func.body:
+            if isinstance(node, _Call):
+                has_call = True
+                for arg in node.args:
+                    if isinstance(arg, _Integer) and arg.size > 8:
+                        raise NotImplementedError(
+                            "passing integers larger than 8 bytes not implemented"
+                        )
+                max_args = max(max_args, len(node.args))
+
+        # A variadic callee spills its argument GPRs (r3-r10, eight doublewords)
+        # into our parameter save area, so it must hold at least eight
+        # doublewords regardless of how many arguments we actually pass;
+        # otherwise the spill overruns the frame and corrupts the saved LR.
+        cg.enter_frame(32 + 8 * max(max_args, 8) if has_call else 0)
+
+        for i, node in enumerate(func.body):
+            if isinstance(node, _Call):
+                cg.call(symbol_addresses[node.func.name], node.args)
+            elif isinstance(node, _StoreReturnValue):
+                cg.store_return_value(node.size, node.dst)
+            elif isinstance(node, _Return):
+                if node.value.size > 8:
+                    raise NotImplementedError(
+                        "return values larger than 8 bytes not implemented"
+                    )
+                cg.return_(node.value, last=i == len(func.body) - 1)
+            elif isinstance(node, _ReturnIfLastReturnValueNonZero):
+                cg.return_if_last_return_value_nonzero(node.value)
+            elif isinstance(node, _AtomicSetBit):
+                cg.atomic_set_bit(node.nr, node.address)
+            elif isinstance(node, _AtomicClearBit):
+                cg.atomic_clear_bit(node.nr, node.address)
+            else:
+                assert_never(node)
+
+        cg.leave_frame()
+
+        return _CodeGenResult(
+            bytes(cg.code), cg.relocations, bytes(cg.toc), cg.toc_relocations
+        )
 
 
 def _find_exported_symbol_in_section(
@@ -1392,6 +1439,20 @@ _COPY_TO_FROM_KERNEL_NOFAULT_NAMES = (
 )
 
 
+def _kernel_function_address(prog: Program, name: str) -> int:
+    """
+    Return the entry point address of a kernel function by name.
+
+    This uses the symbol table rather than the debug information address
+    (``prog[name].address_``). On kernels that split a function into hot and
+    cold parts (``-freorder-blocks-and-partition``), the debug information may
+    describe the function at a cold fragment's address; calling that fragment
+    runs only part of the function. The symbol table always names the real
+    entry point.
+    """
+    return prog.symbol(name).address
+
+
 @takes_program_or_default
 def write_memory(prog: Program, address: IntegerLike, value: bytes) -> None:
     """
@@ -1421,10 +1482,14 @@ def write_memory(prog: Program, address: IntegerLike, value: bytes) -> None:
         copy_from_kernel_nofault,
     ) in _COPY_TO_FROM_KERNEL_NOFAULT_NAMES:
         try:
-            copy_to_kernel_nofault_address = prog[copy_to_kernel_nofault].address_
-            copy_from_kernel_nofault_address = prog[copy_from_kernel_nofault].address_
+            copy_to_kernel_nofault_address = _kernel_function_address(
+                prog, copy_to_kernel_nofault
+            )
+            copy_from_kernel_nofault_address = _kernel_function_address(
+                prog, copy_from_kernel_nofault
+            )
             break
-        except KeyError:
+        except LookupError:
             pass
     if copy_to_kernel_nofault_address is None:
         raise LookupError("copy_to_kernel_nofault not found")
@@ -1466,7 +1531,11 @@ def write_memory(prog: Program, address: IntegerLike, value: bytes) -> None:
                 ),
                 _Return(_Integer(sizeof_int, -errno.EINPROGRESS)),
             ]
-        )
+        ),
+        symbol_addresses={
+            copy_from_kernel_nofault: copy_from_kernel_nofault_address,
+            copy_to_kernel_nofault: copy_to_kernel_nofault_address,
+        },
     )
     ret = kmodify.insert(
         name=f"write_{len(value)}",
@@ -1513,9 +1582,11 @@ def _modify_bit(prog: Program, nr: int, address: int, value: bool) -> None:
     copy_from_kernel_nofault_address = None
     for _, copy_from_kernel_nofault in _COPY_TO_FROM_KERNEL_NOFAULT_NAMES:
         try:
-            copy_from_kernel_nofault_address = prog[copy_from_kernel_nofault].address_
+            copy_from_kernel_nofault_address = _kernel_function_address(
+                prog, copy_from_kernel_nofault
+            )
             break
-        except KeyError:
+        except LookupError:
             pass
     if copy_from_kernel_nofault_address is None:
         raise LookupError("copy_from_kernel_nofault not found")
@@ -1550,7 +1621,8 @@ def _modify_bit(prog: Program, nr: int, address: int, value: bool) -> None:
                 ),
                 _Return(_Integer(sizeof_int, -errno.EINPROGRESS)),
             ]
-        )
+        ),
+        symbol_addresses={copy_from_kernel_nofault: copy_from_kernel_nofault_address},
     )
     ret = kmodify.insert(
         name="set_bit" if value else "clear_bit",
@@ -1869,9 +1941,11 @@ def _insert_call_function(
         "probe_user_write",
     ):
         try:
-            copy_to_user_nofault_address = prog[copy_to_user_nofault].address_
+            copy_to_user_nofault_address = _kernel_function_address(
+                prog, copy_to_user_nofault
+            )
             break
-        except KeyError:
+        except LookupError:
             continue
     if copy_to_user_nofault_address is None:
         raise LookupError("copy_to_user_nofault not found")
@@ -1909,8 +1983,12 @@ def _insert_call_function(
 
     function_body.append(_Return(_Integer(sizeof_int, -errno.EINPROGRESS)))
 
+    # ppc64le bakes call-target addresses as immediates, so the code generator
+    # needs each referenced function's address. The symbols (with their values)
+    # are already built above, before this code_gen call.
+    symbol_addresses = {symbol.name: symbol.value for symbol in symbols}
     code, code_relocations, toc, toc_relocations = kmodify.arch.code_gen(
-        _Function(function_body)
+        _Function(function_body), symbol_addresses=symbol_addresses
     )
 
     ret = kmodify.insert(

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -770,6 +770,113 @@ class _Arch_X86_64:
         return _CodeGenResult(bytes(code_gen.code), code_gen.relocations)
 
 
+class _CodeGen_ppc64le:
+    # ELFv2, little-endian. Instruction encodings mirror the kernel's PPC_RAW_*
+    # macros (arch/powerpc/include/asm/ppc-opcode.h); each 32-bit instruction is
+    # emitted as 4 little-endian bytes.
+
+    _r0 = 0
+    _r1 = 1
+    _r2 = 2
+    _r3 = 3
+    _r4 = 4
+    _r11 = 11
+    _r12 = 12
+    _argument_registers = (3, 4, 5, 6, 7, 8, 9, 10)
+
+    _R_PPC64_ADDR64 = 38
+    _R_PPC64_REL16_HA = 252
+    _R_PPC64_REL16_LO = 250
+    _R_PPC64_TOC16_DS = 63
+
+    _BCTRL = 0x4E800421
+    _BLR = 0x4E800020
+
+    def __init__(self) -> None:
+        self.code = bytearray()
+        self.relocations: List[_ElfRelocation] = []
+        self.toc = bytearray()
+        self.toc_relocations: List[_ElfRelocation] = []
+        self._epilogue_branches: List[int] = []
+        self._frame = 0
+
+    def _emit(self, word: int) -> None:
+        self.code.extend((word & 0xFFFFFFFF).to_bytes(4, "little"))
+
+    @staticmethod
+    def _rt(x: int) -> int:
+        return (x & 0x1F) << 21
+
+    @staticmethod
+    def _ra(x: int) -> int:
+        return (x & 0x1F) << 16
+
+    @staticmethod
+    def _rb(x: int) -> int:
+        return (x & 0x1F) << 11
+
+    def _addi(self, d: int, a: int, i: int) -> int:
+        return 0x38000000 | self._rt(d) | self._ra(a) | (i & 0xFFFF)
+
+    def _addis(self, d: int, a: int, i: int) -> int:
+        return 0x3C000000 | self._rt(d) | self._ra(a) | (i & 0xFFFF)
+
+    def _ori(self, a: int, s: int, i: int) -> int:
+        return 0x60000000 | self._rt(s) | self._ra(a) | (i & 0xFFFF)
+
+    def _oris(self, a: int, s: int, i: int) -> int:
+        return 0x64000000 | self._rt(s) | self._ra(a) | (i & 0xFFFF)
+
+    def _rldicr32(self, a: int, s: int) -> int:
+        # rldicr a, s, 32, 31  (SH=32 -> 0x2, ME=31 -> 0x7c0)
+        return 0x78000004 | self._rt(s) | self._ra(a) | 0x2 | 0x7C0
+
+    def _std(self, s: int, a: int, i: int) -> int:
+        return 0xF8000000 | self._rt(s) | self._ra(a) | (i & 0xFFFC)
+
+    def _stdu(self, s: int, a: int, i: int) -> int:
+        return 0xF8000001 | self._rt(s) | self._ra(a) | (i & 0xFFFC)
+
+    def _ld(self, t: int, a: int, i: int) -> int:
+        return 0xE8000000 | self._rt(t) | self._ra(a) | (i & 0xFFFC)
+
+    def _stb(self, s: int, a: int, i: int) -> int:
+        return 0x98000000 | self._rt(s) | self._ra(a) | (i & 0xFFFF)
+
+    def _sth(self, s: int, a: int, i: int) -> int:
+        return 0xB0000000 | self._rt(s) | self._ra(a) | (i & 0xFFFF)
+
+    def _stw(self, s: int, a: int, i: int) -> int:
+        return 0x90000000 | self._rt(s) | self._ra(a) | (i & 0xFFFF)
+
+    def _add(self, t: int, a: int, b: int) -> int:
+        return 0x7C000214 | self._rt(t) | self._ra(a) | self._rb(b)
+
+    def _or(self, a: int, s: int, b: int) -> int:
+        return 0x7C000378 | self._rt(s) | self._ra(a) | self._rb(b)
+
+    def _andc(self, a: int, s: int, b: int) -> int:
+        return 0x7C000078 | self._rt(s) | self._ra(a) | self._rb(b)
+
+    def _ldarx(self, t: int, a: int, b: int) -> int:
+        return 0x7C0000A8 | self._rt(t) | self._ra(a) | self._rb(b)
+
+    def _stdcx(self, s: int, a: int, b: int) -> int:
+        return 0x7C0001AD | self._rt(s) | self._ra(a) | self._rb(b)
+
+    def _cmpdi(self, a: int, i: int) -> int:
+        return 0x2C200000 | self._ra(a) | (i & 0xFFFF)
+
+    def _mflr(self, t: int) -> int:
+        return 0x7C0802A6 | self._rt(t)
+
+    def _mtlr(self, t: int) -> int:
+        return 0x7C0803A6 | self._rt(t)
+
+    def _mtctr(self, t: int) -> int:
+        return 0x7C0903A6 | self._rt(t)
+
+
 def _ppc64_stubs_section() -> _ElfSection:
     # The ppc64 module loader (arch/powerpc/kernel/module_64.c) rejects any
     # module that does not contain a .stubs section. We never emit a

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -897,6 +897,8 @@ class _Kmodify:
         data: bytes,
         data_alignment: int,
         symbols: Sequence[_ElfSymbol],
+        toc: bytes = b"",
+        toc_relocations: Sequence[_ElfRelocation] = (),
     ) -> int:
         struct_module = self.prog.type("struct module")
 
@@ -972,6 +974,24 @@ class _Kmodify:
         if versions_section is not None:
             sections.append(versions_section)
 
+        # Add any sections the architecture requires unconditionally (e.g. the
+        # mandatory empty .stubs section on ppc64).
+        for section_factory in getattr(self.arch, "MODULE_SECTIONS", ()):
+            sections.append(section_factory())
+
+        # Add the Table of Contents section if the code generator produced one
+        # (ppc64le addresses .data through it).
+        if toc:
+            sections.append(
+                _ElfSection(
+                    name=".toc",
+                    type=SHT.PROGBITS,
+                    flags=SHF.WRITE | SHF.ALLOC,
+                    data=toc,
+                    addralign=8,
+                )
+            )
+
         symbols = [
             *symbols,
             _ElfSymbol(
@@ -1011,6 +1031,8 @@ class _Kmodify:
                 )
             ],
         }
+        if toc_relocations:
+            relocations[".toc"] = toc_relocations
 
         with open(_memfd_create(module_name.decode() + ".ko"), "wb") as f:
             _write_elf(
@@ -1093,7 +1115,7 @@ def write_memory(prog: Program, address: IntegerLike, value: bytes) -> None:
     sizeof_int = sizeof(prog.type("int"))
     sizeof_void_p = sizeof(prog.type("void *"))
     sizeof_size_t = sizeof(prog.type("size_t"))
-    code, code_relocations, _, _ = kmodify.arch.code_gen(
+    code, code_relocations, toc, toc_relocations = kmodify.arch.code_gen(
         _Function(
             [
                 # copy_to_kernel_nofault() can still fault in some cases; see
@@ -1129,6 +1151,8 @@ def write_memory(prog: Program, address: IntegerLike, value: bytes) -> None:
         name=f"write_{len(value)}",
         code=code,
         code_relocations=code_relocations,
+        toc=toc,
+        toc_relocations=toc_relocations,
         data=value + b"\0",
         # Align generously so that the copy can use larger units and small
         # copies can be slightly less racy.
@@ -1184,7 +1208,7 @@ def _modify_bit(prog: Program, nr: int, address: int, value: bool) -> None:
         # I'm not sure about bit fields. kmodify only supports little-endian
         # architectures at the moment anyways.
         raise NotImplementedError("_modify_bit() is only implemented for little-endian")
-    code, code_relocations, _, _ = kmodify.arch.code_gen(
+    code, code_relocations, toc, toc_relocations = kmodify.arch.code_gen(
         _Function(
             [
                 _Call(
@@ -1211,6 +1235,8 @@ def _modify_bit(prog: Program, nr: int, address: int, value: bool) -> None:
         name="set_bit" if value else "clear_bit",
         code=code,
         code_relocations=code_relocations,
+        toc=toc,
+        toc_relocations=toc_relocations,
         data=b"\0",
         data_alignment=1,
         symbols=[
@@ -1562,12 +1588,16 @@ def _insert_call_function(
 
     function_body.append(_Return(_Integer(sizeof_int, -errno.EINPROGRESS)))
 
-    code, code_relocations, _, _ = kmodify.arch.code_gen(_Function(function_body))
+    code, code_relocations, toc, toc_relocations = kmodify.arch.code_gen(
+        _Function(function_body)
+    )
 
     ret = kmodify.insert(
         name=name,
         code=code,
         code_relocations=code_relocations,
+        toc=toc,
+        toc_relocations=toc_relocations,
         data=data,
         data_alignment=data_alignment,
         symbols=symbols,

--- a/drgn/helpers/experimental/kmodify.py
+++ b/drgn/helpers/experimental/kmodify.py
@@ -1,4 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+# (C) Copyright IBM Corp. 2026
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 """
@@ -452,6 +453,16 @@ class _Function(NamedTuple):
     body: Sequence[_FunctionBodyNode]
 
 
+class _CodeGenResult(NamedTuple):
+    code: bytes
+    code_relocations: Sequence[_ElfRelocation]
+    # Architectures that address their own sections through a Table of Contents
+    # (ppc64le) emit a .toc section and its relocations here. Architectures that
+    # don't (x86-64) leave these empty.
+    toc: bytes = b""
+    toc_relocations: Sequence[_ElfRelocation] = ()
+
+
 class _CodeGen_x86_64:
     _R_X86_64_PC32 = 2
     _R_X86_64_PLT32 = 4
@@ -712,7 +723,9 @@ class _Arch_X86_64:
     ABSOLUTE_ADDRESS_RELOCATION_TYPE = 1  # R_X86_64_64
 
     @staticmethod
-    def code_gen(func: _Function) -> Tuple[bytes, Sequence[_ElfRelocation]]:
+    def code_gen(
+        func: _Function, symbol_addresses: Optional[Mapping[str, int]] = None
+    ) -> _CodeGenResult:
         needed_stack_size = 0
         for node in func.body:
             if not isinstance(node, _Call):
@@ -754,7 +767,7 @@ class _Arch_X86_64:
 
         code_gen.leave_frame()
 
-        return code_gen.code, code_gen.relocations
+        return _CodeGenResult(bytes(code_gen.code), code_gen.relocations)
 
 
 def _find_exported_symbol_in_section(
@@ -1080,7 +1093,7 @@ def write_memory(prog: Program, address: IntegerLike, value: bytes) -> None:
     sizeof_int = sizeof(prog.type("int"))
     sizeof_void_p = sizeof(prog.type("void *"))
     sizeof_size_t = sizeof(prog.type("size_t"))
-    code, code_relocations = kmodify.arch.code_gen(
+    code, code_relocations, _, _ = kmodify.arch.code_gen(
         _Function(
             [
                 # copy_to_kernel_nofault() can still fault in some cases; see
@@ -1171,7 +1184,7 @@ def _modify_bit(prog: Program, nr: int, address: int, value: bool) -> None:
         # I'm not sure about bit fields. kmodify only supports little-endian
         # architectures at the moment anyways.
         raise NotImplementedError("_modify_bit() is only implemented for little-endian")
-    code, code_relocations = kmodify.arch.code_gen(
+    code, code_relocations, _, _ = kmodify.arch.code_gen(
         _Function(
             [
                 _Call(
@@ -1549,7 +1562,7 @@ def _insert_call_function(
 
     function_body.append(_Return(_Integer(sizeof_int, -errno.EINPROGRESS)))
 
-    code, code_relocations = kmodify.arch.code_gen(_Function(function_body))
+    code, code_relocations, _, _ = kmodify.arch.code_gen(_Function(function_body))
 
     ret = kmodify.insert(
         name=name,

--- a/tests/linux_kernel/helpers/test_kmodify.py
+++ b/tests/linux_kernel/helpers/test_kmodify.py
@@ -4,6 +4,7 @@
 import os
 from pathlib import Path
 import random
+import sys
 import unittest
 
 from _drgn_util.platform import NORMALIZED_MACHINE_NAME
@@ -20,7 +21,8 @@ from drgn.helpers.experimental.kmodify import (
 from tests.linux_kernel import LinuxKernelTestCase, skip_unless_have_test_kmod
 
 skip_unless_have_kmodify = unittest.skipUnless(
-    NORMALIZED_MACHINE_NAME == "x86_64",
+    NORMALIZED_MACHINE_NAME == "x86_64"
+    or (NORMALIZED_MACHINE_NAME == "ppc64" and sys.byteorder == "little"),
     f"kmodify is not implemented for {NORMALIZED_MACHINE_NAME}",
 )
 

--- a/tests/linux_kernel/kmod/drgn_test.c
+++ b/tests/linux_kernel/kmod/drgn_test.c
@@ -2448,7 +2448,7 @@ static void drgn_test_search_exit(void)
 
 // kmodify
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || (defined(__powerpc64__) && defined(__LITTLE_ENDIAN__))
 enum drgn_kmodify_enum {
 	DRGN_KMODIFY_ONE = 1,
 	DRGN_KMODIFY_TWO,

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -350,6 +350,110 @@ class TestPPC64CodeGen(unittest.TestCase):
         self.assertEqual(stdu, _CodeGen_ppc64le()._stdu(1, 1, -96))
 
 
+class TestPPC64ModuleSymbols(unittest.TestCase):
+    def test_toc_symbol_present_for_rel16_relocation(self):
+        # The ppc64le prologue emits R_PPC64_REL16_HA/_LO relocations against the
+        # special ".TOC." symbol. The kernel's dedotify() resolves it, but only
+        # if the module's symbol table actually contains a ".TOC." (SHN_UNDEF)
+        # symbol. Without it, _write_elf raises KeyError('.TOC.').
+        import io
+
+        from _drgn_util.elf import SHF, SHN, SHT, STB, STT
+        from drgn.helpers.experimental.kmodify import (
+            _Arch_PPC64,
+            _ElfRelocation,
+            _ElfSection,
+            _ElfSymbol,
+            _write_elf,
+        )
+
+        toc_symbols = [s for s in _Arch_PPC64.MODULE_SYMBOLS if s.name == ".TOC."]
+        self.assertEqual(len(toc_symbols), 1)
+        self.assertEqual(toc_symbols[0].section, SHN.UNDEF)
+
+        sections = [
+            _ElfSection(
+                name=".init.text",
+                type=SHT.PROGBITS,
+                flags=SHF.ALLOC | SHF.EXECINSTR,
+                data=b"\0" * 8,
+            )
+        ]
+        symbols = [
+            *_Arch_PPC64.MODULE_SYMBOLS,
+            _ElfSymbol(
+                name="init_module",
+                value=0,
+                size=8,
+                type=STT.FUNC,
+                binding=STB.GLOBAL,
+                section=".init.text",
+            ),
+        ]
+        relocations = {
+            ".init.text": [
+                _ElfRelocation(
+                    offset=0,
+                    type=252,  # R_PPC64_REL16_HA
+                    symbol_name=".TOC.",
+                    section_symbol=False,
+                )
+            ]
+        }
+        out = io.BytesIO()
+        _write_elf(
+            out,
+            machine=21,
+            is_little_endian=True,
+            is_64_bit=True,
+            rela=True,
+            flags=_Arch_PPC64.ELF_FLAGS,
+            sections=sections,
+            symbols=symbols,
+            relocations=relocations,
+        )
+        self.assertGreater(len(out.getvalue()), 0)
+
+    def test_elf_header_has_elfv2_abi_flag(self):
+        # The ppc64le module loader's module_elf_check_arch() requires
+        # e_flags & 0x3 == 2 (ELFv2 ABI); a zero e_flags is rejected with
+        # -ENOEXEC ("Invalid module architecture in ELF header").
+        import io
+
+        from _drgn_util.elf import SHF, SHT
+        from drgn.helpers.experimental.kmodify import (
+            _Arch_PPC64,
+            _ElfSection,
+            _write_elf,
+        )
+
+        self.assertEqual(_Arch_PPC64.ELF_FLAGS, 2)
+
+        out = io.BytesIO()
+        _write_elf(
+            out,
+            machine=21,
+            is_little_endian=True,
+            is_64_bit=True,
+            rela=True,
+            flags=_Arch_PPC64.ELF_FLAGS,
+            sections=[
+                _ElfSection(
+                    name=".init.text",
+                    type=SHT.PROGBITS,
+                    flags=SHF.ALLOC | SHF.EXECINSTR,
+                    data=b"\0" * 4,
+                )
+            ],
+            symbols=[],
+            relocations={},
+        )
+        data = out.getvalue()
+        # 64-bit LE ELF header: e_flags is a 4-byte field at offset 48.
+        e_flags = int.from_bytes(data[48:52], "little")
+        self.assertEqual(e_flags & 0x3, 2)
+
+
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):
         from drgn.helpers.experimental.kmodify import _Arch_PPC64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -57,6 +57,40 @@ class TestX86_64CodegenGolden(unittest.TestCase):
         self.assertEqual(list(result.toc_relocations), [])
 
 
+def _words(code):
+    return [
+        int.from_bytes(bytes(code)[i : i + 4], "little") for i in range(0, len(code), 4)
+    ]
+
+
+class TestPPC64Emitters(unittest.TestCase):
+    def cg(self):
+        from drgn.helpers.experimental.kmodify import _CodeGen_ppc64le
+
+        return _CodeGen_ppc64le()
+
+    def test_word_emitted_little_endian(self):
+        cg = self.cg()
+        cg._emit(0x60000000)  # nop (ori 0,0,0) — known-good constant
+        self.assertEqual(bytes(cg.code), b"\x00\x00\x00\x60")
+
+    def test_known_constant_encodings(self):
+        # Independently-known encodings (from the Power ISA / kernel PPC_RAW_*).
+        cg = self.cg()
+        self.assertEqual(cg._mflr(0), 0x7C0802A6)  # mflr r0
+        self.assertEqual(cg._mtctr(12), 0x7C0903A6 | (12 << 21))  # mtctr r12
+        self.assertEqual(cg._BLR, 0x4E800020)
+        self.assertEqual(cg._BCTRL, 0x4E800421)
+
+    def test_li_negative_sign_extends(self):
+        cg = self.cg()
+        cg._emit(cg._addi(3, 0, -12345))  # li r3, -12345
+        self.assertEqual(
+            bytes(cg.code),
+            (0x38000000 | (3 << 21) | (-12345 & 0xFFFF)).to_bytes(4, "little"),
+        )
+
+
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):
         from drgn.helpers.experimental.kmodify import _Arch_PPC64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -90,6 +90,46 @@ class TestPPC64Emitters(unittest.TestCase):
             (0x38000000 | (3 << 21) | (-12345 & 0xFFFF)).to_bytes(4, "little"),
         )
 
+    def test_load_imm_small_negative_is_single_li(self):
+        cg = self.cg()
+        cg._load_imm(3, -12345)  # fits signed 16-bit -> one li (sign-extends)
+        self.assertEqual(_words(cg.code), [cg._addi(3, 0, -12345)])
+
+    def test_load_imm_32bit(self):
+        cg = self.cg()
+        cg._load_imm(3, 0x0001D431)  # > 16-bit, < 2^31 -> lis + ori
+        self.assertEqual(
+            _words(cg.code),
+            [cg._addis(3, 0, 0x0001), cg._ori(3, 3, 0xD431)],
+        )
+
+    def test_load_imm_full64_all_pieces(self):
+        cg = self.cg()
+        cg._load_imm(3, 0x123456789ABCDEF0)
+        self.assertEqual(
+            _words(cg.code),
+            [
+                cg._addis(3, 0, 0x1234),  # lis  -> bits 48-63
+                cg._ori(3, 3, 0x5678),  # ori  -> bits 32-47
+                cg._rldicr32(3, 3),  # << 32
+                cg._oris(3, 3, 0x9ABC),  # oris -> bits 16-31
+                cg._ori(3, 3, 0xDEF0),  # ori  -> bits 0-15
+            ],
+        )
+
+    def test_load_imm_full64_kernel_address(self):
+        # Typical kernel text address: high 16 bits set, low 16 set, middle 0.
+        cg = self.cg()
+        cg._load_imm(12, 0xC000000000001234)
+        self.assertEqual(
+            _words(cg.code),
+            [
+                cg._addis(12, 0, 0xC000),  # lis (middle pieces skipped)
+                cg._rldicr32(12, 12),
+                cg._ori(12, 12, 0x1234),
+            ],
+        )
+
 
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -234,6 +234,66 @@ class TestPPC64Call(unittest.TestCase):
         self.assertIn(cg._std(11, 1, 96), words)
 
 
+class TestPPC64Lowering(unittest.TestCase):
+    def cg(self):
+        from drgn.helpers.experimental.kmodify import _CodeGen_ppc64le
+
+        return _CodeGen_ppc64le()
+
+    def test_store_return_value_sizes(self):
+        for size, op_name in ((1, "_stb"), (2, "_sth"), (4, "_stw"), (8, "_std")):
+            cg = self.cg()
+            cg.store_return_value(size, _Symbol(".data", section=True, offset=0))
+            op = getattr(cg, op_name)
+            # r11 = &.data (ld, no addi for offset 0), then store r3 via r11.
+            self.assertEqual(_words(cg.code), [cg._ld(11, 2, 0), op(3, 11, 0)])
+
+    def test_return_not_last_branches_to_epilogue(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        n = len(cg.code)
+        cg.return_(_Integer(4, -115), last=False)
+        words = _words(bytes(cg.code)[n:])
+        self.assertEqual(words[0], cg._addi(3, 0, -115))  # li r3, -115
+        self.assertEqual(words[1] & 0xFC000000, 0x48000000)  # b (to be fixed up)
+        self.assertEqual(cg._epilogue_branches, [n + 4])
+
+    def test_return_last_falls_through(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        n = len(cg.code)
+        cg.return_(_Integer(4, -115), last=True)
+        self.assertEqual(_words(bytes(cg.code)[n:]), [cg._addi(3, 0, -115)])
+        self.assertEqual(cg._epilogue_branches, [])
+
+    def test_return_if_nonzero_tests_before_overwrite(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        n = len(cg.code)
+        cg.return_if_last_return_value_nonzero(_Integer(4, -14))
+        words = _words(bytes(cg.code)[n:])
+        self.assertEqual(words[0], cg._cmpdi(3, 0))  # cmpdi r3,0 BEFORE overwrite
+        self.assertEqual(words[1], cg._addi(3, 0, -14))  # li r3,-14
+        self.assertEqual(words[2] & 0xFC000000, 0x40000000)  # bc (bne)
+
+    def test_atomic_set_bit_loop(self):
+        cg = self.cg()
+        cg.atomic_set_bit(3, _Integer(8, 0x1005))
+        words = _words(cg.code)
+        # mask = (1<<3) << (8*(0x1005 & 7)) = 8 << 40
+        # ldarx r0,0,r3 ; or r0,r0,r4 ; stdcx. r0,0,r3 ; bne- (back)
+        self.assertIn(cg._ldarx(0, 0, 3), words)
+        self.assertIn(cg._or(0, 0, 4), words)
+        self.assertIn(cg._stdcx(0, 0, 3), words)
+        self.assertEqual(words[-1] & 0xFC000000, 0x40000000)  # bc backward
+
+    def test_atomic_clear_bit_uses_andc(self):
+        cg = self.cg()
+        cg.atomic_clear_bit(0, _Integer(8, 0x2000))
+        words = _words(cg.code)
+        self.assertIn(cg._andc(0, 0, 4), words)
+
+
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):
         from drgn.helpers.experimental.kmodify import _Arch_PPC64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -55,3 +55,14 @@ class TestX86_64CodegenGolden(unittest.TestCase):
         )
         self.assertEqual(bytes(result.toc), b"")
         self.assertEqual(list(result.toc_relocations), [])
+
+
+class TestArchSelection(unittest.TestCase):
+    def test_ppc64_arch_constants(self):
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64
+
+        self.assertEqual(_Arch_PPC64.ELF_MACHINE, 21)  # EM_PPC64
+        self.assertTrue(_Arch_PPC64.RELA)
+        self.assertEqual(
+            _Arch_PPC64.ABSOLUTE_ADDRESS_RELOCATION_TYPE, 38
+        )  # R_PPC64_ADDR64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -201,6 +201,39 @@ class TestPPC64FrameAndToc(unittest.TestCase):
         )
 
 
+class TestPPC64Call(unittest.TestCase):
+    def cg(self):
+        from drgn.helpers.experimental.kmodify import _CodeGen_ppc64le
+
+        return _CodeGen_ppc64le()
+
+    def test_call_two_args(self):
+        cg = self.cg()
+        cg.enter_frame(32)
+        base = len(cg.code)
+        # call() takes the resolved target ADDRESS (int), not a _Symbol.
+        cg.call(
+            0xC000000000001234,
+            [_Integer(8, 0xDEADBEEF00), _Symbol(".data", section=True, offset=8)],
+        )
+        words = _words(bytes(cg.code)[base:])
+        # arg0 immediate -> r3 (first instruction loads r3)
+        self.assertEqual(words[0], cg._addis(3, 0, (0xDEADBEEF00 >> 48) & 0xFFFF))
+        # tail: mtctr r12 ; bctrl ; ld r2,24(r1)
+        self.assertEqual(words[-3], cg._mtctr(12))
+        self.assertEqual(words[-2], cg._BCTRL)
+        self.assertEqual(words[-1], cg._ld(2, 1, 24))
+
+    def test_call_stack_args_use_param_save_area(self):
+        cg = self.cg()
+        cg.enter_frame(32 + 8 * 9)
+        base = len(cg.code)
+        cg.call(0xC000000000000010, [_Integer(8, i) for i in range(9)])
+        words = _words(bytes(cg.code)[base:])
+        # The 9th arg (index 8) is staged via r11 into 32 + 8*8 = 96(r1).
+        self.assertIn(cg._std(11, 1, 96), words)
+
+
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):
         from drgn.helpers.experimental.kmodify import _Arch_PPC64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -131,6 +131,76 @@ class TestPPC64Emitters(unittest.TestCase):
         )
 
 
+class TestPPC64FrameAndToc(unittest.TestCase):
+    def cg(self):
+        from drgn.helpers.experimental.kmodify import _CodeGen_ppc64le
+
+        return _CodeGen_ppc64le()
+
+    def test_prologue_slot_ordering(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        words = _words(cg.code)
+        # addis r2,r12,..; addi r2,r2,..; mflr r0; std r0,16(r1);
+        # stdu r1,-32(r1); std r2,24(r1)
+        self.assertEqual(words[2], cg._mflr(0))
+        self.assertEqual(words[3], cg._std(0, 1, 16))  # LR -> caller frame, PRE-stdu
+        self.assertEqual(words[4], cg._stdu(1, 1, -32))
+        self.assertEqual(words[5], cg._std(2, 1, 24))  # TOC -> own frame, POST-stdu
+
+    def test_prologue_toc_relocations(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        # The @ha and @l relocations must be anchored to the same instruction:
+        # the addi (offset 4) carries addend +4 so the kernel evaluates both
+        # against (.TOC. - addis), otherwise r2 ends up off by 4.
+        self.assertEqual(
+            [(r.offset, r.type, r.symbol_name, r.addend) for r in cg.relocations[:2]],
+            [
+                (0, cg._R_PPC64_REL16_HA, ".TOC.", 0),
+                (4, cg._R_PPC64_REL16_LO, ".TOC.", 4),
+            ],
+        )
+
+    def test_frame_size_includes_param_area(self):
+        cg = self.cg()
+        cg.enter_frame(32 + 8 * 10)  # 10 args -> 112, align 16 -> 112
+        self.assertEqual(_words(cg.code)[4], cg._stdu(1, 1, -112))
+
+    def test_epilogue(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        cg.leave_frame()
+        tail = _words(cg.code)[-4:]
+        self.assertEqual(
+            tail, [cg._addi(1, 1, 32), cg._ld(0, 1, 16), cg._mtlr(0), cg._BLR]
+        )
+
+    def test_load_data_ptr_emits_toc_and_addr64(self):
+        cg = self.cg()
+        cg._load_data_ptr(3, 8)
+        words = _words(cg.code)
+        # ld r3, 0(r2) ; addi r3, r3, 8
+        self.assertEqual(words, [cg._ld(3, 2, 0), cg._addi(3, 3, 8)])
+        # TOC16_DS reloc against the .toc section on the ld.
+        self.assertEqual(
+            [
+                (r.offset, r.type, r.symbol_name, r.section_symbol)
+                for r in cg.relocations
+            ],
+            [(0, cg._R_PPC64_TOC16_DS, ".toc", True)],
+        )
+        # One 8-byte slot filled by R_PPC64_ADDR64 against .data.
+        self.assertEqual(bytes(cg.toc), b"\0" * 8)
+        self.assertEqual(
+            [
+                (r.offset, r.type, r.symbol_name, r.section_symbol)
+                for r in cg.toc_relocations
+            ],
+            [(0, cg._R_PPC64_ADDR64, ".data", True)],
+        )
+
+
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):
         from drgn.helpers.experimental.kmodify import _Arch_PPC64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -528,3 +528,47 @@ class TestPPC64BranchRange(unittest.TestCase):
         self._pad_body_to_displacement(cg, 0x8000)  # one past the bc reach
         with self.assertRaises(OverflowError):
             cg.leave_frame()
+
+
+class _FakeSymbol:
+    def __init__(self, address):
+        self.address = address
+
+
+class _FakeProgram:
+    # Minimal duck-typed stand-in: _kernel_function_address() must resolve via
+    # the symbol table (prog.symbol(name).address), never the debug-info object
+    # (prog[name]).
+    def __init__(self, symbols):
+        self._symbols = symbols
+
+    def symbol(self, name):
+        try:
+            return _FakeSymbol(self._symbols[name])
+        except KeyError:
+            raise LookupError(name) from None
+
+    def __getitem__(self, name):
+        raise AssertionError(
+            f"_kernel_function_address must not consult debug info (prog[{name!r}])"
+        )
+
+
+class TestKernelFunctionAddress(unittest.TestCase):
+    def test_uses_symbol_table_not_debuginfo(self):
+        # Symbol-table address is authoritative: with -freorder-blocks-and-
+        # partition the debug-info address can name a cold fragment, and calling
+        # it would run only part of the function.
+        from drgn.helpers.experimental.kmodify import _kernel_function_address
+
+        prog = _FakeProgram({"copy_to_kernel_nofault": 0xFFFFFFFF81000000})
+        self.assertEqual(
+            _kernel_function_address(prog, "copy_to_kernel_nofault"),
+            0xFFFFFFFF81000000,
+        )
+
+    def test_missing_symbol_raises_lookuperror(self):
+        from drgn.helpers.experimental.kmodify import _kernel_function_address
+
+        with self.assertRaises(LookupError):
+            _kernel_function_address(_FakeProgram({}), "nonexistent")

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -49,7 +49,9 @@ _X86_64_GOLDEN_RELOCS = [
 class TestX86_64CodegenGolden(unittest.TestCase):
     def test_codegen_unchanged(self):
         result = _Arch_X86_64.code_gen(_X86_64_GOLDEN_FUNCTION)
-        # Works pre-refactor (tuple) and post-refactor (_CodeGenResult).
-        code, relocs = result[0], result[1]
-        self.assertEqual(bytes(code), _X86_64_GOLDEN_CODE)
-        self.assertEqual([tuple(r) for r in relocs], _X86_64_GOLDEN_RELOCS)
+        self.assertEqual(bytes(result.code), _X86_64_GOLDEN_CODE)
+        self.assertEqual(
+            [tuple(r) for r in result.code_relocations], _X86_64_GOLDEN_RELOCS
+        )
+        self.assertEqual(bytes(result.toc), b"")
+        self.assertEqual(list(result.toc_relocations), [])

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -463,3 +463,42 @@ class TestArchSelection(unittest.TestCase):
         self.assertEqual(
             _Arch_PPC64.ABSOLUTE_ADDRESS_RELOCATION_TYPE, 38
         )  # R_PPC64_ADDR64
+
+
+class TestPPC64BranchRange(unittest.TestCase):
+    # A conditional bc to the epilogue has only a signed 14-bit (32 KiB)
+    # displacement, and call_functions() over a long list can grow the body. If
+    # it ever overflows, the fixup must raise instead of silently truncating to
+    # a wild branch target.
+    _NOP = b"\x60\x00\x00\x00"  # ori 0,0,0
+
+    def cg(self):
+        from drgn.helpers.experimental.kmodify import _CodeGen_ppc64le
+
+        return _CodeGen_ppc64le()
+
+    def _pad_body_to_displacement(self, cg, disp):
+        # Pad the body with nops so the recorded epilogue branch ends up exactly
+        # `disp` bytes from the (about to be appended) epilogue.
+        branch_offset = cg._epilogue_branches[-1]
+        pad = disp - (len(cg.code) - branch_offset)
+        self.assertGreaterEqual(pad, 0)
+        cg.code.extend(self._NOP * (pad // 4))
+
+    def test_conditional_branch_in_range_is_fixed_up(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        cg.return_if_last_return_value_nonzero(_Integer(4, -14))
+        branch_offset = cg._epilogue_branches[-1]
+        self._pad_body_to_displacement(cg, 0x7FFC)  # largest in-range bc
+        cg.leave_frame()
+        word = int.from_bytes(cg.code[branch_offset : branch_offset + 4], "little")
+        self.assertEqual(word & 0xFFFC, 0x7FFC)
+
+    def test_conditional_branch_overflow_raises(self):
+        cg = self.cg()
+        cg.enter_frame(0)
+        cg.return_if_last_return_value_nonzero(_Integer(4, -14))
+        self._pad_body_to_displacement(cg, 0x8000)  # one past the bc reach
+        with self.assertRaises(OverflowError):
+            cg.leave_frame()

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -1,0 +1,55 @@
+# (C) Copyright IBM Corp. 2026
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""
+Host-runnable unit tests for the kmodify machine-code generators. These exercise
+the pure ``_Arch_*.code_gen`` functions with no kernel or virtual machine; the
+end-to-end authority for instruction encoding is the integration test
+(``tests/linux_kernel/helpers/test_kmodify.py``) run on each architecture's VM.
+"""
+
+import unittest
+
+from drgn.helpers.experimental.kmodify import (
+    _Arch_X86_64,
+    _Call,
+    _Function,
+    _Integer,
+    _Return,
+    _ReturnIfLastReturnValueNonZero,
+    _StoreReturnValue,
+    _Symbol,
+)
+
+_X86_64_GOLDEN_FUNCTION = _Function(
+    [
+        _Call(
+            _Symbol("func"),
+            [_Integer(4, -12345), _Symbol(".data", section=True, offset=8)],
+        ),
+        _StoreReturnValue(8, _Symbol(".data", section=True)),
+        _ReturnIfLastReturnValueNonZero(_Integer(4, -14)),
+        _Return(_Integer(4, -115)),
+    ]
+)
+
+# Captured from main before the _Arch refactor.
+_X86_64_GOLDEN_CODE = (
+    b"\xf3\x0f\x1e\xfaUH\x89\xe5\xbf\xc7\xcf\xff\xffH\xc7\xc6\x00\x00\x00\x00"
+    b"\xe8\x00\x00\x00\x00H\x89\x05\x00\x00\x00\x00H\x89\xc2\xb8\xf2\xff\xff"
+    b"\xffH\x85\xd2\x0f\x85\x05\x00\x00\x00\xb8\x8d\xff\xff\xff\xc9\xc3"
+)
+_X86_64_GOLDEN_RELOCS = [
+    (16, 11, ".data", True, 8),
+    (21, 4, "func", False, -4),
+    (28, 2, ".data", True, -4),
+]
+
+
+class TestX86_64CodegenGolden(unittest.TestCase):
+    def test_codegen_unchanged(self):
+        result = _Arch_X86_64.code_gen(_X86_64_GOLDEN_FUNCTION)
+        # Works pre-refactor (tuple) and post-refactor (_CodeGenResult).
+        code, relocs = result[0], result[1]
+        self.assertEqual(bytes(code), _X86_64_GOLDEN_CODE)
+        self.assertEqual([tuple(r) for r in relocs], _X86_64_GOLDEN_RELOCS)

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -294,6 +294,62 @@ class TestPPC64Lowering(unittest.TestCase):
         self.assertIn(cg._andc(0, 0, 4), words)
 
 
+class TestPPC64CodeGen(unittest.TestCase):
+    def test_code_gen_requires_symbol_addresses(self):
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64
+
+        with self.assertRaises(ValueError):
+            _Arch_PPC64.code_gen(_Function([_Return(_Integer(4, 0))]))
+
+    def test_code_gen_full_function(self):
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64, _CodeGen_ppc64le
+
+        func = _Function(
+            [
+                _Call(_Symbol("func"), [_Integer(4, -12345)]),
+                _ReturnIfLastReturnValueNonZero(_Integer(4, -14)),
+                _Return(_Integer(4, -115)),
+            ]
+        )
+        result = _Arch_PPC64.code_gen(
+            func, symbol_addresses={"func": 0xC000000000001234}
+        )
+        self.assertEqual(len(result.code) % 4, 0)
+        # First instruction is the global-entry addis r2, r12, ...
+        self.assertEqual(_words(result.code)[0], _CodeGen_ppc64le()._addis(2, 12, 0))
+        # Only loader-supported relocation types are emitted.
+        allowed = {38, 250, 252, 63, 10}
+        self.assertTrue({r.type for r in result.code_relocations} <= allowed)
+        self.assertTrue({r.type for r in result.toc_relocations} <= allowed)
+
+    def test_code_gen_rejects_large_argument(self):
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64
+
+        func = _Function([_Call(_Symbol("func"), [_Integer(16, 0)])])
+        with self.assertRaises(NotImplementedError):
+            _Arch_PPC64.code_gen(func, symbol_addresses={"func": 0x1000})
+
+    def test_code_gen_reserves_min_param_save_area_for_variadic_callee(self):
+        # A variadic callee (e.g. _printk) spills its argument GPRs r3-r10
+        # (eight doublewords) into the caller-provided parameter save area. If
+        # the frame reserves fewer than eight doublewords there, the spill runs
+        # off the end of the frame and clobbers the caller's saved LR at
+        # old_sp+16, so init_module returns through a corrupt link register.
+        # The ELFv2 ABI requires a minimum eight-doubleword parameter save area
+        # whenever a function makes a call, independent of its own argument
+        # count.
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64, _CodeGen_ppc64le
+
+        func = _Function([_Call(_Symbol("func"), [_Integer(4, 1)])])  # one arg
+        result = _Arch_PPC64.code_gen(
+            func, symbol_addresses={"func": 0xC000000000001234}
+        )
+        # Prologue word index 4 is `stdu r1, r1, -frame`. The frame must reserve
+        # 32 (linkage) + 64 (eight-doubleword parameter save area) = 96 bytes.
+        stdu = _words(result.code)[4]
+        self.assertEqual(stdu, _CodeGen_ppc64le()._stdu(1, 1, -96))
+
+
 class TestArchSelection(unittest.TestCase):
     def test_ppc64_arch_constants(self):
         from drgn.helpers.experimental.kmodify import _Arch_PPC64

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -255,7 +255,7 @@ class TestPPC64Lowering(unittest.TestCase):
         cg.return_(_Integer(4, -115), last=False)
         words = _words(bytes(cg.code)[n:])
         self.assertEqual(words[0], cg._addi(3, 0, -115))  # li r3, -115
-        self.assertEqual(words[1] & 0xFC000000, 0x48000000)  # b (to be fixed up)
+        self.assertEqual(words[1], cg._B)  # b (to be fixed up)
         self.assertEqual(cg._epilogue_branches, [n + 4])
 
     def test_return_last_falls_through(self):
@@ -274,7 +274,7 @@ class TestPPC64Lowering(unittest.TestCase):
         words = _words(bytes(cg.code)[n:])
         self.assertEqual(words[0], cg._cmpdi(3, 0))  # cmpdi r3,0 BEFORE overwrite
         self.assertEqual(words[1], cg._addi(3, 0, -14))  # li r3,-14
-        self.assertEqual(words[2] & 0xFC000000, 0x40000000)  # bc (bne)
+        self.assertEqual(words[2], cg._BNE_CR0)  # bc (bne)
 
     def test_atomic_set_bit_loop(self):
         cg = self.cg()
@@ -285,7 +285,7 @@ class TestPPC64Lowering(unittest.TestCase):
         self.assertIn(cg._ldarx(0, 0, 3), words)
         self.assertIn(cg._or(0, 0, 4), words)
         self.assertIn(cg._stdcx(0, 0, 3), words)
-        self.assertEqual(words[-1] & 0xFC000000, 0x40000000)  # bc backward
+        self.assertEqual(words[-1] & 0xFFFF0000, cg._BNE_CR0)  # bc backward
 
     def test_atomic_clear_bit_uses_andc(self):
         cg = self.cg()

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -465,6 +465,19 @@ class TestArchSelection(unittest.TestCase):
         )  # R_PPC64_ADDR64
 
 
+class TestPPC64ZeroCallTarget(unittest.TestCase):
+    def test_code_gen_rejects_zero_call_target(self):
+        # ppc64le bakes the call target into the code as an immediate, so a zero
+        # address (e.g. an unresolved symbol) can't be fixed up by the loader the
+        # way an x86-64 relocation would be. It must fail fast instead of
+        # emitting a call to address 0.
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64
+
+        func = _Function([_Call(_Symbol("func"), [_Integer(4, 1)])])
+        with self.assertRaises(ValueError):
+            _Arch_PPC64.code_gen(func, symbol_addresses={"func": 0})
+
+
 class TestPPC64BranchRange(unittest.TestCase):
     # A conditional bc to the epilogue has only a signed 14-bit (32 KiB)
     # displacement, and call_functions() over a long list can grow the body. If

--- a/tests/test_kmodify_codegen.py
+++ b/tests/test_kmodify_codegen.py
@@ -464,6 +464,19 @@ class TestArchSelection(unittest.TestCase):
             _Arch_PPC64.ABSOLUTE_ADDRESS_RELOCATION_TYPE, 38
         )  # R_PPC64_ADDR64
 
+    def test_both_arches_expose_optional_members(self):
+        # _Kmodify.insert() reads these directly (no getattr default), so every
+        # _Arch must declare them. x86-64 has no extra flags/sections/symbols.
+        from drgn.helpers.experimental.kmodify import _Arch_PPC64, _Arch_X86_64
+
+        for arch in (_Arch_X86_64, _Arch_PPC64):
+            self.assertIsInstance(arch.ELF_FLAGS, int)
+            self.assertIsInstance(tuple(arch.MODULE_SECTIONS), tuple)
+            self.assertIsInstance(tuple(arch.MODULE_SYMBOLS), tuple)
+        self.assertEqual(_Arch_X86_64.ELF_FLAGS, 0)
+        self.assertEqual(_Arch_X86_64.MODULE_SECTIONS, ())
+        self.assertEqual(_Arch_X86_64.MODULE_SYMBOLS, ())
+
 
 class TestPPC64ZeroCallTarget(unittest.TestCase):
     def test_code_gen_rejects_zero_call_target(self):


### PR DESCRIPTION
kmodify currently generates and inserts its helper module only for
x86-64. This series adds a second architecture, little-endian ppc64
(ELFv2), so that set_bit()/clear_bit()/write_memory()/call_function()
work on a running ppc64le kernel.

Approach
--------
The first patch pins the existing x86-64 code generator's output as a
golden unit test so the subsequent refactor is provably behavior-
preserving. The code generator is then split so an architecture can
return a _CodeGenResult (code + relocations + an optional TOC) and can
contribute its own ELF sections and symbols. The ppc64le generator is
added incrementally (emitters, 64-bit immediate materialization,
prologue/TOC access, call lowering, returns and atomic bit ops, then
the AST walker that ties them together), followed by the .TOC. symbol
and ELFv2 e_flags the module loader requires.

ppc64le specifics worth a reviewer's attention:

- Calls are lowered as an indirect bctrl through r12. ppc64le has no
 loader-resolved relocation for this call, so the target is baked in
 as an immediate; it must therefore be a live, stable kallsyms
 address (kmodify only ever modifies a running kernel). r12 carries
 the callee's global entry point, from which the callee recomputes
 its own TOC. A zero (unresolved) target is rejected up front.

- Kernel function addresses are resolved through the symbol table, not
 the debug-info object: with -freorder-blocks-and-partition the DWARF
 address can name a cold fragment, and KASLR shifts the runtime
 address away from the vmlinux value.

- Atomic {set,clear}_bit() use a doubleword ldarx/stdcx. loop with the
 bit placed in the correct little-endian byte lane, matching the
 kernel's unsigned-long bitop granularity.

- Big-endian ppc64 (ELFv1) is explicitly rejected; the test gates admit
 only little-endian ppc64 so they skip (rather than error) elsewhere.

Testing
-------
- New pure-Python unit tests (tests/test_kmodify_codegen.py, 34 cases)
 pin the x86-64 golden output and the ppc64le prologue/TOC/relocation
 structure, immediate materialization, branch-range checks, the zero-
 target guard, the shared _Arch interface, and symbol-table
 resolution. They run without a kernel or virtual machine.
- The kmodify integration tests (tests/linux_kernel/helpers/
 test_kmodify.py) were exercised under vmtest:
```
 arch: ppc64le (powerpc64le, ELFv2, little-endian)
 kernel: 6.19.14-vmtest41.1default, built with
 powerpc64-linux-gcc (GCC) 12.5.0
 config: CONFIG_PPC64=y, CONFIG_CPU_LITTLE_ENDIAN=y,
 CONFIG_PPC64_ELF_ABI_V2=y, CONFIG_MODULES=y,
 CONFIG_MODULE_UNLOAD=y, CONFIG_KALLSYMS_ALL=y,
 CONFIG_DEBUG_INFO_DWARF4=y, CONFIG_DEBUG_INFO_BTF=y;
 CONFIG_MODVERSIONS is not set
 emulation: qemu-system-ppc64le 10.1.5 (foreign-arch) on an
 x86_64 Fedora 43 host
 host libs: elfutils/libdw 0.195
 drgn: 0.2.0+20.g64e1ffab, CPython 3.13
 result: 34/34 kmodify integration tests pass
```
 Note: this run had CONFIG_MODVERSIONS=n, so the __versions-section
 path in _get_versions_section() was not exercised on ppc64le; that
 code is architecture-independent and is covered by the x86-64 run.

The two trailing patches harden the generator (branch-displacement
overflow checks, zero-target rejection, a uniform _Arch interface
replacing getattr() defaults) and document the call-path assumptions;
the last patch changes no generated bytes (verified by hashing the
code_gen output before and after).

David Christensen (18):
 tests: pin x86-64 kmodify codegen output before refactor
 drgn.helpers.experimental.kmodify: return _CodeGenResult from code_gen
 drgn.helpers.experimental.kmodify: add arch .toc and module sections
 drgn.helpers.experimental.kmodify: dispatch ppc64le, reject big-endian
 drgn.helpers.experimental.kmodify: add ppc64le instruction emitters
 drgn.helpers.experimental.kmodify: materialize ppc64le 64-bit immediates
 drgn.helpers.experimental.kmodify: add ppc64le prologue and TOC access
 drgn.helpers.experimental.kmodify: add ppc64le call lowering
 drgn.helpers.experimental.kmodify: add ppc64le returns and atomic bitops
 drgn.helpers.experimental.kmodify: add ppc64le AST walker (code_gen)
 drgn.helpers.experimental.kmodify: emit .TOC. symbol and ELFv2 e_flags
 drgn.helpers.experimental.kmodify: enable tests on little-endian ppc64
 tests: enable kmodify drgn_test fixtures on ppc64le
 drgn.helpers.experimental.kmodify: validate ppc64le branch displacements
 drgn.helpers.experimental.kmodify: reject a zero ppc64le call target
 drgn.helpers.experimental.kmodify: give every _Arch a uniform interface
 tests: cover _kernel_function_address symbol-table resolution
 drgn.helpers.experimental.kmodify: clarify ppc64le call diagnostics

Addresses ppc64le from issue #482 