### PR TITLE
Add BTF type & object finder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y btrfs-progs check dwarves libelf-dev libdw-dev libjson-c-dev libkdumpfile-dev libpcre2-dev qemu-kvm zstd ${{ matrix.cc == 'clang' && 'libomp-$(clang --version | sed -rn "s/.*clang version ([0-9]+).*/\\1/p")-dev' || '' }}
+          sudo apt-get install -y btrfs-progs check dwarves libbpf-dev libelf-dev libdw-dev libjson-c-dev libkdumpfile-dev libpcre2-dev qemu-kvm zstd ${{ matrix.cc == 'clang' && 'libomp-$(clang --version | sed -rn "s/.*clang version ([0-9]+).*/\\1/p")-dev' || '' }}
           # pyroute2 0.9.1 dropped support for Python < 3.9.
           if [[ "${{ matrix.python-version }}" =~ ^3\.[678]$ ]]; then
               pyroute2_version="<0.9.1"

--- a/README.rst
+++ b/README.rst
@@ -162,13 +162,13 @@ First, install dependencies:
 
   .. code-block:: console
 
-      $ sudo dnf install autoconf automake check-devel elfutils-debuginfod-client-devel elfutils-devel gcc git json-c-devel libkdumpfile-devel libtool make pcre2-devel pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
+      $ sudo dnf install autoconf automake check-devel elfutils-debuginfod-client-devel elfutils-devel gcc git json-c-devel libbpf-devel libkdumpfile-devel libtool make pcre2-devel pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
 
 * RHEL/CentOS < 9, Oracle Linux
 
   .. code-block:: console
 
-      $ sudo dnf install autoconf automake check-devel elfutils-devel gcc git json-c-devel libtool make pcre2-devel pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
+      $ sudo dnf install autoconf automake check-devel elfutils-devel gcc git json-c-devel libbpf-devel libtool make pcre2-devel pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
 
   Optionally, install ``libkdumpfile-devel`` from EPEL on RHEL/CentOS >= 8 or
   install `libkdumpfile <https://github.com/ptesarik/libkdumpfile>`_ from
@@ -187,7 +187,7 @@ First, install dependencies:
 
   .. code-block:: console
 
-      $ sudo apt install autoconf automake check gcc git libdebuginfod-dev libjson-c-dev libkdumpfile-dev liblzma-dev libelf-dev libdw-dev libpcre2-dev libtool make pkgconf python3 python3-dev python3-pip python3-setuptools zlib1g-dev
+      $ sudo apt install autoconf automake check gcc git libbpf-dev libdebuginfod-dev libjson-c-dev libkdumpfile-dev liblzma-dev libelf-dev libdw-dev libpcre2-dev libtool make pkgconf python3 python3-dev python3-pip python3-setuptools zlib1g-dev
 
   On Debian <= 11 (Bullseye) and Ubuntu <= 22.04 (Jammy Jellyfish),
   ``libkdumpfile-dev`` is not available, so you must install libkdumpfile from
@@ -197,19 +197,19 @@ First, install dependencies:
 
   .. code-block:: console
 
-      $ sudo pacman -S --needed autoconf automake check gcc git json-c libelf libkdumpfile libtool make pcre2 pkgconf python python-pip python-setuptools xz
+      $ sudo pacman -S --needed autoconf automake check gcc git json-c libbpf libelf libkdumpfile libtool make pcre2 pkgconf python python-pip python-setuptools xz
 
 * Gentoo
 
   .. code-block:: console
 
-      $ sudo emerge --noreplace --oneshot dev-build/autoconf dev-build/automake dev-libs/check dev-libs/elfutils dev-libs/json-c dev-libs/libpcre2 sys-devel/gcc dev-vcs/git dev-libs/libkdumpfile dev-build/libtool dev-build/make dev-python/pip virtual/pkgconfig dev-lang/python dev-python/setuptools app-arch/xz-utils
+      $ sudo emerge --noreplace --oneshot dev-build/autoconf dev-build/automake dev-libs/check dev-libs/elfutils dev-libs/json-c dev-libs/libbpf dev-libs/libpcre2 sys-devel/gcc dev-vcs/git dev-libs/libkdumpfile dev-build/libtool dev-build/make dev-python/pip virtual/pkgconfig dev-lang/python dev-python/setuptools app-arch/xz-utils
 
 * openSUSE
 
   .. code-block:: console
 
-      $ sudo zypper install autoconf automake check-devel gcc git libdebuginfod-devel libdw-devel libelf-devel libjson-c-devel libkdumpfile-devel libtool make pcre2-devel pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
+      $ sudo zypper install autoconf automake check-devel gcc git libbpf-devel libdebuginfod-devel libdw-devel libelf-devel libjson-c-devel libkdumpfile-devel libtool make pcre2-devel pkgconf python3 python3-devel python3-pip python3-setuptools xz-devel
 
 Then, run:
 

--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -2007,6 +2007,23 @@ class Module:
         """
         ...
 
+    def load_btf(
+        self,
+        *,
+        data: Union[bytes, str, None] = None,
+        main_module_base: Union[bool, None] = None,
+    ) -> None:
+        """
+        Load BPF Type Format (BTF) for this module, for type and object finding.
+
+        :param data: An optional buffer containing BTF data
+        :param main_module_base: Whether the main module BTF should be used as
+          the split BTF base. When unspecified or ``None``, the default depends
+          on the target.  For Linux kernel programs, the default is ``True``,
+          and for userspace programs, the default is ``False``.
+        """
+        ...
+
     def try_file(
         self,
         path: Path,
@@ -4156,6 +4173,7 @@ _have_debuginfod: bool
 _enable_dlopen_debuginfod: bool
 _with_json_c: bool
 _with_libkdumpfile: bool
+_with_libbpf: bool
 _with_lzma: bool
 _with_pcre2: bool
 _with_pcre2_utf: bool

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,6 +23,8 @@ It optionally depends on:
   expressions.
 - `json-c <https://github.com/json-c/json-c>`_ for QEMU Machine Protocol
   support
+- `libbpf <https://docs.kernel.org/bpf/libbpf/libbpf_overview.html>`_ 1.0.0 or
+  newer, for using BPF Type Format (BTF)
 
 The build requires:
 

--- a/drgn/__init__.py
+++ b/drgn/__init__.py
@@ -121,6 +121,7 @@ from _drgn import (  # noqa: F401
     _enable_dlopen_debuginfod as _enable_dlopen_debuginfod,
     _have_debuginfod as _have_debuginfod,
     _with_json_c as _with_json_c,
+    _with_libbpf as _with_libbpf,
     _with_libkdumpfile as _with_libkdumpfile,
     _with_lzma as _with_lzma,
     _with_pcre2 as _with_pcre2,

--- a/drgn/cli.py
+++ b/drgn/cli.py
@@ -132,7 +132,8 @@ def version_header() -> str:
     libkdumpfile = f'with{"" if drgn._with_libkdumpfile else "out"} libkdumpfile'
     lzma = f'with{"" if drgn._with_lzma else "out"} lzma'
     pcre2 = f'with{"" if drgn._with_pcre2 else "out"} pcre2'
-    return f"drgn {drgn.__version__} (using Python {python_version}, elfutils {drgn._elfutils_version}, {debuginfod}, {json_c}, {libkdumpfile}, {lzma}, {pcre2})"
+    bpf = f'with{"" if drgn._with_libbpf else "out"} libbpf'
+    return f"drgn {drgn.__version__} (using Python {python_version}, elfutils {drgn._elfutils_version}, {debuginfod}, {json_c}, {libkdumpfile}, {lzma}, {pcre2}, {bpf})"
 
 
 def default_globals(prog: drgn.Program) -> Dict[str, Any]:

--- a/drgn/helpers/experimental/btf.py
+++ b/drgn/helpers/experimental/btf.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 Oracle and/or its affiliates
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""
+BTF
+---
+
+This module contains Python helpers to simplify loading BTF debuginfo and
+associated kallsyms symbol info.
+"""
+import os
+import re
+from typing import Callable, Optional
+
+from drgn import FindObjectFlags, Object, Program, ProgramFlags
+from drgn.helpers.linux.kallsyms import load_module_kallsyms, load_vmlinux_kallsyms
+from drgn.helpers.linux.list import list_for_each_entry
+
+__all__ = ("build_c_declaration_object_finder", "load_builtin_btf")
+
+
+def build_c_declaration_object_finder(
+    decls: str,
+) -> Callable[[Program, str, FindObjectFlags, Optional[str]], Optional[Object]]:
+    """
+    Create an object finder from C variable declarations
+
+    For all released Linux kernel versions, in-kernel BTF does not contain a
+    mapping of variable names to their types or addresses. To make up for this,
+    objects whose types are known ahead of time can be created via their
+    kallsyms symbol entry. This function creates an object finder using that
+    strategy. All that is necessary is to provide a set of C-style declarations,
+    such as::
+
+        struct list_head modules, btf_modules;
+
+    The declarations may contain only variable declarations. Fun ction
+    declarations, as well as type declarations, are not allowed. C style line
+    comments and blank lines are permitted, though multi-line comments are not.
+
+    The returned object finder can be registered with
+    :meth:`Program.register_object_finder` and used to access the declared
+    variables.
+
+    :param decls: a string containing C-style variable declarations
+    :returns: a corresponding object finder
+    """
+    name_to_type = {}
+
+    single_decl = r"\*?\s*[a-zA-Z_]\w*(?:\s*\[\s*\d*\s*\])*\s*"
+    declarator_list = re.compile(
+        r"(?:" + single_decl + r",\s*)*" + single_decl + r";\s*$"
+    )
+    for decl in decls.strip().split("\n"):
+        comment_start = decl.find("//")
+        if comment_start >= 0:
+            decl = decl[:comment_start]
+        decl = decl.strip()
+        if not decl:
+            continue
+        m = declarator_list.search(decl)
+        if not m:
+            raise ValueError("Invalid declaration: {}".format(decl))
+        type_string = decl[: -len(m.group(0))]
+        for name in m.group(0).rstrip(";").split(","):
+            this_type = type_string
+            name = name.strip()
+            if name.startswith("*"):
+                this_type += " *"
+                name = name[1:].lstrip()
+            start_bracket = name.find("[")
+            if start_bracket > 0:
+                this_type += " " + name[start_bracket:]
+                name = name[:start_bracket]
+            name_to_type[name.strip()] = this_type
+
+    def ofind(
+        prog: Program, name: str, flags: FindObjectFlags, filename: Optional[str]
+    ) -> Optional[Object]:
+        if flags & FindObjectFlags.VARIABLE and name in name_to_type:
+            return Object(prog, name_to_type[name], address=prog.symbol(name).address)
+        return None
+
+    return ofind
+
+
+def load_builtin_btf(prog: Program, declarations: Optional[str] = None) -> None:
+    """
+    Use built-in BPF Type Format (BTF) data for debugging the kernel
+
+    This loads the built-in BTF data for the kernel and uses it for type
+    finding, as well as limited object finding. As of Linux 7.1, the kernel BTF
+    does not contain mappings of variable names to types, but it does contain
+    the definitions of all types.
+
+    In order to provide a fuller debugging experience, kallsyms is loaded as
+    well, and a small number of hardcoded declarations are used to help
+    bootstrap kernel module discovery.
+
+    :param prog: Program for debugging
+    :param declarations: C-style declarations to create a supplemental object
+      finder. If not provided, a minimal set of declarations will be provided in
+      order to allow drgn to load module BTF. See
+      :func:`build_c_declaration_object_finder`
+    """
+    # First, we need the built-in kallsyms
+    finder = load_vmlinux_kallsyms(prog)
+    prog.register_symbol_finder("vmlinux_kallsyms", finder, enable_index=0)
+
+    # Create the main module if not already existing
+    kernel = prog.main_module("kernel", create=True)
+
+    use_kernfs = (
+        prog.flags & (ProgramFlags.IS_LIVE | ProgramFlags.IS_LOCAL)
+        == (ProgramFlags.IS_LIVE | ProgramFlags.IS_LOCAL)
+    ) and os.path.isdir("/sys/kernel/btf")
+
+    # Load vmlinux BTF
+    if use_kernfs:
+        with open("/sys/kernel/btf/vmlinux", "rb") as f:
+            btf = f.read()
+    else:
+        btf = prog.read(
+            prog.symbol("__start_BTF").address,
+            prog.symbol("__stop_BTF").address - prog.symbol("__start_BTF").address,
+        )
+    kernel.load_btf(data=btf, main_module_base=False)
+
+    # Finders for necessary objects to iterate modules and BTF
+    if not declarations:
+        declarations = "struct list_head modules, btf_modules, slab_caches;"
+    ofind = build_c_declaration_object_finder(declarations)
+    prog.register_object_finder("btf_manual_globals", ofind, enable_index=1)
+
+    # Load module BTF
+    mod_to_btf = {}
+    if use_kernfs:
+        for name in os.listdir("/sys/kernel/btf"):
+            if name != "vmlinux":
+                with open(f"/sys/kernel/btf/{name}", "rb") as f:
+                    mod_to_btf[name] = f.read()
+    else:
+        btf_module_tp = prog.type("struct btf_module")
+        data_in_btf_module = btf_module_tp.has_member("btf_data_size")
+        for btf_mod in list_for_each_entry(
+            btf_module_tp, prog["btf_modules"].address_of_(), "list"
+        ):
+            name = btf_mod.module.name.string_().decode()
+            if data_in_btf_module:
+                mod_to_btf[name] = prog.read(
+                    btf_mod.btf,
+                    btf_mod.btf_data_size.value_(),
+                )
+            else:
+                mod_to_btf[name] = prog.read(
+                    btf_mod.btf.data, btf_mod.btf.data_size.value_()
+                )
+
+    prog.create_loaded_modules()
+    for name, data in mod_to_btf.items():
+        module = prog.module(name)
+        module.load_btf(data=data)
+    module_finder = load_module_kallsyms(prog)
+    prog.register_symbol_finder("module_kallsyms", module_finder, enable_index=1)

--- a/libdrgn/Makefile.am
+++ b/libdrgn/Makefile.am
@@ -165,6 +165,12 @@ libdrgn_common_la_CFLAGS += $(libkdumpfile_CFLAGS)
 libdrgn_common_la_LIBADD += $(libkdumpfile_LIBS)
 endif
 
+if WITH_LIBBPF
+libdrgn_common_la_SOURCES += btf_info.c btf_info.h
+libdrgn_common_la_CFLAGS += $(bpf_CFLAGS)
+libdrgn_common_la_LIBADD += $(bpf_LIBS)
+endif
+
 if ENABLE_PYTHON
 noinst_LTLIBRARIES += libdrgn_common_python.la
 

--- a/libdrgn/btf_info.c
+++ b/libdrgn/btf_info.c
@@ -1,0 +1,1336 @@
+// Copyright (c) 2026 Oracle and/or its affiliates.
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include <errno.h>
+#include <gelf.h>
+#include <libelf.h>
+#include <linux/btf.h>
+#include <bpf/btf.h>
+#include <bpf/libbpf_legacy.h>
+#include <stdint.h>
+
+#include "btf_info.h"
+#include "cleanup.h"
+#include "debug_info.h"
+#include "drgn.h"
+#include "drgn_internal.h"
+#include "elf_file.h"
+#include "elf_symtab.h"
+#include "error.h"
+#include "hash_table.h"
+#include "lazy_object.h"
+#include "log.h"
+#include "program.h"
+#include "symbol.h"
+#include "type.h"
+#include "util.h"
+#include "vector.h"
+
+DEFINE_VECTOR_FUNCTIONS(drgn_btf_index_bucket);
+DEFINE_HASH_MAP_FUNCTIONS(drgn_btf_index, c_string_key_hash_pair, c_string_key_eq);
+
+// The ENUM64 kind was introduced in Linux kernel v6.0, in commit 6089fb325cf73
+// ("bpf: Add btf enum64 support"). If drgn is built against kernel headers
+// prior to this, then <linux/btf.h> will not contain the definition. While
+// libbpf 1.0+ will provide a definition of the type kind, it cannot provide the
+// struct declaration. Duplicate it here.
+struct drgn_btf_enum64 {
+	struct btf_enum orig;
+	uint32_t hi32;
+};
+
+// From libbpf 1.0 to 1.4, libbpf declared, but did not implement,
+// btf__new_split().
+// https://github.com/libbpf/libbpf/commit/5b7613e
+//
+// Despite it being trivial to implement directly in libbpf, it cannot be easily
+// done from a libbpf client. As a result, we need a hack to create it from a
+// temporary file even though we already have the bytes.
+//
+// Use the hack unconditionally rather than detecting the missing function, so
+// that we get uniform behavior and a smaller test matrix.
+static struct drgn_error *drgn_new_split_btf(const void *btf_data, uint32_t btf_data_size,
+					     struct btf *base, struct btf **ret)
+{
+	char template[] = "/tmp/drgn-btf-XXXXXX";
+	int fd = mkstemp(template);
+	int error;
+	if (fd < 0)
+		return drgn_error_create_os("cannot create BTF temp file", errno, NULL);
+
+	_cleanup_fclose_ FILE *f = fdopen(fd, "w");
+	if (!f) {
+		error = errno;
+		unlink(template);
+		close(fd);
+		return drgn_error_create_os("fopen", error, NULL);
+	}
+
+	if (fwrite(btf_data, 1, btf_data_size, f) != btf_data_size || fflush(f) != 0) {
+		error = errno;
+		unlink(template);
+		return drgn_error_create_os("error writing BTF tmpfile", error, NULL);
+	}
+
+	struct btf *data = btf__parse_raw_split(template, base);
+	error = errno;
+	unlink(template);
+	if (!data)
+		return drgn_error_create_os("error parsing BTF", error, NULL);
+	*ret = data;
+	return NULL;
+}
+
+static inline struct drgn_error *drgn_new_btf(const void *btf_data, uint32_t btf_data_size,
+					      struct btf **ret)
+{
+	struct btf *btf = btf__new(btf_data, (uint32_t)btf_data_size);
+	if (!btf)
+		return drgn_error_create_os("error parsing BTF", errno, NULL);
+	*ret = btf;
+	return NULL;
+}
+
+static inline struct drgn_program *MBI_PROG(struct drgn_module_btf_info *mbi)
+{
+	return container_of(mbi, struct drgn_module, btf)->prog;
+}
+
+static bool index_name(struct drgn_module *module, const char *name,
+		       struct drgn_btf_index_item *value)
+{
+	struct hash_pair hp = drgn_btf_index_hash(&name);
+	struct drgn_btf_index_iterator it =
+		drgn_btf_index_search_hashed(&module->prog->dbinfo.btf.htab, &name, hp);
+	if (it.entry && !drgn_btf_index_bucket_append(&it.entry->value, value)) {
+		return false;
+	} else if (!it.entry) {
+		struct drgn_btf_index_entry entry;
+		entry.key = name;
+		drgn_btf_index_bucket_init(&entry.value);
+		if (!drgn_btf_index_bucket_append(&entry.value, value) ||
+		    drgn_btf_index_insert_searched(&module->prog->dbinfo.btf.htab,
+						   &entry, hp, NULL) == -1) {
+			drgn_btf_index_bucket_deinit(&entry.value);
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool update_var_address_from_datasec(struct drgn_module *module,
+					    const char *name,
+					    uint32_t type_id, uint64_t addr,
+					    bool base_found)
+{
+	struct hash_pair hp = drgn_btf_index_hash(&name);
+	struct drgn_btf_index_iterator it =
+		drgn_btf_index_search_hashed(&module->prog->dbinfo.btf.htab, &name, hp);
+	if (it.entry) {
+		struct drgn_btf_index_bucket *l = &it.entry->value;
+		for (uint32_t i = 0; i < drgn_btf_index_bucket_size(l); i++) {
+			struct drgn_btf_index_item *e = drgn_btf_index_bucket_at(l, i);
+			if (e->module == module && e->kind == BTF_KIND_VAR
+			    && e->type_id == type_id) {
+				e->addr = addr;
+				e->is_present = 1;
+				e->addr_valid = base_found;
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static char *vmlinux_section_symbol_name(const char *name)
+{
+	if (strcmp(name, ".data..percpu") == 0)
+		return strdup("__per_cpu_start");
+	else if (strcmp(name, ".data") == 0)
+		return strdup("_sdata");
+	else if (strcmp(name, ".bss") == 0)
+		return strdup("__bss_start");
+	else if (strcmp(name, ".brk") == 0)
+		return strdup("_brk_start");
+
+	char *new = malloc(strlen(name) + sizeof("__start_"));
+	if (!new)
+		return NULL;
+
+	strcpy(new, "__start_");
+	int out = sizeof("__start_") - 1;
+	int in = 0;
+	while (name[in] == '.')
+		in++;
+	while (name[in]) {
+		if (name[in] == '.')
+			new[out] = '_';
+		else
+			new[out] = name[in];
+		out++;
+		in++;
+	}
+	new[out] = '\0';
+	return new;
+}
+
+static struct drgn_error *
+find_section_base_elf_file(struct drgn_elf_file *file, uint64_t file_bias,
+			   const char *name, uint64_t *ret)
+{
+	size_t shstrndx;
+	if (elf_getshdrstrndx(file->elf, &shstrndx))
+		return &drgn_not_found;
+
+	Elf_Scn *scn = NULL;
+	while ((scn = elf_nextscn(file->elf, scn))) {
+		GElf_Shdr shdr_mem, *shdr = gelf_getshdr(scn, &shdr_mem);
+		if (!shdr)
+			return drgn_error_libelf();
+		char *scnname = elf_strptr(file->elf, shstrndx, shdr->sh_name);
+		if (!scnname)
+			return drgn_error_libelf();
+		if (strcmp(scnname, name) == 0
+		    && (shdr->sh_flags & SHF_ALLOC)) {
+			*ret = shdr->sh_addr + file_bias;
+			return NULL;
+		}
+	}
+	return &drgn_not_found;
+}
+
+static struct drgn_error *find_section_base(struct drgn_module *module,
+					    const char *name,
+					    uint64_t *ret)
+{
+	struct drgn_error *err;
+
+	if (module->kind == DRGN_MODULE_RELOCATABLE) {
+		// Linux kernel loadable modules have a dedicated section map
+		// for this. Use this directly rather than any ELF file or
+		// symbol.
+		return drgn_module_get_section_address(module, name, ret);
+	}
+
+	if (module->loaded_file || module->debug_file) {
+		// For userspace, or in case we happen to have a vmlinux file
+		// loaded, we can search for the section and find its address.
+		if (module->loaded_file) {
+			err = find_section_base_elf_file(module->loaded_file,
+							 module->loaded_file_bias,
+							 name, ret);
+			if (!drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
+				return err;
+		}
+		if (module->debug_file) {
+			err = find_section_base_elf_file(module->debug_file,
+							 module->debug_file_bias,
+							 name, ret);
+			if (!drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
+				return err;
+		}
+	}
+
+	if (module->kind == DRGN_MODULE_MAIN
+	    && (module->prog->flags & DRGN_PROGRAM_IS_LINUX_KERNEL)) {
+		// Finally, in the case of vmlinux, if we don't have an ELF
+		// file, we can apply a heuristic by finding a corresponding
+		// symbol name.
+		_cleanup_free_ char *section = vmlinux_section_symbol_name(name);
+		if (!section)
+			return &drgn_enomem;
+
+		_cleanup_symbol_ struct drgn_symbol *sym = NULL;
+		err = drgn_program_find_symbol_by_name(module->prog, section, &sym);
+		if (err)
+			return err;
+
+		*ret = sym->address;
+		return NULL;
+	}
+	return &drgn_not_found;
+}
+
+static struct drgn_error *find_symbol_addr(struct drgn_module *module,
+                                           const char *name, uint64_t *ret)
+{
+	struct drgn_error *err;
+	_cleanup_symbol_ struct drgn_symbol *sym = NULL;
+
+	// If we have a loaded file, bypass the pluggable symbol finder and
+	// directly access the module's symbols. This has the lowest chance of a
+	// name conflict.
+	if (module->loaded_file || module->debug_file) {
+		enum drgn_find_symbol_flags flags =
+			DRGN_FIND_SYMBOL_NAME | DRGN_FIND_SYMBOL_ONE;
+		struct drgn_symbol_result_builder builder;
+		drgn_symbol_result_builder_init(&builder, true);
+		err = drgn_module_elf_symbols_search(module, name, 0, flags, &builder);
+		if (err && !drgn_error_catch(&err, DRGN_ERROR_STOP))
+			return err;
+		if (!drgn_symbol_result_builder_count(&builder))
+			return &drgn_not_found;
+		sym = drgn_symbol_result_builder_single(&builder);
+		*ret = sym->address;
+		return NULL;
+	}
+
+	// Otherwise, use the global symbol finder
+	err = drgn_program_find_symbol_by_name(module->prog, name, &sym);
+	if (!err)
+		*ret = sym->address;
+	return err;
+}
+
+static struct drgn_error *index_enumerator(struct drgn_module *module,
+					   uint32_t type_id,
+					   const struct btf_type *tp)
+{
+	struct btf_enum *enum32 = btf_enum(tp);
+	struct drgn_btf_enum64 *enum64 = (struct drgn_btf_enum64 *)enum32;
+	struct drgn_btf_index_item value = {};
+	value.is_enum = 1;
+	value.type_id = type_id;
+	value.module = module;
+	bool is_enum64 = btf_kind(tp) == BTF_KIND_ENUM64;
+	for (int i = 0; i < btf_vlen(tp); i++) {
+		const char *enumname;
+		if (is_enum64)
+			enumname = btf__str_by_offset(module->btf.btf, enum64[i].orig.name_off);
+		else
+			enumname = btf__str_by_offset(module->btf.btf, enum32[i].name_off);
+		value.index = i;
+		if (!index_name(module, enumname, &value))
+			return &drgn_enomem;
+	}
+	return NULL;
+}
+
+static struct drgn_error *index_datasec(struct drgn_module *module,
+					uint32_t type_id,
+					const struct btf_type *tp,
+					const char *name)
+{
+	struct btf_var_secinfo *si = btf_var_secinfos(tp);
+	bool base_found;
+	uint64_t base = 0;
+	struct drgn_error *err = find_section_base(module, name, &base);
+
+	if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP)) {
+		// Finding the DATASEC base address is not guaranteed. We could
+		// find ourselves missing a hard-coded fallback, or it could be
+		// that a DATASEC corresponds to an "init" section which is
+		// discarded. Failing the entire BTF initialization just because
+		// we could not find a DATASEC is overzealous. Instead, log a
+		// debug message. The VARs which are part of this datasec will
+		// have the is_present flag but not the addr_valid flag, so
+		// object finding will fail at the point that the user tries to
+		// use an affected variable: a much more reasonable time for
+		// failure. At that point, this log can be used to help diagnose
+		// the issue.
+		drgn_log_debug(
+			module->prog,
+			"module %s: unable to find base address of section %s: skipping"
+			" initialization of %u BTF VAR locations\n",
+			module->name, name, btf_vlen(tp));
+		base_found = false;
+	} else if (err) {
+		return err;
+	} else {
+		base_found = true;
+	}
+
+	for (int i = 0; i < btf_vlen(tp); i++) {
+		const struct btf_type *var = btf__type_by_id(module->btf.btf, si[i].type);
+		const char *varname = btf__str_by_offset(module->btf.btf, var->name_off);
+		if (!update_var_address_from_datasec(module, varname, si[i].type,
+						     base + si[i].offset, base_found))
+			return drgn_error_format(
+				DRGN_ERROR_OTHER,
+				"cannot find variable from DATASEC '%s' (id: %u) (section '%s')",
+				varname, si[i].type, name);
+	}
+	return NULL;
+}
+
+static bool should_index_kind(uint8_t kind)
+{
+	// Only index names which have a user-visible lookup
+	switch (kind) {
+		case BTF_KIND_ENUM:
+		case BTF_KIND_ENUM64:
+		case BTF_KIND_STRUCT:
+		case BTF_KIND_UNION:
+		case BTF_KIND_TYPEDEF:
+		case BTF_KIND_VAR:
+		case BTF_KIND_FWD:
+		case BTF_KIND_FUNC:
+			return true;
+		default:
+			return false;
+	}
+}
+
+static struct drgn_error *index_btf(struct drgn_module *module)
+{
+	uint32_t start = 1;
+	const struct btf *base = btf__base_btf(module->btf.btf);
+	if (base)
+		start = btf__type_cnt(base);
+
+	for (uint32_t i = start; i < btf__type_cnt(module->btf.btf); i++) {
+		const struct btf_type *tp = btf__type_by_id(module->btf.btf, i);
+		const char *name = btf__str_by_offset(module->btf.btf, tp->name_off);
+		uint8_t kind = btf_kind(tp);
+
+		// Hash the name -> type mapping
+		if (name && name[0] && should_index_kind(kind)) {
+			struct drgn_btf_index_item value = {};
+			value.module = module;
+			value.kind = btf_kind(tp);
+			value.type_id = i;
+			if (!index_name(module, name, &value))
+				return &drgn_enomem;
+		}
+
+		// Hash enumerator and variable names
+		if (kind == BTF_KIND_ENUM || kind == BTF_KIND_ENUM64) {
+			struct drgn_error *err = index_enumerator(module, i, tp);
+			if (err)
+				return err;
+		}
+	}
+	// Now, for each DATASEC, fix up the references to VARs with their
+	// proper address. We have to do this in a second pass because a DATASEC
+	// may reference VARs with type_ids greater than their own.
+	for (uint32_t i = start; i < btf__type_cnt(module->btf.btf); i++) {
+		const struct btf_type *tp = btf__type_by_id(module->btf.btf, i);
+		const char *name = btf__str_by_offset(module->btf.btf, tp->name_off);
+		uint8_t kind = btf_kind(tp);
+
+		if (kind == BTF_KIND_DATASEC) {
+			struct drgn_error *err = index_datasec(module, i, tp, name);
+			if (err)
+				return err;
+		}
+	}
+	return NULL;
+}
+
+static void clear_btf_on_failure(struct drgn_module *module)
+{
+	struct drgn_btf_index_iterator it = drgn_btf_index_first(&module->prog->dbinfo.btf.htab);
+	while (it.entry) {
+		while (drgn_btf_index_bucket_size(&it.entry->value) &&
+		       drgn_btf_index_bucket_last(&it.entry->value)->module == module)
+			drgn_btf_index_bucket_pop(&it.entry->value);
+		if (drgn_btf_index_bucket_size(&it.entry->value) == 0) {
+			drgn_btf_index_bucket_deinit(&it.entry->value);
+			it = drgn_btf_index_delete_iterator(&module->prog->dbinfo.btf.htab, it);
+		} else {
+			it = drgn_btf_index_next(it);
+		}
+	}
+}
+
+static bool kind_match(uint64_t drgn_flags, const struct btf_type *tp)
+{
+	int kind = btf_kind(tp);
+	uint32_t int_info;
+	switch (kind) {
+	case BTF_KIND_INT:
+		int_info = *(uint32_t *)(tp + 1);
+		if (BTF_INT_BOOL & int_info)
+			return drgn_flags & (1 << DRGN_TYPE_BOOL);
+		else
+			return drgn_flags & (1 << DRGN_TYPE_INT);
+	case BTF_KIND_PTR:
+		return drgn_flags & (1 << DRGN_TYPE_POINTER);
+	case BTF_KIND_ARRAY:
+		return drgn_flags & (1 << DRGN_TYPE_ARRAY);
+	case BTF_KIND_STRUCT:
+		return drgn_flags & (1 << DRGN_TYPE_STRUCT);
+	case BTF_KIND_UNION:
+		return drgn_flags & (1 << DRGN_TYPE_UNION);
+	case BTF_KIND_ENUM:
+	case BTF_KIND_ENUM64:
+		return drgn_flags & (1 << DRGN_TYPE_ENUM);
+	case BTF_KIND_FLOAT:
+		return drgn_flags & (1 << DRGN_TYPE_FLOAT);
+	case BTF_KIND_TYPEDEF:
+		return drgn_flags & (1 << DRGN_TYPE_TYPEDEF);
+	default:
+		return false;
+	}
+}
+
+/**
+ * Follow the linked list of BTF qualifiers, combining them into a single
+ * drgn_qualifiers, ending at the first non-qualifier type entry.
+ * @param idx Starting index, which may be a qualifier
+ * @param[out] ret Location to store the index of the first non-qualifier
+ * @returns drgn_qualifiers with all relevant bits set
+ */
+static enum drgn_qualifiers
+drgn_btf_resolve_qualifiers(struct btf *btf, uint32_t idx, uint32_t *ret)
+{
+	enum drgn_qualifiers qual = 0;
+
+	while (idx) {
+		const struct btf_type *tp = btf__type_by_id(btf, idx);
+		switch (btf_kind(tp)) {
+		case BTF_KIND_CONST:
+			qual |= DRGN_QUALIFIER_CONST;
+			break;
+		case BTF_KIND_RESTRICT:
+			qual |= DRGN_QUALIFIER_RESTRICT;
+			break;
+		case BTF_KIND_VOLATILE:
+			qual |= DRGN_QUALIFIER_VOLATILE;
+			break;
+		case BTF_KIND_TYPE_TAG:
+			// Skip type tags, as they may come between
+			// a pointer and its qualifiers.
+			break;
+		default:
+			goto out;
+		}
+		idx = tp->type;
+	}
+out:
+	*ret = idx;
+	return qual;
+}
+
+static struct drgn_error *
+drgn_btf_type_create(struct drgn_module_btf_info *mbi, uint32_t idx,
+		     struct drgn_qualified_type *ret);
+static struct drgn_error *
+drgn_type_from_btf(uint64_t flags, const char *name,
+		   size_t name_len, const char *filename,
+		   void *arg, struct drgn_qualified_type *ret);
+
+static struct drgn_error *
+drgn_int_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+		       struct drgn_type **ret)
+{
+	const char *name = btf__str_by_offset(mbi->btf, tp->name_off);
+
+	// btf_int_bits() is not used here:
+	// -> For normal int types which aren't bitfield members, it is normally
+	//    set to tp->size * 8.
+	// -> For bitfield types referenced by a struct with kind_flag unset, it
+	//    may be used, but drgn only cares about the bitfield size in the
+	//    context of the struct.
+	// btf_int_offset() is not used for much the same reason. According to
+	// the documentation, non-zero offsets are not emitted by clang or
+	// pahole anymore, but legacy BTF may contain them.
+	uint8_t encoding = btf_int_encoding(tp);
+	bool is_signed = BTF_INT_SIGNED & encoding;
+	bool is_bool = BTF_INT_BOOL & encoding;
+	if (is_bool)
+		return drgn_bool_type_create(MBI_PROG(mbi), name, tp->size,
+					     DRGN_PROGRAM_ENDIAN,
+					     &drgn_language_c, ret);
+	else
+		return drgn_int_type_create(MBI_PROG(mbi), name, tp->size,
+					    is_signed, DRGN_PROGRAM_ENDIAN,
+					    &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_pointer_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+			   struct drgn_type **ret)
+{
+	struct drgn_qualified_type pointed;
+	struct drgn_error *err = NULL;
+
+	err = drgn_btf_type_create(mbi, tp->type, &pointed);
+
+	if (err)
+		return err;
+
+	int pointer_size = btf__pointer_size(mbi->btf);
+	return drgn_pointer_type_create(MBI_PROG(mbi), pointed, pointer_size,
+					DRGN_PROGRAM_ENDIAN, &drgn_language_c,
+					ret);
+}
+
+static struct drgn_error *
+drgn_typedef_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+			   struct drgn_type **ret)
+{
+	struct drgn_qualified_type aliased;
+	struct drgn_error *err;
+	const char *name = btf__str_by_offset(mbi->btf, tp->name_off);
+
+	err = drgn_btf_type_create(mbi, tp->type, &aliased);
+	if (err)
+		return err;
+
+	return drgn_typedef_type_create(MBI_PROG(mbi), name, aliased,
+					&drgn_language_c, ret);
+}
+
+struct drgn_btf_member_thunk_arg {
+	struct btf_member *member;
+	struct drgn_module_btf_info *mbi;
+	uint32_t bit_offset;
+	uint32_t bit_field_size;
+};
+
+static struct drgn_error *
+drgn_btf_member_thunk_fn(struct drgn_object *res, void *arg_)
+{
+	struct drgn_btf_member_thunk_arg *arg = arg_;
+	struct drgn_error *err;
+
+	if (res) {
+		struct drgn_qualified_type qualified_type;
+		err = drgn_btf_type_create(arg->mbi, arg->member->type,
+					   &qualified_type);
+		if (err)
+			return err;
+		err = drgn_object_set_absent(res, qualified_type,
+					     DRGN_ABSENCE_REASON_OTHER,
+					     arg->bit_field_size);
+		if (err)
+			return err;
+	}
+	free(arg);
+	return NULL;
+}
+
+static void legacy_bitfield_offset_size(struct drgn_btf_member_thunk_arg *arg)
+{
+	struct btf *btf = arg->mbi->btf;
+	const struct btf_type *tp = btf__type_by_id(btf, arg->member->type);
+
+	while (btf_is_mod(tp) || btf_is_typedef(tp)) {
+		tp = btf__type_by_id(btf, tp->type);
+	}
+	if (btf_is_int(tp)) {
+		arg->bit_offset += btf_int_offset(tp);
+		// Drgn interprets a non-zero bit field size as a bitfield, even
+		// when the bit size matches the integer type's underlying byte
+		// size.
+		// BTF's legacy bitfield encoding does not give us a way to tell
+		// the difference between a bitfield declared with the same bit
+		// size as the underlying integer type, e.g:
+		//   unsigned char flags : 8;
+		//   unsigned char flags;
+		// The overwhelmingly common case is that integers whose
+		// bitfield size matches their byte size are NOT bitfields, so
+		// clear the bit_field_size in that case.
+		if (btf_int_bits(tp) != tp->size * 8)
+			arg->bit_field_size = btf_int_bits(tp);
+	}
+}
+
+static struct drgn_error *
+drgn_compound_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+			    struct drgn_type **ret)
+{
+	struct btf_member *members = btf_members(tp);
+	size_t vlen = btf_vlen(tp);
+	enum drgn_type_kind kind = DRGN_TYPE_STRUCT;
+	struct drgn_error *err;
+	const char *tag = NULL;
+
+	if (btf_kind(tp) == BTF_KIND_UNION)
+		kind = DRGN_TYPE_UNION;
+
+	if (tp->name_off)
+		tag = btf__str_by_offset(mbi->btf, tp->name_off);
+
+	_cleanup_(drgn_compound_type_builder_deinit)
+		struct drgn_compound_type_builder builder;
+	drgn_compound_type_builder_init(&builder, MBI_PROG(mbi), kind);
+	for (size_t i = 0; i < vlen; i++) {
+		struct drgn_btf_member_thunk_arg *thunk_arg =
+			malloc(sizeof(*thunk_arg));
+		const char *name = NULL;
+		if (!thunk_arg)
+			return &drgn_enomem;
+		thunk_arg->member = &members[i];
+		thunk_arg->mbi = mbi;
+		thunk_arg->bit_offset = btf_member_bit_offset(tp, i);
+		thunk_arg->bit_field_size = btf_member_bitfield_size(tp, i);
+		if (!btf_kflag(tp))
+			legacy_bitfield_offset_size(thunk_arg);
+		if (members[i].name_off)
+			name = btf__str_by_offset(mbi->btf, members[i].name_off);
+
+		union drgn_lazy_object member_object;
+		drgn_lazy_object_init_thunk(&member_object, MBI_PROG(mbi),
+					    drgn_btf_member_thunk_fn, thunk_arg);
+
+		err = drgn_compound_type_builder_add_member(&builder,
+							    &member_object,
+							    name,
+							    thunk_arg->bit_offset);
+		if (err) {
+			drgn_lazy_object_deinit(&member_object);
+			return err;
+		}
+	}
+	return drgn_compound_type_create(&builder, tag, tp->size, true,
+					 &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_array_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+			 struct drgn_type **ret)
+{
+	struct btf_array *arr = btf_array(tp);
+	struct drgn_error *err;
+	struct drgn_qualified_type qt;
+
+	err = drgn_btf_type_create(mbi, arr->type, &qt);
+	if (err)
+		return err;
+
+	// BTF cannot distinguish an incomplete array from a zero length array,
+	// but they are different. For our purposes, the main difference is that
+	// a zero-length array has a size (0), whereas an incomplete array does
+	// not. Since we cannot know whether the original source intended a
+	// zero-length or incomplete array, use the more flexible type. This
+	// means we'll never generate an incomplete array type.
+	return drgn_array_type_create(MBI_PROG(mbi), qt, arr->nelems,
+				      &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+compatible_int(struct drgn_program *prog, bool signed_, uint64_t size, struct drgn_type **ret)
+{
+	// drgn won't allow an anonymous type, but BTF doesn't give us the
+	// underlying type ID for an enum. So we need to make one up, and we
+	// need to invent a name for it. Since BTF is kernel-specific, we'll use
+	// the "{su}{8,16,32,64}" names. However, in reality, those are typedefs
+	// in the kernel. This shouldn't really cause confusion, since you can't
+	// lookup these integers by name.
+	static const char *names[] = {
+		"u8", "u16", "u32", "u64", "s8", "s16", "s32", "s64",
+	};
+	int name_index = signed_ ? 4 : 0;
+	switch (size) {
+	case 1:
+		name_index += 0;
+		break;
+	case 2:
+		name_index += 1;
+		break;
+	case 4:
+		name_index += 2;
+		break;
+	case 8:
+		name_index += 3;
+		break;
+	default:
+		return drgn_error_format(
+			DRGN_ERROR_OTHER, "invalid BTF enum size: %" PRIu64, size);
+	}
+	return drgn_int_type_create(prog, names[name_index], size, signed_, DRGN_PROGRAM_ENDIAN,
+				    &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_enum_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+			struct drgn_type **ret)
+{
+	struct drgn_error *err;
+	struct drgn_enum_type_builder builder;
+	const char *name = NULL;
+	size_t count = btf_vlen(tp);
+	bool signed_ = BTF_INFO_KFLAG(tp->info);
+	struct drgn_type *type;
+
+	if (tp->name_off)
+		name = btf__str_by_offset(mbi->btf, tp->name_off);
+
+	if (!count)
+		/* no enumerators, incomplete type */
+		return drgn_incomplete_enum_type_create(MBI_PROG(mbi), name,
+							&drgn_language_c, ret);
+
+	drgn_enum_type_builder_init(&builder, MBI_PROG(mbi));
+	struct btf_enum *enum32 = btf_enum(tp);
+	struct drgn_btf_enum64 *enum64 = (struct drgn_btf_enum64 *)enum32;
+	bool is_enum64 = btf_kind(tp) == BTF_KIND_ENUM64;
+	for (size_t i = 0; i < count; i++) {
+		const char *mname;
+		union {uint64_t u; int64_t s; } val;
+		if (is_enum64) {
+			mname = btf__str_by_offset(mbi->btf, enum64[i].orig.name_off);
+			val.u = ((uint64_t)enum64[i].hi32 << 32)
+				| (uint32_t)enum64[i].orig.val;
+		} else {
+			mname = btf__str_by_offset(mbi->btf, enum32[i].name_off);
+			if (signed_)
+				val.s = enum32[i].val;
+			else
+				val.u = (uint32_t)enum32[i].val;
+		}
+		if (signed_)
+			err = drgn_enum_type_builder_add_signed(&builder,
+								mname,
+								val.s);
+		else
+			err = drgn_enum_type_builder_add_unsigned(&builder,
+								  mname,
+								  val.u);
+		if (err)
+			goto out;
+	}
+	err = compatible_int(MBI_PROG(mbi), signed_, tp->size, &type);
+	if (err)
+		goto out;
+
+	err = drgn_enum_type_create(&builder, name, type,
+				    &drgn_language_c, ret);
+	if (!err)
+		return NULL;
+out:
+	drgn_enum_type_builder_deinit(&builder);
+	return err;
+}
+
+struct drgn_btf_param_thunk_arg {
+	struct btf_param *param;
+	struct drgn_module_btf_info *mbi;
+};
+
+static struct drgn_error *
+drgn_btf_param_thunk_fn(struct drgn_object *res, void *arg_)
+{
+	struct drgn_btf_param_thunk_arg *arg = arg_;
+	struct drgn_error *err;
+
+	if (res) {
+		struct drgn_qualified_type qualified_type;
+
+		err = drgn_btf_type_create(arg->mbi, arg->param->type,
+					   &qualified_type);
+		if (err)
+			return err;
+
+		err = drgn_object_set_absent(res, qualified_type,
+					     DRGN_ABSENCE_REASON_OTHER, 0);
+		if (err)
+			return err;
+	}
+	free(arg);
+	return NULL;
+}
+
+static struct drgn_error *
+drgn_func_proto_type_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+			      struct drgn_type **ret)
+{
+	struct drgn_error *err = NULL;
+	bool is_variadic = false;
+	struct drgn_qualified_type return_type;
+	size_t num_params = btf_vlen(tp);
+	struct btf_param *params = btf_params(tp);
+
+	err = drgn_btf_type_create(mbi, tp->type, &return_type);
+	if (err)
+		return err;
+
+	_cleanup_(drgn_function_type_builder_deinit)
+		  struct drgn_function_type_builder builder;
+	drgn_function_type_builder_init(&builder, MBI_PROG(mbi));
+	for (size_t i = 0; i < num_params; i++) {
+		const char *name = NULL;
+		union drgn_lazy_object param_object;
+		struct drgn_btf_param_thunk_arg *arg;
+
+		if (i + 1 == num_params && !params[i].name_off
+		    && !params[i].type) {
+			is_variadic = true;
+			break;
+		}
+		name = btf__str_by_offset(mbi->btf, params[i].name_off);
+
+		arg = malloc(sizeof(*arg));
+		if (!arg)
+			return &drgn_enomem;
+		arg->mbi = mbi;
+		arg->param = &params[i];
+		drgn_lazy_object_init_thunk(&param_object, MBI_PROG(mbi),
+					    drgn_btf_param_thunk_fn, arg);
+		err = drgn_function_type_builder_add_parameter(&builder,
+							       &param_object,
+							       name);
+		if (err) {
+			free(arg);
+			return err;
+		}
+	}
+	return drgn_function_type_create(&builder, return_type, is_variadic,
+					 &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_fwd_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+		  struct drgn_type **ret)
+{
+	struct drgn_program *prog = MBI_PROG(mbi);
+	const char *tag = btf__str_by_offset(mbi->btf, tp->name_off);
+	_cleanup_(drgn_compound_type_builder_deinit)
+		struct drgn_compound_type_builder builder;
+
+	drgn_compound_type_builder_init(&builder, prog,
+					btf_kflag(tp) ? DRGN_TYPE_UNION
+					              : DRGN_TYPE_STRUCT);
+	return drgn_compound_type_create(&builder, tag, 0, false,
+					 &drgn_language_c, ret);
+}
+
+static struct drgn_error *
+drgn_float_from_btf(struct drgn_module_btf_info *mbi, const struct btf_type *tp,
+		    struct drgn_type **ret)
+{
+	struct drgn_program *prog = MBI_PROG(mbi);
+	const char *tag = btf__str_by_offset(mbi->btf, tp->name_off);
+	return drgn_float_type_create(prog, tag, tp->size, DRGN_PROGRAM_ENDIAN,
+				      &drgn_language_c, ret);
+}
+
+/**
+ * Create a BTF type given its index within the the type buffer.
+ *
+ * This is the main workhorse function for loading BTF types into drgn. It
+ * assumes you've already looked up the name for a type and resolved it into a
+ * type_id / idx.
+ *
+ * All struct drgn_type created by this function are cached, but qualifiers are
+ * not, since they are trivial to resolve each time.
+ *
+ * @param bf Pointer to BTF registry
+ * @param idx Index of type in the type section
+ * @param[out] ret On success, set to the qualified type
+ * @returns NULL on success, or an error pointer
+ */
+static struct drgn_error *
+drgn_btf_type_create(struct drgn_module_btf_info *mbi, uint32_t idx,
+		     struct drgn_qualified_type *ret)
+{
+	struct drgn_error *err;
+	enum drgn_qualifiers qual = drgn_btf_resolve_qualifiers(mbi->btf, idx, &idx);
+	const struct btf_type *tp = btf__type_by_id(mbi->btf, idx);
+
+	if (mbi->cache[idx]) {
+		ret->qualifiers = qual;
+		ret->type = mbi->cache[idx];
+		return NULL;
+	}
+
+	if (idx == 0) {
+		ret->type = drgn_void_type(MBI_PROG(mbi), &drgn_language_c);
+		ret->qualifiers = qual;
+		mbi->cache[idx] = ret->type;
+		return NULL;
+	}
+
+	switch (btf_kind(tp)) {
+	case BTF_KIND_INT:
+		err = drgn_int_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_PTR:
+		err = drgn_pointer_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_TYPEDEF:
+		err = drgn_typedef_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_STRUCT:
+	case BTF_KIND_UNION:
+		err = drgn_compound_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_ARRAY:
+		err = drgn_array_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_ENUM:
+	case BTF_KIND_ENUM64:
+		err = drgn_enum_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_FUNC_PROTO:
+		err = drgn_func_proto_type_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_FWD:
+		err = drgn_fwd_from_btf(mbi, tp, &ret->type);
+		break;
+	case BTF_KIND_FLOAT:
+		err = drgn_float_from_btf(mbi, tp, &ret->type);
+		break;
+	default:
+		return &drgn_not_found;
+	}
+	if (!err) {
+		ret->qualifiers = qual;
+		mbi->cache[idx] = ret->type;
+	}
+	return err;
+}
+
+/**
+ * The drgn type finder for BTF.
+ *
+ * In order to lookup a type by name, we translate the type kind into a BTF type
+ * kind, search for a type entry of the same name and kind, and then use the
+ * general purpose drgn_btf_type_create() function to do the heavy lifting.
+ * Since BTF encodes no information about compilation units or source filenames,
+ * we always ignore @a filename.
+ *
+ * @param flags Bits set for each type kind drgn may want
+ * @param name Type name to search
+ * @param name_len Length of @a name (not including nul terminator)
+ * @param filename Source filename of type (ignored)
+ * @param arg Pointer to struct drgn_prog_btf of this program.
+ * @param ret Output a qualified type
+ * @returns NULL on success. On error, an appropriate struct drgn_error.
+ */
+static struct drgn_error *
+drgn_type_from_btf(uint64_t flags, const char *name,
+		   size_t name_len, const char *filename,
+		   void *arg, struct drgn_qualified_type *ret)
+{
+	struct drgn_btf_info *bf = arg;
+
+	_cleanup_free_ char *name_copy = strndup(name, name_len);
+	if (!name_copy)
+		return &drgn_enomem;
+
+	struct drgn_btf_index_iterator it =
+		drgn_btf_index_search(&bf->htab, (const char **)&name_copy);
+	if (!it.entry)
+		return &drgn_not_found;
+
+	struct drgn_btf_index_bucket *l = &it.entry->value;
+	for (int i = 0; i < drgn_btf_index_bucket_size(l); i++) {
+		struct drgn_btf_index_item *entry = drgn_btf_index_bucket_at(l, i);
+		const struct btf_type *tp = btf__type_by_id(entry->module->btf.btf,
+							    entry->type_id);
+
+		if (!tp->name_off)
+			continue;
+		if (!kind_match(flags, tp))
+			continue;
+
+		return drgn_btf_type_create(&entry->module->btf, entry->type_id, ret);
+	}
+	return &drgn_not_found;
+}
+
+static struct drgn_error *
+make_constant(struct drgn_btf_index_item *entry, struct drgn_object *ret)
+{
+	struct drgn_module_btf_info *mbi = &entry->module->btf;
+	struct drgn_qualified_type qt;
+	const struct btf_type *tp = btf__type_by_id(mbi->btf, entry->type_id);
+	union {uint64_t u; int64_t s; } val;
+	bool signed_;
+
+	signed_ = BTF_INFO_KFLAG(tp->info);
+	if (btf_kind(tp) == BTF_KIND_ENUM) {
+		struct btf_enum *enum32 = (struct btf_enum *)&tp[1];
+		if (signed_)
+			val.s = enum32[entry->index].val;
+		else
+			val.u = (uint32_t)enum32[entry->index].val;
+	} else if (btf_kind(tp) == BTF_KIND_ENUM64) {
+		struct drgn_btf_enum64 *enum64 = (struct drgn_btf_enum64 *)&tp[1];
+		val.u = ((uint64_t)enum64[entry->index].hi32 << 32)
+			| (uint32_t) enum64[entry->index].orig.val;
+	} else {
+		assert(false);
+	}
+	struct drgn_error *err = drgn_btf_type_create(mbi, entry->type_id, &qt);
+	if (err)
+		return err;
+	if (signed_)
+		return drgn_object_set_signed(ret, qt, val.s, 0);
+	else
+		return drgn_object_set_unsigned(ret, qt, val.u, 0);
+}
+
+static struct drgn_error *
+make_function(const char *name, struct drgn_btf_index_item *entry, struct drgn_object *ret)
+{
+	struct drgn_module_btf_info *mbi = &entry->module->btf;
+	const struct btf_type *tp = btf__type_by_id(mbi->btf, entry->type_id);
+	uint64_t addr;
+
+	struct drgn_error *err =
+		find_symbol_addr(entry->module, name, &addr);
+	if (err)
+		return err;
+
+	struct drgn_qualified_type qt;
+	err = drgn_btf_type_create(mbi, tp->type, &qt);
+	if (err) {
+		return err;
+	}
+	return drgn_object_set_reference(ret, qt, addr, 0, 0);
+}
+
+static struct drgn_error *
+make_variable(struct drgn_btf_info *dbi, const char *name,
+              struct drgn_btf_index_item *entry, bool use_symtab,
+	      struct drgn_object *ret)
+{
+	struct drgn_module *mod = entry->module;
+	struct drgn_error *err;
+	uint64_t address;
+
+	if (use_symtab) {
+		err = find_symbol_addr(mod, name, &address);
+		if (err)
+			return err;
+	} else {
+		if (!entry->is_present)
+			return drgn_error_format(DRGN_ERROR_LOOKUP,
+						 "A BTF VAR is present for \"%s\" in "
+						 "module \"%s\", but it has no DATASEC "
+						 "containing address information. "
+						 "Consider using the btf_symbol "
+						 "object finder.",
+						 name, mod->name);
+		else if (!entry->addr_valid)
+			return drgn_error_format(DRGN_ERROR_LOOKUP,
+						 "A BTF VAR is present for \"%s\" in "
+						 "module \"%s\", but its containing "
+						 "DATASEC base address was not found. "
+						 "Consider using the btf_symbol "
+						 "object finder.",
+						 name, mod->name);
+		else
+			address = entry->addr;
+	}
+	const struct btf_type *tp = btf__type_by_id(mod->btf.btf, entry->type_id);
+	struct drgn_qualified_type qt;
+	err = drgn_btf_type_create(&mod->btf, tp->type, &qt);
+	if (err)
+		return err;
+	return drgn_object_set_reference(ret, qt, address, 0, 0);
+}
+
+static struct drgn_error *drgn_btf_object_find(
+	const char *name, size_t name_len, const char *filename,
+	enum drgn_find_object_flags flags, void *arg, bool use_symtab,
+	struct drgn_object *ret)
+{
+	struct drgn_btf_info *bi = arg;
+	_cleanup_free_ char *name_copy = strndup(name, name_len);
+	if (!name_copy)
+		return &drgn_enomem;
+	struct drgn_btf_index_iterator it =
+		drgn_btf_index_search(&bi->htab, (const char **)&name_copy);
+	if (!it.entry)
+		return &drgn_not_found;
+
+	struct drgn_btf_index_bucket *l = &it.entry->value;
+	for (int i = 0; i < drgn_btf_index_bucket_size(l); i++) {
+		struct drgn_btf_index_item *entry = drgn_btf_index_bucket_at(l, i);
+		if (entry->is_enum && (flags & DRGN_FIND_OBJECT_CONSTANT)) {
+			return make_constant(entry, ret);
+		} else if (entry->kind == BTF_KIND_VAR &&
+			   (flags & DRGN_FIND_OBJECT_VARIABLE)) {
+			return make_variable(bi, name, entry, use_symtab, ret);
+		} else if (entry->kind == BTF_KIND_FUNC &&
+			   (flags & DRGN_FIND_OBJECT_FUNCTION)) {
+			return make_function(name, entry, ret);
+		}
+	}
+	return &drgn_not_found;
+}
+
+static struct drgn_error *drgn_btf_object_find_symbol(
+	const char *name, size_t name_len, const char *filename,
+	enum drgn_find_object_flags flags, void *arg, struct drgn_object *ret)
+{
+	return drgn_btf_object_find(name, name_len, filename, flags,
+				    arg, true, ret);
+}
+
+static struct drgn_error *drgn_btf_object_find_datasec(
+	const char *name, size_t name_len, const char *filename,
+	enum drgn_find_object_flags flags, void *arg, struct drgn_object *ret)
+{
+	return drgn_btf_object_find(name, name_len, filename, flags,
+				    arg, false, ret);
+}
+
+void drgn_module_btf_info_deinit(struct drgn_module *module)
+{
+	free(module->btf.cache);
+	btf__free(module->btf.btf);
+	module->btf.btf = NULL;
+	module->btf.cache = NULL;
+}
+
+static struct drgn_error *
+find_btf_section(struct drgn_elf_file *file, const void **data_ret, size_t *size_ret)
+{
+	Elf_Scn *scn = NULL;
+	size_t shstrndx;
+
+	if (elf_getshdrstrndx(file->elf, &shstrndx))
+		return drgn_error_libelf();
+
+	while ((scn = elf_nextscn(file->elf, scn))) {
+		GElf_Shdr shdr_mem, *shdr = gelf_getshdr(scn, &shdr_mem);
+		if (!shdr)
+			return drgn_error_libelf();
+		const char *scnname = elf_strptr(file->elf, shstrndx, shdr->sh_name);
+		if (!scnname)
+			return drgn_error_libelf();
+		if (strcmp(scnname, ".BTF") != 0)
+			continue;
+		Elf_Data *btf_contents;
+		struct drgn_error *err = read_elf_section(scn, &btf_contents);
+		if (err)
+			return err;
+		*data_ret = btf_contents->d_buf;
+		*size_ret = btf_contents->d_size;
+		return NULL;
+	}
+	return &drgn_not_found;
+}
+
+struct drgn_error *
+drgn_module_load_btf(struct drgn_module *module, const void *btf_data,
+                     size_t btf_data_size, enum drgn_tristate main_module_base)
+{
+	struct drgn_program *prog = module->prog;
+	if (module->btf.btf)
+		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+					 "BTF is already loaded for this module");
+
+	// Linux kernel modules almost always reference the vmlinux BTF as their
+	// base. On the other hand, userspace programs don't typically have a
+	// base BTF.
+	if (main_module_base == DRGN_TRISTATE_DEFAULT)
+		main_module_base = (prog->flags & DRGN_PROGRAM_IS_LINUX_KERNEL)
+			           ? DRGN_TRISTATE_TRUE : DRGN_TRISTATE_FALSE;
+
+	struct btf *base = NULL;
+	if (main_module_base && module->kind != DRGN_MODULE_MAIN) {
+		if (!prog->dbinfo.main_module || !prog->dbinfo.main_module->btf.btf)
+			return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+						 "BTF is not loaded for the main module");
+		base = prog->dbinfo.main_module->btf.btf;
+	}
+
+	// When BTF data is not provided, we can search for it in the loaded and
+	// debug files. This could be useful for kernel or userspace programs.
+	bool checked_loaded = false, checked_debug = false;
+	const char *source = btf_data ? "user input" : NULL;
+	struct drgn_error *err;
+	if (!btf_data && !(module->loaded_file || module->debug_file))
+		return drgn_error_format(DRGN_ERROR_INVALID_ARGUMENT,
+		                         "%s: no BTF data provided and no loaded/debug file present",
+		                         module->name);
+	if (!btf_data && module->loaded_file) {
+		checked_loaded = true;
+		err = find_btf_section(module->loaded_file, &btf_data, &btf_data_size);
+		if (err && !drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
+			return err;
+		if (btf_data)
+			source = "loaded file";
+	}
+	if (!btf_data && module->debug_file) {
+		checked_debug = true;
+		err = find_btf_section(module->debug_file, &btf_data, &btf_data_size);
+		if (err && !drgn_error_catch(&err, DRGN_ERROR_LOOKUP))
+			return err;
+		if (btf_data)
+			source = "debug file";
+	}
+	if (!btf_data)
+		return drgn_error_format(DRGN_ERROR_MISSING_DEBUG_INFO,
+		                         "%s: no .BTF section found (checked:%s%s%s)",
+		                         module->name,
+		                         checked_loaded ? " loaded" : "",
+		                         (checked_loaded && checked_debug) ? " and" : "",
+		                         checked_debug ? " debug" : "");
+
+	if (btf_data_size > UINT32_MAX)
+		return drgn_error_format(DRGN_ERROR_INVALID_ARGUMENT,
+		                         "%s: BTF too large: %zu",
+		                         module->name, btf_data_size);
+
+	struct btf *btf = NULL;
+	if (base)
+		err = drgn_new_split_btf(btf_data, (uint32_t) btf_data_size, base, &btf);
+	else
+		err = drgn_new_btf(btf_data, (uint32_t)btf_data_size, &btf);
+	if (err)
+		return err;
+
+	struct drgn_type **cache =
+		calloc(btf__type_cnt(btf), sizeof(*cache));
+	if (!cache) {
+		btf__free(btf);
+		return &drgn_enomem;
+	}
+
+	module->btf.btf = btf;
+	module->btf.cache = cache;
+	err = index_btf(module);
+	if (err) {
+		clear_btf_on_failure(module);
+		drgn_module_btf_info_deinit(module);
+		return err;
+	}
+	drgn_log_debug(prog, "%s: loaded BTF from %s", module->name, source);
+	return NULL;
+}
+
+void drgn_btf_info_init(struct drgn_debug_info *dbi)
+{
+	drgn_btf_index_init(&dbi->btf.htab);
+
+	// Register type finder with index 1 so that DWARF is used first.
+	const struct drgn_type_finder_ops type_finder_ops = {
+		.find = drgn_type_from_btf,
+	};
+	drgn_program_register_type_finder_impl(dbi->prog, &dbi->btf.type_finder,
+					"btf", &type_finder_ops,
+					&dbi->btf, 1);
+
+	// We have two ways to find objects:
+	// - btf_symbol: Use VAR entries for the types, and use symbol lookup by
+	//   name for object addresses.
+	// - btf_datasec: Use VAR entries for the types, and rely on offset
+	//   information from DATASEC entries to determine object addresses.
+	//
+	// The reason for including btf_symbol is that GCC currently emits BTF
+	// for which the DATASEC offsets are all zero (as of GCC 15,
+	// 2026-07-21). It's difficult to define a reliable heuristic to detect
+	// this, since 0 is a valid offset. Instead, we provide btf_symbol as a
+	// default-disabled object finder.
+	const struct drgn_object_finder_ops object_finder_datasec_ops = {
+		.find = drgn_btf_object_find_datasec,
+	};
+	drgn_program_register_object_finder_impl(dbi->prog, &dbi->btf.object_finder_datasec,
+						 "btf", &object_finder_datasec_ops,
+						 &dbi->btf, 1);
+	const struct drgn_object_finder_ops object_finder_symbol_ops = {
+		.find = drgn_btf_object_find_symbol,
+	};
+	drgn_program_register_object_finder_impl(dbi->prog, &dbi->btf.object_finder_symbol,
+						 "btf_symbol", &object_finder_symbol_ops,
+						 &dbi->btf, DRGN_HANDLER_REGISTER_DONT_ENABLE);
+}
+
+void drgn_btf_info_deinit(struct drgn_debug_info *dbi)
+{
+	// The name map values are a dynamically allocated vector of entries,
+	// free them before deinit.
+	struct drgn_btf_index_iterator it = drgn_btf_index_first(&dbi->btf.htab);
+	while (it.entry) {
+		drgn_btf_index_bucket_deinit(&it.entry->value);
+		it = drgn_btf_index_next(it);
+	}
+	drgn_btf_index_deinit(&dbi->btf.htab);
+}

--- a/libdrgn/btf_info.h
+++ b/libdrgn/btf_info.h
@@ -1,0 +1,78 @@
+#ifndef BTF_INFO_H_
+#define BTF_INFO_H_
+
+#include <stdint.h>
+
+#include "hash_table.h"
+#include "object.h"
+#include "type.h"
+#include "vector.h"
+
+struct drgn_program;
+struct drgn_debug_info;
+
+enum drgn_tristate {
+	DRGN_TRISTATE_DEFAULT = -1,
+	DRGN_TRISTATE_FALSE,
+	DRGN_TRISTATE_TRUE,
+};
+
+/**
+ * Represents an BTF item which can be indexed by name: a variable, a named
+ * type, or an enumerator.
+ */
+struct drgn_btf_index_item {
+	/** Drgn module associated with the type ID */
+	struct drgn_module *module;
+	union {
+		/** For variables: the address of the variable */
+		uint64_t addr;
+		/** For enumerators: the enumerator index */
+		uint64_t index;
+	};
+	/** The indexed type, variable type, or enumerator type */
+	uint32_t type_id;
+	uint8_t kind;
+	unsigned int is_enum : 1;
+	unsigned int is_present : 1;
+	unsigned int addr_valid : 1;
+};
+
+DEFINE_VECTOR_TYPE(drgn_btf_index_bucket, struct drgn_btf_index_item, 1);
+DEFINE_HASH_MAP_TYPE(drgn_btf_index, const char *, struct drgn_btf_index_bucket);
+
+/** BTF type information for the entire program */
+struct drgn_btf_info {
+	struct drgn_type_finder type_finder;
+	struct drgn_object_finder object_finder_symbol, object_finder_datasec;
+	struct drgn_btf_index htab;
+};
+
+/** BTF type information for a module */
+struct drgn_module_btf_info {
+	/** Handle from libbpf */
+	struct btf *btf;
+	/** Map from type ID to the drgn_type */
+	struct drgn_type **cache;
+};
+
+#if defined(WITH_LIBBPF)
+void drgn_btf_info_init(struct drgn_debug_info *);
+void drgn_btf_info_deinit(struct drgn_debug_info *);
+void drgn_module_btf_info_deinit(struct drgn_module *);
+struct drgn_error *
+drgn_module_load_btf(struct drgn_module *, const void *btf_data,
+                     size_t btf_data_size, enum drgn_tristate main_module_base);
+#else
+static inline void drgn_btf_info_init(struct drgn_debug_info *dbi) {}
+static inline void drgn_btf_info_deinit(struct drgn_debug_info *dbi) {}
+static inline void drgn_module_btf_info_deinit(struct drgn_module *mod) {}
+static inline struct drgn_error *
+drgn_module_load_btf(struct drgn_module *mod, const void *btf_data,
+                     size_t btf_data_size, enum drgn_tristate main_module_base)
+{
+	return drgn_error_create(DRGN_ERROR_NOT_IMPLEMENTED,
+				 "drgn was not built with libbpf support");
+}
+#endif
+#endif // BTF_INFO_H_

--- a/libdrgn/configure.ac
+++ b/libdrgn/configure.ac
@@ -158,6 +158,19 @@ AS_CASE(["x$with_json_c"],
 AM_CONDITIONAL([WITH_JSON_C], [test "x$with_json_c" = xyes])
 AM_COND_IF([WITH_JSON_C], [AC_DEFINE(WITH_JSON_C)])
 
+AC_ARG_WITH([libbpf],
+	    [AS_HELP_STRING([--with-libbpf],
+			    [build with support for loading BTF type information with libbpf
+			     @<:@default=auto@:>@])],
+			     [], [with_libbpf=auto])
+AS_CASE(["x$with_libbpf"],
+	[xyes], [PKG_CHECK_MODULES(bpf, [libbpf >= 1.0.0])],
+	[xauto], [PKG_CHECK_MODULES(bpf, [libbpf >= 1.0.0],
+				    [with_libbpf=yes],
+				    [with_libbpf=no])])
+AM_CONDITIONAL([WITH_LIBBPF], [test "x$with_libbpf" = xyes])
+AM_COND_IF([WITH_LIBBPF], [AC_DEFINE(WITH_LIBBPF)])
+
 dnl We need check for running tests, but we don't want to fail the build over
 dnl it. Instead, if it's not found, set variables so that only `make check`
 dnl fails.

--- a/libdrgn/debug_info.c
+++ b/libdrgn/debug_info.c
@@ -28,6 +28,7 @@
 #include "binary_buffer.h"
 #include "binary_search.h"
 #include "bitmap.h"
+#include "btf_info.h"
 #include "cleanup.h"
 #include "crc32.h"
 #include "debug_info.h"
@@ -447,6 +448,7 @@ static void drgn_module_destroy(struct drgn_module *module)
 	drgn_module_section_address_map_deinit(&module->section_addresses);
 	drgn_module_orc_info_deinit(module);
 	drgn_module_dwarf_info_deinit(module);
+	drgn_module_btf_info_deinit(module);
 	drgn_module_clear_wanted_supplementary_debug_file(module);
 	drgn_elf_file_destroy(module->gnu_debugdata_file);
 	drgn_elf_file_destroy(module->supplementary_debug_file);
@@ -5669,6 +5671,7 @@ void drgn_debug_info_init(struct drgn_debug_info *dbinfo,
 	}
 #endif
 	drgn_dwarf_info_init(dbinfo);
+	drgn_btf_info_init(dbinfo);
 }
 
 void drgn_debug_info_deinit(struct drgn_debug_info *dbinfo)
@@ -5684,6 +5687,7 @@ void drgn_debug_info_deinit(struct drgn_debug_info *dbinfo)
 		if (finder->ops.destroy)
 			finder->ops.destroy(finder->arg);
 	);
+	drgn_btf_info_deinit(dbinfo);
 	drgn_dwarf_info_deinit(dbinfo);
 	hash_table_for_each(drgn_module_table, it, &dbinfo->modules) {
 		struct drgn_module *module = *it.entry;

--- a/libdrgn/debug_info.h
+++ b/libdrgn/debug_info.h
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 
 #include "binary_search_tree.h"
+#include "btf_info.h"
 #include "cfi.h"
 #include "debug_info_options.h"
 #include "drgn_internal.h"
@@ -108,6 +109,8 @@ struct drgn_debug_info {
 	struct drgn_module *modules_pending_indexing;
 	/** DWARF debugging information. */
 	struct drgn_dwarf_info dwarf;
+	/** BTF type information. */
+	struct drgn_btf_info btf;
 
 	struct drgn_handler_list debug_info_finders;
 	struct drgn_debug_info_finder standard_debug_info_finder;
@@ -265,6 +268,8 @@ struct drgn_module {
 	struct drgn_elf_symbol_table elf_symtab;
 	/** Symbol table from the gnu_debugdata_file */
 	struct drgn_elf_symbol_table gnu_debugdata_symtab;
+	/** BTF type information */
+	struct drgn_module_btf_info btf;
 
 	/** Whether .debug_frame has been parsed. */
 	bool parsed_debug_frame;

--- a/libdrgn/python/main.c
+++ b/libdrgn/python/main.c
@@ -477,6 +477,15 @@ DRGNPY_PUBLIC PyMODINIT_FUNC PyInit__drgn(void)
 		    ))
 		goto err;
 
+	if (add_bool(m, "_with_libbpf",
+#ifdef WITH_LIBBPF
+		     true
+#else
+		     false
+#endif
+		    ))
+		goto err;
+
 	return m;
 
 err:

--- a/libdrgn/python/module.c
+++ b/libdrgn/python/module.c
@@ -181,6 +181,22 @@ static PyObject *Module_try_file(Module *self, PyObject *args, PyObject *kwds)
 	Py_RETURN_NONE;
 }
 
+static PyObject *Module_load_btf(Module *self, PyObject *args, PyObject *kwds)
+{
+	static char *keywords[] = { "data", "main_module_base", NULL };
+	const char *btf_data = NULL;
+	size_t btf_size = 0;
+	int main_module_base = DRGN_TRISTATE_DEFAULT;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$z#p:load_btf", keywords,
+					 &btf_data, &btf_size, &main_module_base))
+		return NULL;
+	struct drgn_error *err = drgn_module_load_btf(self->module, btf_data,
+						      btf_size, main_module_base);
+	if (err)
+		return set_drgn_error(err);
+	Py_RETURN_NONE;
+}
+
 static Program *Module_get_prog(Module *self, void *arg)
 {
 	Program *prog = Module_prog(self);
@@ -497,6 +513,8 @@ static PyMethodDef Module_methods[] = {
 	 drgn_Module_wanted_supplementary_debug_file_DOC},
 	{"try_file", (PyCFunction)Module_try_file,
 	 METH_VARARGS | METH_KEYWORDS, drgn_Module_try_file_DOC},
+	{"load_btf", (PyCFunction)Module_load_btf,
+	 METH_VARARGS | METH_KEYWORDS, drgn_Module_load_btf_DOC},
 	{},
 };
 

--- a/scripts/build_manylinux_in_docker.sh
+++ b/scripts/build_manylinux_in_docker.sh
@@ -75,6 +75,18 @@ curl -L "$check_url" | tar -xz --strip-components=1
 make -j$(($(nproc) + 1))
 make install
 
+# CentOS 7 has no libbpf, and CentOS 8 ships 0.5.0, neither of which are new
+# enough for our 1.0.0 minimum.
+libbpf_version=1.7.0
+libbpf_url=https://github.com/libbpf/libbpf/archive/refs/tags/v$libbpf_version.tar.gz
+mkdir /tmp/libbpf
+cd /tmp/libbpf
+curl -L "$libbpf_url" | tar -xz --strip-components=1
+make -j$(($(nproc) + 1)) -C src
+# CentOS 7's kernel does not even have BTF, so we need to be sure to install
+# libbpf's bundled UAPI headers.
+make -C src install install_uapi_headers
+
 ldconfig
 
 mkdir /tmp/drgn

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,6 +28,7 @@ from drgn import (
     TypeMember,
     TypeParameter,
     TypeTemplateParameter,
+    _with_libbpf,
     get_default_prog,
     set_default_prog,
 )
@@ -474,3 +475,6 @@ def with_default_prog(prog):
         yield
     finally:
         set_default_prog(old_default_prog)
+
+
+skip_unless_have_libbpf = unittest.skipUnless(_with_libbpf, "test requires libbpf")

--- a/tests/btf.py
+++ b/tests/btf.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026 Oracle and/or its affiliates
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import enum
+import struct
+from typing import NamedTuple, Optional, Sequence
+
+
+class BTF_KIND(enum.IntEnum):
+    UNKN = 0
+    INT = 1
+    PTR = 2
+    ARRAY = 3
+    STRUCT = 4
+    UNION = 5
+    ENUM = 6
+    FWD = 7
+    TYPEDEF = 8
+    VOLATILE = 9
+    CONST = 10
+    RESTRICT = 11
+    FUNC = 12
+    FUNC_PROTO = 13
+    VAR = 14
+    DATASEC = 15
+    FLOAT = 16
+    DECL_TAG = 17
+    TYPE_TAG = 18
+    ENUM64 = 19
+
+
+class BTF_INT(enum.IntFlag):
+    SIGNED = 1 << 0
+    CHAR = 1 << 1
+    BOOL = 1 << 2
+
+
+class BTF_VAR(enum.IntEnum):
+    STATIC = 0
+    GLOBAL_ALLOCATED = 1
+    GLOBAL_EXTERN = 2
+
+
+class BTF_FUNC(enum.IntEnum):
+    STATIC = 0
+    GLOBAL = 1
+    EXTERN = 2
+
+
+class BtfMember(NamedTuple):
+    name: Optional[str]
+    type: int
+    offset: int
+    bitfield_size: int = 0
+
+
+class BtfEnum(NamedTuple):
+    name: str
+    value: int
+
+
+class BtfParam(NamedTuple):
+    name: Optional[str]
+    type: int
+
+
+class BtfVarSecinfo(NamedTuple):
+    type: int
+    offset: int
+    size: int
+
+
+class BtfType(NamedTuple):
+    kind: BTF_KIND
+    name: Optional[str] = None
+    size_type: int = 0
+    vlen: int = 0
+    kflag: bool = False
+    data: object = ()
+
+
+class CompiledBtf(NamedTuple):
+    data: bytes
+    nr_types: int
+    strings_len: int
+
+
+def btf_int(
+    name: str,
+    *,
+    bits: int,
+    signed: bool = False,
+    char: bool = False,
+    bool: bool = False,
+    offset: int = 0,
+    size: int = 0,
+) -> BtfType:
+    encoding = (
+        (BTF_INT.SIGNED if signed else 0)
+        | (BTF_INT.CHAR if char else 0)
+        | (BTF_INT.BOOL if bool else 0)
+    )
+    # Automatically determine byte size
+    if size == 0:
+        size = (bits + 7) // 8
+    return BtfType(
+        BTF_KIND.INT,
+        name,
+        size,
+        data=(int(encoding) << 24) | (offset << 16) | bits,
+    )
+
+
+def btf_ptr(type: int) -> BtfType:
+    return BtfType(BTF_KIND.PTR, size_type=type)
+
+
+def btf_array(type: int, index_type: int, nelems: int) -> BtfType:
+    return BtfType(BTF_KIND.ARRAY, data=(type, index_type, nelems))
+
+
+def btf_member(
+    name: Optional[str], type: int, offset: int, *, bitfield_size: int = 0
+) -> BtfMember:
+    return BtfMember(name, type, offset, bitfield_size)
+
+
+def _btf_compound(
+    kind: BTF_KIND,
+    name: str,
+    size: int,
+    members: Sequence[BtfMember],
+    *,
+    kflag: bool = False,
+) -> BtfType:
+    return BtfType(
+        kind,
+        name,
+        size,
+        len(members),
+        kflag or any(member.bitfield_size for member in members),
+        tuple(members),
+    )
+
+
+def btf_struct(
+    name: str, size: int, members: Sequence[BtfMember] = (), kflag: bool = False
+) -> BtfType:
+    return _btf_compound(BTF_KIND.STRUCT, name, size, members, kflag=kflag)
+
+
+def btf_union(
+    name: str, size: int, members: Sequence[BtfMember] = (), kflag: bool = False
+) -> BtfType:
+    return _btf_compound(BTF_KIND.UNION, name, size, members, kflag=kflag)
+
+
+def btf_enum(
+    name: str, size: int, values: Sequence[BtfEnum] = (), *, signed: bool = False
+) -> BtfType:
+    return BtfType(BTF_KIND.ENUM, name, size, len(values), signed, tuple(values))
+
+
+def btf_fwd(name: str, *, is_union: bool = False) -> BtfType:
+    return BtfType(BTF_KIND.FWD, name, kflag=is_union)
+
+
+def btf_typedef(name: str, type: int) -> BtfType:
+    return BtfType(BTF_KIND.TYPEDEF, name, type)
+
+
+def btf_volatile(type: int) -> BtfType:
+    return BtfType(BTF_KIND.VOLATILE, None, type)
+
+
+def btf_const(type: int) -> BtfType:
+    return BtfType(BTF_KIND.CONST, None, type)
+
+
+def btf_restrict(type: int) -> BtfType:
+    return BtfType(BTF_KIND.RESTRICT, None, type)
+
+
+def btf_func(name: str, proto: int, *, vlen: BTF_FUNC = BTF_FUNC.STATIC) -> BtfType:
+    return BtfType(BTF_KIND.FUNC, name, proto, int(vlen))
+
+
+def btf_param(name: Optional[str], type: int) -> BtfParam:
+    return BtfParam(name, type)
+
+
+def btf_func_proto(ret: int, params: Sequence[BtfParam] = ()) -> BtfType:
+    return BtfType(
+        BTF_KIND.FUNC_PROTO, size_type=ret, vlen=len(params), data=tuple(params)
+    )
+
+
+def btf_var(name: str, type: int, *, linkage: BTF_VAR = BTF_VAR.STATIC) -> BtfType:
+    return BtfType(BTF_KIND.VAR, name, type, data=int(linkage))
+
+
+def btf_var_secinfo(type: int, offset: int, size: int) -> BtfVarSecinfo:
+    return BtfVarSecinfo(type, offset, size)
+
+
+def btf_datasec(
+    name: str, size: int, variables: Sequence[BtfVarSecinfo] = ()
+) -> BtfType:
+    return BtfType(BTF_KIND.DATASEC, name, size, len(variables), data=tuple(variables))
+
+
+def btf_float(name: str, size: int) -> BtfType:
+    return BtfType(BTF_KIND.FLOAT, name, size)
+
+
+def btf_decl_tag(name: str, type: int, component_idx: int = -1) -> BtfType:
+    return BtfType(BTF_KIND.DECL_TAG, name, type, data=component_idx)
+
+
+def btf_type_tag(name: str, type: int) -> BtfType:
+    return BtfType(BTF_KIND.TYPE_TAG, name, type)
+
+
+def btf_enum64(
+    name: str, size: int, values: Sequence[BtfEnum] = (), *, signed: bool = False
+) -> BtfType:
+    return BtfType(BTF_KIND.ENUM64, name, size, len(values), signed, tuple(values))
+
+
+def btf_compile(
+    types: Sequence[BtfType],
+    *,
+    little_endian: bool = True,
+    base: Optional[CompiledBtf] = None,
+) -> CompiledBtf:
+    endian = "<" if little_endian else ">"
+    u32 = struct.Struct(endian + "I")
+    type_struct = struct.Struct(endian + "III")
+    strings = bytearray(b"\0")
+    string_offsets = {None: 0, "": 0}
+    start_str = 0
+    if base:
+        start_str += base.strings_len
+
+    def string_offset(name: Optional[str]) -> int:
+        try:
+            return string_offsets[name]
+        except KeyError:
+            assert name is not None
+            offset = start_str + len(strings)
+            string_offsets[name] = offset
+            strings.extend(name.encode())
+            strings.append(0)
+            return offset
+
+    type_data = bytearray()
+    for type in types:
+        info = type.vlen | (int(type.kind) << 24) | (int(type.kflag) << 31)
+        type_data.extend(
+            type_struct.pack(string_offset(type.name), info, type.size_type)
+        )
+        if type.kind == BTF_KIND.INT:
+            type_data.extend(u32.pack(type.data))
+        elif type.kind == BTF_KIND.ARRAY:
+            type_data.extend(struct.pack(endian + "III", *type.data))
+        elif type.kind in (BTF_KIND.STRUCT, BTF_KIND.UNION):
+            for member in type.data:
+                offset = member.offset | (member.bitfield_size << 24)
+                type_data.extend(
+                    struct.pack(
+                        endian + "III", string_offset(member.name), member.type, offset
+                    )
+                )
+        elif type.kind in (BTF_KIND.ENUM, BTF_KIND.ENUM64):
+            for value in type.data:
+                if type.kind == BTF_KIND.ENUM:
+                    type_data.extend(
+                        struct.pack(
+                            endian + "Ii", string_offset(value.name), value.value
+                        )
+                    )
+                else:
+                    type_data.extend(
+                        struct.pack(
+                            endian + "III",
+                            string_offset(value.name),
+                            value.value & 0xFFFFFFFF,
+                            value.value >> 32 & 0xFFFFFFFF,
+                        )
+                    )
+        elif type.kind == BTF_KIND.FUNC_PROTO:
+            for param in type.data:
+                type_data.extend(
+                    struct.pack(endian + "II", string_offset(param.name), param.type)
+                )
+        elif type.kind in (BTF_KIND.VAR, BTF_KIND.DECL_TAG):
+            type_data.extend(
+                struct.pack(
+                    endian + ("I" if type.kind == BTF_KIND.VAR else "i"), type.data
+                )
+            )
+        elif type.kind == BTF_KIND.DATASEC:
+            for variable in type.data:
+                type_data.extend(struct.pack(endian + "III", *variable))
+
+    # fmt: off
+    header = struct.pack(
+        endian + "HBBIIIII",
+        0xEB9F,              # BTF_MAGIC
+        1,                   # BTF_VERSION == 1
+        0,                   # flags... unused?
+        24,                  # header length
+        0,                   # offset of type section
+        len(type_data),      # length of type section
+        len(type_data),      # offset of string section
+        len(strings),        # length of string section
+    )
+    # fmt: on
+    data = header + type_data + strings
+    return CompiledBtf(data, len(types), len(strings))

--- a/tests/linux_kernel/helpers/test_btf.py
+++ b/tests/linux_kernel/helpers/test_btf.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2026 Oracle and/or its affiliates
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import struct
+import unittest
+from unittest import mock
+
+from drgn import (
+    FindObjectFlags,
+    Program,
+    Symbol,
+    SymbolBinding,
+    SymbolIndex,
+    SymbolKind,
+    TypeKind,
+    TypeMember,
+    host_platform,
+)
+from drgn.helpers.experimental.btf import (
+    build_c_declaration_object_finder,
+    load_builtin_btf,
+)
+from tests import TestCase, skip_unless_have_libbpf
+from tests.linux_kernel import LinuxKernelTestCase, skip_unless_have_test_kmod
+from tests.linux_kernel.helpers import test_block, test_fs
+
+VMLINUX_BTF_PATH = "/sys/kernel/btf/vmlinux"
+DRGN_TEST_BTF_PATH = "/sys/kernel/btf/drgn_test"
+
+
+@skip_unless_have_libbpf
+class TestBtfLoading(LinuxKernelTestCase):
+
+    def setUp(self):
+        if not os.path.exists(VMLINUX_BTF_PATH):
+            raise unittest.SkipTest("BTF is not available")
+
+        # For these tests we need a new kernel program each time.
+        # Each test will load BTF in a different way.
+        # However, we still reuse the LinuxKernelTestCase so we can guarantee
+        # that any reason why we may have wanted to skip the test (e.g. lack of
+        # permissions) is already handled.
+        self.dwarf_prog = self.prog
+        self.prog = Program()
+        self.prog.set_kernel()
+        self.prog.main_module("kernel", create=True)
+
+        # Even though we're loading BTF repeatedly, we really don't want to
+        # parse kallsyms repeatedly: it's rather slow. These are the minimum
+        # symbols necessary, copy them from the DWARF program. This is purely a
+        # speed optimization: they *are* present in kallsyms.
+        syms = []
+        names = [
+            # Needed for module discovery:
+            "modules",
+            # Needed to find built-in BTF:
+            "__start_BTF",
+            "__stop_BTF",
+        ]
+        optional_names = [
+            # Needed for BTF module discovery, but it is missing on kernels
+            # which do not have module BTF -- that's ok.
+            "btf_modules",
+            # Needed as the base address for percpu DATASEC vars. However, on
+            # !SMP configurations, some architectures don't have the symbol at
+            # all, so make it optional.
+            "__per_cpu_start",
+        ]
+        for name in names + optional_names:
+            try:
+                syms.append(self.dwarf_prog.symbol(name))
+            except LookupError:
+                # Some kernels have BTF but not built-in module BTF
+                if name not in optional_names:
+                    raise
+        self.prog.register_symbol_finder(
+            "required_symbols", SymbolIndex(syms), enable_index=0
+        )
+
+    def _skip_unless_have_module_btf(self):
+        try:
+            self.dwarf_prog.symbol("btf_modules")
+        except LookupError:
+            # Module BTF is introduced in 36e68442d1afd ("bpf: Load and verify
+            # kernel module BTFs").
+            self.skipTest("Module BTF is not available")
+
+    def _do_vmlinux_btf_smoke(self):
+        task_struct = self.prog.type("struct task_struct")
+        self.assertEqual(task_struct.kind, TypeKind.STRUCT)
+        self.assertGreater(len(task_struct.members), 20)
+
+    def _load_vmlinux_kernfs_btf(self):
+        with open(VMLINUX_BTF_PATH, "rb") as f:
+            btf = f.read()
+        self.prog.main_module().load_btf(data=btf)
+
+    def test_kernfs_smoke(self):
+        self._load_vmlinux_kernfs_btf()
+        self._do_vmlinux_btf_smoke()
+
+    def test_builtin_smoke(self):
+        try:
+            start_sym = self.dwarf_prog.symbol("__start_BTF")
+            stop_sym = self.dwarf_prog.symbol("__stop_BTF")
+        except LookupError:
+            self.skipTest("Built-in BTF not available")
+        addr = start_sym.address
+        size = stop_sym.address - start_sym.address
+        btf = self.dwarf_prog.read(addr, size)
+        self.prog.main_module().load_btf(data=btf)
+        self._do_vmlinux_btf_smoke()
+
+    def _do_drgn_test_kmod_smoke(self):
+        t = self.prog.type("drgn_test_anonymous_union")
+        self.assertEqual(t.kind, TypeKind.TYPEDEF)
+        union = t.type
+        self.assertEqual(union.kind, TypeKind.UNION)
+
+    @skip_unless_have_test_kmod
+    def test_kmod_smoke(self):
+        self._skip_unless_have_module_btf()
+        self._load_vmlinux_kernfs_btf()
+        self.prog.create_loaded_modules()
+        with open(DRGN_TEST_BTF_PATH, "rb") as f:
+            btf = f.read()
+        drgn_test = self.prog.module("drgn_test")
+        # The default is main_module_base=True for the kernel
+        drgn_test.load_btf(data=btf)
+        self._do_drgn_test_kmod_smoke()
+
+    @skip_unless_have_test_kmod
+    def test_load_builtin_btf_kernfs(self):
+        self._skip_unless_have_module_btf()
+        with mock.patch(
+            "drgn.helpers.experimental.btf.load_vmlinux_kallsyms",
+            return_value=lambda *_: [],
+        ), mock.patch(
+            "os.path.isdir",
+            return_value=True,
+        ):
+            load_builtin_btf(self.prog)
+            self._do_vmlinux_btf_smoke()
+            self._do_drgn_test_kmod_smoke()
+
+    @skip_unless_have_test_kmod
+    def test_load_bulitin_btf_internal(self):
+        self._skip_unless_have_module_btf()
+        with mock.patch(
+            "drgn.helpers.experimental.btf.load_vmlinux_kallsyms",
+            return_value=lambda *_: [],
+        ), mock.patch(
+            "os.path.isdir",
+            return_value=False,
+        ):
+            load_builtin_btf(self.prog)
+            self._do_vmlinux_btf_smoke()
+            self._do_drgn_test_kmod_smoke()
+
+
+class LinuxKernelBtfTestCase(LinuxKernelTestCase):
+
+    btf_prog = None
+    declarations = """
+    // Needed by BTF loading:
+    struct list_head btf_modules, modules;
+    // Needed for tests.linux_kernel.helpers.test_block:
+    struct drgn_test_blkdev drgn_test_blkdevs[2];
+    const struct class block_class;
+    struct super_block *blockdev_superblock;
+    struct kset *class_kset;
+    // Needed for tests.linux_kernel.helpers.test_fs:
+    struct task_struct init_task;
+    struct pid_namespace init_pid_ns;
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Similar to LinuxKernelTestCase, create the program just once and cache
+        # it on the class. The overhead of parsing kallsyms is quite a lot.
+        super().setUpClass()
+        try:
+            cls.prog.symbol("btf_modules")
+        except LookupError:
+            raise unittest.SkipTest("Module BTF is not available")
+
+        if cls.btf_prog is None:
+            cls.dwarf_prog = cls.prog
+            cls.btf_prog = Program()
+            cls.btf_prog.set_kernel()
+            load_builtin_btf(cls.btf_prog, cls.declarations)
+
+    def setUp(self):
+        super().setUp()
+        self.prog = self.btf_prog
+
+
+@skip_unless_have_libbpf
+class TestKernelBTF(LinuxKernelBtfTestCase):
+    def test_per_cpu_global_var(self):
+        # Since v2.6.34-rc2 commit 259354deaaf03 ("module: encapsulate percpu
+        # handling better and record percpu_size"), the percpu field of struct
+        # module has been guarded exclusively by CONFIG_SMP.
+        if not self.prog.type("struct module").has_member("percpu"):
+            self.skipTest("No percpu variables on !SMP")
+        # Percpu variables are the only ones for which BTF already contains a
+        # DATASEC. Test that the BTF object finder can find the percpu base
+        # address for vmlinux.
+        obj = self.prog["runqueues"]
+        dwarf_obj = self.dwarf_prog["runqueues"]
+        self.assertEqual(obj.address_, dwarf_obj.address_)
+
+
+@skip_unless_have_test_kmod
+@skip_unless_have_libbpf
+class TestKmod(LinuxKernelBtfTestCase):
+    def test_unions(self):
+        # The test isn't really about the correct definition of u32/s32, which
+        # changes over kernel versions and architectures.
+        u32 = self.prog.type("u32")
+        s32 = self.prog.type("s32")
+        u64 = self.prog.type("u64")
+        s64 = self.prog.type("s64")
+
+        drgn_test_union = self.prog.union_type(
+            "drgn_test_union",
+            4,
+            (
+                TypeMember(u32, "u", 0),
+                TypeMember(s32, "s", 0),
+            ),
+        )
+        self.assertIdentical(drgn_test_union, self.prog.type("union drgn_test_union"))
+        anon_union = self.prog.union_type(
+            None,
+            8,
+            (
+                TypeMember(u64, "u", 0),
+                TypeMember(s64, "s", 0),
+            ),
+        )
+        anon_union_typedef = self.prog.typedef_type(
+            "drgn_test_anonymous_union",
+            anon_union,
+        )
+        self.assertIdentical(
+            anon_union_typedef, self.prog.type("drgn_test_anonymous_union")
+        )
+
+    def test_per_cpu_global_var(self):
+        # Since v2.6.34-rc2 commit 259354deaaf03 ("module: encapsulate percpu
+        # handling better and record percpu_size"), the percpu field of struct
+        # module has been guarded exclusively by CONFIG_SMP.
+        if not self.prog.type("struct module").has_member("percpu"):
+            self.skipTest("No percpu variables on !SMP")
+        # Percpu variables are the only ones for which BTF already contains a
+        # DATASEC. Test that the BTF object finder can find the percpu base
+        # address for the drgn_test module.
+        obj = self.prog["drgn_test_percpu_static"]
+        dwarf_obj = self.dwarf_prog["drgn_test_percpu_static"]
+        self.assertEqual(obj.address_, dwarf_obj.address_)
+
+
+@skip_unless_have_libbpf
+class TestFsBTF(test_fs.TestFs, LinuxKernelBtfTestCase):
+    pass
+
+
+@skip_unless_have_libbpf
+class TestBlockBTF(test_block.TestBlock, LinuxKernelBtfTestCase):
+    pass
+
+
+@skip_unless_have_libbpf
+class TestCDeclarationObjectFinder(TestCase):
+    def setUp(self):
+        self.prog = Program(host_platform)
+
+        int_type = self.prog.int_type("int", 4, True)
+        pair_type = self.prog.struct_type(
+            "pair",
+            8,
+            (
+                TypeMember(int_type, "first", 0),
+                TypeMember(int_type, "second", 32),
+            ),
+        )
+        types = {
+            (TypeKind.INT, "int"): int_type,
+            (TypeKind.STRUCT, "pair"): pair_type,
+        }
+
+        def type_finder(prog, kinds, name, filename):
+            if filename is None:
+                for kind in kinds:
+                    type_ = types.get((kind, name))
+                    if type_ is not None:
+                        return type_
+            return None
+
+        symbols = {
+            "number": Symbol(
+                "number", 0x1000, 4, SymbolBinding.GLOBAL, SymbolKind.OBJECT
+            ),
+            "numbers": Symbol(
+                "numbers", 0x1004, 8, SymbolBinding.GLOBAL, SymbolKind.OBJECT
+            ),
+            "number_pointer": Symbol(
+                "number_pointer", 0x100C, 8, SymbolBinding.GLOBAL, SymbolKind.OBJECT
+            ),
+            "pair": Symbol("pair", 0x1014, 8, SymbolBinding.GLOBAL, SymbolKind.OBJECT),
+        }
+        memory = struct.pack("=iiiQii", 42, 1, 2, 0x1000, -3, 4)
+
+        def symbol_finder(prog, name, address, one):
+            if name is not None and name in symbols:
+                return (symbols[name],)
+            return ()
+
+        def memory_reader(address, count, offset, physical):
+            return memory[offset : offset + count]
+
+        self.prog.register_type_finder("test", type_finder, enable_index=0)
+        self.prog.register_symbol_finder("test", symbol_finder, enable_index=0)
+        self.prog.add_memory_segment(0x1000, len(memory), memory_reader)
+        self.prog.register_object_finder(
+            "test",
+            build_c_declaration_object_finder(
+                """
+                // Declarations can be split over multiple lines.
+                int number, numbers[2];
+                int *number_pointer;
+
+                struct pair pair; // And can have trailing comments.
+                """
+            ),
+            enable_index=0,
+        )
+
+    def test_find_declared_objects(self):
+        self.assertEqual(self.prog["number"].value_(), 42)
+        self.assertEqual(self.prog["numbers"].value_(), [1, 2])
+        self.assertEqual(self.prog["number_pointer"][0].value_(), 42)
+        self.assertEqual(self.prog["pair"].value_(), {"first": -3, "second": 4})
+
+        self.assertEqual(
+            self.prog.object("number", FindObjectFlags.VARIABLE).value_(), 42
+        )
+        with self.assertRaises(LookupError):
+            self.prog.object("number", FindObjectFlags.CONSTANT)
+        with self.assertRaises(LookupError):
+            self.prog.object("undeclared_symbol")
+
+    def test_invalid_declaration(self):
+        with self.assertRaisesRegex(ValueError, "Invalid declaration"):
+            build_c_declaration_object_finder("int function(void);")

--- a/tests/test_btf.py
+++ b/tests/test_btf.py
@@ -1,0 +1,727 @@
+# Copyright (c) 2026 Oracle and/or its affiliates
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import tempfile
+
+from _drgn_util.elf import ET, PT, SHF, SHT, STB, STT
+from drgn import (
+    Object,
+    ObjectNotFoundError,
+    PlatformFlags,
+    Program,
+    Qualifiers,
+    TypeEnumerator,
+    TypeMember,
+    TypeParameter,
+    host_platform,
+)
+from tests import MOCK_BIG_ENDIAN_PLATFORM, TestCase, skip_unless_have_libbpf
+from tests.btf import (
+    BtfEnum,
+    btf_array,
+    btf_compile,
+    btf_const,
+    btf_datasec,
+    btf_enum,
+    btf_enum64,
+    btf_float,
+    btf_func,
+    btf_func_proto,
+    btf_fwd,
+    btf_int,
+    btf_member,
+    btf_param,
+    btf_ptr,
+    btf_restrict,
+    btf_struct,
+    btf_typedef,
+    btf_union,
+    btf_var,
+    btf_var_secinfo,
+    btf_volatile,
+)
+from tests.elfwriter import ElfSection, ElfSymbol, create_elf_file
+
+
+def btf_program(types, *, little_endian=True, platform=host_platform):
+    # libbpf infers the pointer size by searching for the "unsigned long" type
+    # size (among others). Include a definition so we get valid pointer sizes
+    # matching the target platform.
+    if not any(t.name == "unsigned long" for t in types):
+        ptr_size = 64 if platform.flags & PlatformFlags.IS_64_BIT else 32
+        types.append(btf_int("unsigned long", bits=ptr_size))
+    data = btf_compile(types, little_endian=little_endian).data
+    prog = Program(platform=platform)
+    module = prog.main_module("btf", create=True)
+    module.load_btf(data=data)
+    return prog
+
+
+def btf_test_type(*types, **kwargs):
+    prog = btf_program([*types, btf_typedef("TEST", len(types))], **kwargs)
+    return prog, prog.type("TEST").type
+
+
+@skip_unless_have_libbpf
+class TestBtfTypeFinder(TestCase):
+    def test_big_endian(self):
+        # A basic correctness check: can big-endian platform read a big-endian
+        # encoded BTF data and load a basic int type?
+        # Note that BTF has no mechanism to encode an integer type with some
+        # other endianness, so this is not about creating a big-endian in on
+        # a little-endian platform.
+        prog, type_ = btf_test_type(
+            btf_int("int", bits=32, signed=True),
+            little_endian=False,
+            platform=MOCK_BIG_ENDIAN_PLATFORM,
+        )
+        self.assertIdentical(type_, prog.int_type("int", 4, True, "big"))
+
+    def test_int(self):
+        prog, type_ = btf_test_type(btf_int("u8", bits=8))
+        self.assertIdentical(type_, prog.int_type("u8", 1, False))
+
+    def test_signed_int(self):
+        prog, type_ = btf_test_type(btf_int("s16", bits=16, signed=True))
+        self.assertIdentical(type_, prog.int_type("s16", 2, True))
+
+    def test_bool(self):
+        prog, type_ = btf_test_type(btf_int("_Bool", bits=8, bool=True))
+        self.assertIdentical(type_, prog.bool_type("_Bool", 1, None))
+
+    def test_char(self):
+        # The char flag actually does nothing. See below.
+        prog, type_ = btf_test_type(btf_int("char", bits=8, char=True))
+        self.assertIdentical(type_, prog.int_type("char", 1, False))
+
+    def test_signed_char(self):
+        # According to the BTF documentation, "At most one encoding can be
+        # specified for the int type", which would indicate that it is not legal
+        # to represent a signed char with both flags enabled. In practice, when
+        # representing a signed char, GCC only uses the "signed" flag. The char
+        # flag doesn't actually do anything except enable pretty-printing for
+        # some BTF consumers.
+        prog, type_ = btf_test_type(btf_int("char", bits=8, signed=True))
+        self.assertIdentical(type_, prog.int_type("char", 1, True))
+
+    def test_int_offset_bits(self):
+        # The offset and bits encoding of an integer type are ignored, since
+        # they only apply to a compound type member. The size field of btf_type
+        # is the official byte size of the integer, regardless of the bit size.
+        #
+        # In practice, an integer with non-standard bits & offset would only be
+        # referenced by a member anyway, not a typedef.
+        prog, type_ = btf_test_type(btf_int("oddball", bits=17, offset=2, size=4))
+        self.assertIdentical(type_, prog.int_type("oddball", 4, False))
+
+    def test_qualifiers(self):
+        for combination in range(8):
+            with self.subTest(combination):
+                types = [btf_int("int", bits=32, signed=True)]
+                quals = Qualifiers.NONE
+                if combination & 1:
+                    types.append(btf_const(len(types)))
+                    quals |= Qualifiers.CONST
+                if combination & 2:
+                    types.append(btf_restrict(len(types)))
+                    quals |= Qualifiers.RESTRICT
+                if combination & 4:
+                    types.append(btf_volatile(len(types)))
+                    quals |= Qualifiers.VOLATILE
+                prog, type_ = btf_test_type(*types)
+                self.assertIdentical(
+                    type_, prog.int_type("int", 4, True, qualifiers=quals)
+                )
+
+    def test_void_pointer(self):
+        prog, type_ = btf_test_type(btf_ptr(0))
+        self.assertIdentical(type_, prog.pointer_type(prog.void_type()))
+
+    def test_qualified_void(self):
+        prog, type_ = btf_test_type(btf_const(0))
+        self.assertIdentical(type_, prog.void_type(qualifiers=Qualifiers.CONST))
+
+    def test_pointer(self):
+        prog, type_ = btf_test_type(btf_int("int", bits=32, signed=True), btf_ptr(1))
+        self.assertIdentical(type_, prog.pointer_type(prog.int_type("int", 4, True)))
+
+    def test_float(self):
+        prog, type_ = btf_test_type(btf_float("float", 4))
+        self.assertIdentical(type_, prog.float_type("float", 4))
+
+    def test_array(self):
+        prog, type_ = btf_test_type(
+            btf_int("int", bits=32, signed=True), btf_array(1, 1, 3)
+        )
+        self.assertIdentical(type_, prog.array_type(prog.int_type("int", 4, True), 3))
+
+    def test_multidimensional_array(self):
+        # BTF is fully capable of representing multi-dimensional arrays.
+        # However, according to the BTF documentation: "Currently for the
+        # kernel, both pahole and llvm collapse multidimensional array into
+        # one-dimensional array, e.g., for a[5][6], the btf_array.nelems is
+        # equal to 30."
+        # HOWEVER, GCC does not perform this flattening. So it's important to
+        # verify that we correctly handle multidimensional arrays. Hopefully
+        # correctly encoding arrays will become the norm for LLVM & pahole too.
+        prog, type_ = btf_test_type(
+            btf_int("int", bits=32, signed=True),
+            btf_array(1, 1, 6),
+            btf_array(2, 1, 5),
+        )
+        self.assertIdentical(
+            type_,
+            prog.array_type(prog.array_type(prog.int_type("int", 4, True), 6), 5),
+        )
+
+    def test_zero_length_array_not_incomplete(self):
+        prog, type_ = btf_test_type(
+            btf_int("int", bits=32, signed=True), btf_array(1, 1, 0)
+        )
+        # BTF does not provide a mechanism to distinguish between a zero-length
+        # array and an incomplete array type. Zero-length arrays are a bit more
+        # flexible (they support sizeof) so drgn always encodes as zero-length,
+        # not incomplete.
+        self.assertIdentical(type_, prog.array_type(prog.int_type("int", 4, True), 0))
+
+    def test_simple_struct_members(self):
+        prog = btf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                btf_struct(
+                    "point",
+                    8,
+                    [
+                        btf_member("x", 1, 0),
+                        btf_member("y", 1, 32),
+                    ],
+                ),
+            ]
+        )
+        int_type = prog.int_type("int", 4, True)
+        self.assertIdentical(
+            prog.type("struct point"),
+            prog.struct_type(
+                "point",
+                8,
+                [
+                    TypeMember(int_type, "x", 0),
+                    TypeMember(int_type, "y", 32),
+                ],
+            ),
+        )
+
+    def test_struct_bitfield_legacy(self):
+        # With the legacy approach, compilers are "supposed" to encode the
+        # byte-aligned offset in the structure and then bit offsets can be
+        # placed into the int encoding. It's important that we must traverse the
+        # type graph and skip typedefs & qualifiers in order to arrive at the
+        # base type.
+        prog = btf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                btf_int("unsigned int", size=4, bits=1, offset=0),
+                btf_int("unsigned int", size=4, bits=1, offset=1),
+                btf_typedef("foo_flag_t", 3),
+                btf_const(4),
+                btf_struct(
+                    "structure",
+                    8,
+                    [
+                        btf_member("number", 1, 0),
+                        btf_member("flag1", 2, 32),
+                        btf_member("flag2", 5, 32),
+                    ],
+                ),
+            ]
+        )
+        int_type = prog.int_type("int", 4, True)
+        uint_type = prog.int_type("unsigned int", 4, False)
+        foo_t = prog.typedef_type("foo_flag_t", uint_type, qualifiers=Qualifiers.CONST)
+        self.assertIdentical(
+            prog.type("struct structure"),
+            prog.struct_type(
+                "structure",
+                8,
+                [
+                    TypeMember(int_type, "number", 0),
+                    TypeMember(Object(prog, uint_type, bit_field_size=1), "flag1", 32),
+                    TypeMember(Object(prog, foo_t, bit_field_size=1), "flag2", 33),
+                ],
+            ),
+        )
+
+    def test_struct_bitfield_kflag(self):
+        # With the flag approach, all bitfield size and offset information is
+        # part of the member itself, not in the int encoding. This is the only
+        # way it is possible to specify bitfields with enums.
+        prog = btf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                # bits and offset here are red herrings! They should go unused.
+                btf_int("unsigned int", size=4, bits=5, offset=9),
+                btf_enum("myflags", size=4, values=[BtfEnum("FLAG_A", 1)]),
+                btf_struct(
+                    "structure",
+                    8,
+                    [
+                        btf_member("number", 1, 0),
+                        btf_member("flag1", 2, 32, bitfield_size=1),
+                        btf_member("flag2", 2, 33, bitfield_size=1),
+                        btf_member("flag3", 3, 34, bitfield_size=1),
+                    ],
+                ),
+            ]
+        )
+        int_type = prog.int_type("int", 4, True)
+        uint_type = prog.int_type("unsigned int", 4, False)
+        enum_type = prog.enum_type(
+            "myflags",
+            prog.int_type("u32", 4, False),
+            [TypeEnumerator("FLAG_A", 1)],
+        )
+        self.assertIdentical(
+            prog.type("struct structure"),
+            prog.struct_type(
+                "structure",
+                8,
+                [
+                    TypeMember(int_type, "number", 0),
+                    TypeMember(Object(prog, uint_type, bit_field_size=1), "flag1", 32),
+                    TypeMember(Object(prog, uint_type, bit_field_size=1), "flag2", 33),
+                    TypeMember(Object(prog, enum_type, bit_field_size=1), "flag3", 34),
+                ],
+            ),
+        )
+
+    def test_empty_struct_and_union(self):
+        prog = btf_program([btf_struct("empty", 0), btf_union("u", 0)])
+        self.assertIdentical(
+            prog.type("struct empty"), prog.struct_type("empty", 0, ())
+        )
+        self.assertIdentical(prog.type("union u"), prog.union_type("u", 0, ()))
+
+    def test_anonymous_struct_union(self):
+        # struct x {
+        #     int kind;
+        #     union {
+        #         struct {
+        #             int value_a;
+        #             int value_b;
+        #         };
+        #         void *ptr;
+        #     };
+        # };
+        prog = btf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                btf_ptr(0),
+                btf_struct(
+                    None,
+                    8,
+                    [
+                        btf_member("value_a", 1, 0),
+                        btf_member("value_b", 1, 32),
+                    ],
+                ),
+                btf_union(
+                    None,
+                    8,
+                    [
+                        btf_member(None, 3, 0),
+                        btf_member("ptr", 2, 0),
+                    ],
+                ),
+                btf_struct(
+                    "x",
+                    16,
+                    [
+                        btf_member("kind", 1, 0),
+                        btf_member(None, 4, 64),
+                    ],
+                ),
+            ]
+        )
+        int_type = prog.int_type("int", 4, True)
+        self.assertIdentical(
+            prog.type("struct x"),
+            prog.struct_type(
+                "x",
+                16,
+                [
+                    TypeMember(int_type, "kind", 0),
+                    TypeMember(
+                        prog.union_type(
+                            None,
+                            8,
+                            [
+                                TypeMember(
+                                    prog.struct_type(
+                                        None,
+                                        8,
+                                        [
+                                            TypeMember(int_type, "value_a", 0),
+                                            TypeMember(int_type, "value_b", 32),
+                                        ],
+                                    ),
+                                    None,
+                                    0,
+                                ),
+                                TypeMember(
+                                    prog.pointer_type(prog.void_type()),
+                                    "ptr",
+                                    0,
+                                ),
+                            ],
+                        ),
+                        None,
+                        64,
+                    ),
+                ],
+            ),
+        )
+
+    def test_forward_declarations(self):
+        prog, type_ = btf_test_type(btf_fwd("s"))
+        self.assertIdentical(type_, prog.struct_type("s"))
+        prog, type_ = btf_test_type(btf_fwd("u", is_union=True))
+        self.assertIdentical(type_, prog.union_type("u"))
+
+    def test_enum(self):
+        prog = btf_program(
+            [
+                btf_enum(
+                    "color",
+                    4,
+                    [
+                        BtfEnum("RED", 0),
+                        BtfEnum("ALL", -1),
+                    ],
+                )
+            ]
+        )
+        type_ = prog.enum_type(
+            "color",
+            prog.int_type("u32", 4, False),
+            (TypeEnumerator("RED", 0), TypeEnumerator("ALL", 2**32 - 1)),
+        )
+        self.assertIdentical(prog.type("enum color"), type_)
+        self.assertIdentical(prog.constant("ALL"), Object(prog, type_, value=2**32 - 1))
+
+    def test_signed_enum64(self):
+        prog = btf_program(
+            [
+                btf_enum64(
+                    "number",
+                    8,
+                    [BtfEnum("NEGATIVE", -1)],
+                    signed=True,
+                )
+            ]
+        )
+        self.assertIdentical(
+            prog.type("enum number"),
+            prog.enum_type(
+                "number",
+                prog.int_type("s64", 8, True),
+                (TypeEnumerator("NEGATIVE", -1),),
+            ),
+        )
+
+    def test_incomplete_enum(self):
+        prog = btf_program([btf_enum("incomplete", 4)])
+        self.assertIdentical(prog.type("enum incomplete"), prog.enum_type("incomplete"))
+
+    def test_function_type(self):
+        prog, type_ = btf_test_type(
+            btf_int("int", bits=32, signed=True),
+            btf_ptr(1),
+            btf_func_proto(1, [btf_param("argc", 1), btf_param("argv", 2)]),
+        )
+        self.assertIdentical(
+            type_,
+            prog.function_type(
+                prog.int_type("int", 4, True),
+                (
+                    TypeParameter(prog.int_type("int", 4, True), "argc"),
+                    TypeParameter(
+                        prog.pointer_type(prog.int_type("int", 4, True)), "argv"
+                    ),
+                ),
+                False,
+            ),
+        )
+
+    def test_variadic_function_type(self):
+        prog, type_ = btf_test_type(
+            btf_int("int", bits=32, signed=True),
+            btf_func_proto(1, [btf_param("arg", 1), btf_param(None, 0)]),
+        )
+        self.assertIdentical(
+            type_,
+            prog.function_type(
+                prog.int_type("int", 4, True),
+                (TypeParameter(prog.int_type("int", 4, True), "arg"),),
+                True,
+            ),
+        )
+
+
+@skip_unless_have_libbpf
+class TestSplitBtf(TestCase):
+
+    def test_main_module_base(self):
+        # Verifies that split BTF can be loaded using the main module as base.
+        # Also verifies that this is NOT the default for userspace programs.
+        for main_mod_base, is_split in ((True, True), (False, False), (None, False)):
+            with self.subTest(main_mod_base=main_mod_base, is_split=is_split):
+                prog = Program(platform=host_platform)
+                main = prog.main_module("btf", create=True)
+                main_btf = btf_compile(
+                    [
+                        btf_int("int", bits=32, signed=True),
+                    ]
+                )
+                main.load_btf(data=main_btf.data)
+                child = prog.extra_module("child", create=True)
+                child_btf = btf_compile(
+                    [
+                        btf_int("short", bits=16, signed=True),
+                        # If child_btf is loaded as split, this will point at
+                        # the int. If child_btf is loaded indpendently, it will
+                        # point at the short.
+                        btf_typedef("TEST", 1),
+                    ],
+                    base=main_btf if main_mod_base else None,
+                )
+                child.load_btf(data=child_btf.data, main_module_base=main_mod_base)
+
+                if is_split:
+                    self.assertIdentical(
+                        prog.type("TEST").type,
+                        prog.int_type("int", 4, True),
+                    )
+                else:
+                    self.assertIdentical(
+                        prog.type("TEST").type,
+                        prog.int_type("short", 2, True),
+                    )
+
+    def test_datasec_variable_type_id_collision(self):
+        prog = Program(platform=host_platform)
+        main = prog.main_module("btf", create=True)
+        main_btf = btf_compile([btf_int("int", bits=32, signed=True)])
+        main.load_btf(data=main_btf.data)
+
+        # Split BTF type IDs are only unique within each module. Give both
+        # modules the same-named variable at the same type ID to verify that
+        # loading the second module does not update the first module's index
+        # entry.
+        variable_type_id = main_btf.nr_types + 1
+        module_btf = btf_compile(
+            [
+                btf_var("counter", 1),
+                btf_datasec(
+                    ".data",
+                    4,
+                    [btf_var_secinfo(variable_type_id, 0, 4)],
+                ),
+            ],
+            base=main_btf,
+        )
+
+        first = prog.relocatable_module("first", 0x1000, create=True)
+        first.section_addresses[".data"] = 0x1000
+        first.load_btf(data=module_btf.data, main_module_base=True)
+        self.assertIdentical(
+            prog.variable("counter"),
+            Object(prog, prog.int_type("int", 4, True), address=0x1000),
+        )
+
+        second = prog.relocatable_module("second", 0x2000, create=True)
+        second.section_addresses[".data"] = 0x2000
+        second.load_btf(data=module_btf.data, main_module_base=True)
+        self.assertIdentical(
+            prog.variable("counter"),
+            Object(prog, prog.int_type("int", 4, True), address=0x1000),
+        )
+
+
+def btf_elf_program(types, symbols):
+    start = min(symbol.value for symbol in symbols) & ~7
+    end = max(symbol.value + max(symbol.size, 1) for symbol in symbols)
+    end = (end + 7) & ~7
+    compiled_btf = btf_compile(types).data
+    data = create_elf_file(
+        ET.EXEC,
+        [
+            ElfSection(
+                name=".data",
+                sh_type=SHT.PROGBITS,
+                sh_flags=SHF.ALLOC,
+                p_type=PT.LOAD,
+                vaddr=start,
+                memsz=end - start,
+                data=bytes(end - start),
+            ),
+            ElfSection(
+                name=".BTF",
+                sh_type=SHT.PROGBITS,
+                sh_flags=0,
+                memsz=len(compiled_btf),
+                data=compiled_btf,
+            ),
+        ],
+        symbols,
+    )
+    prog = Program(platform=host_platform)
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(data)
+        f.flush()
+        module = prog.extra_module(f.name, 1, create=True)
+        module.address_range = (start, end)
+        module.try_file(f.name, force=True)
+        module.load_btf()
+    return prog
+
+
+@skip_unless_have_libbpf
+class TestBtfObjectFinder(TestCase):
+    def test_function(self):
+        # Function lookup always works based on symbol finder. There is no
+        # DATASEC equivalent for functions. It should work the same for either
+        # object finder.
+        prog = btf_elf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                btf_func_proto(1),
+                btf_func("main", 2),
+            ],
+            [ElfSymbol("main", 0x1000, 0, STT.FUNC, STB.GLOBAL, 1)],
+        )
+        prog.set_enabled_object_finders(["btf"])
+        self.assertIdentical(
+            prog.function("main"),
+            Object(
+                prog,
+                prog.function_type(prog.int_type("int", 4, True), (), False),
+                address=0x1000,
+            ),
+        )
+        prog.set_enabled_object_finders(["btf_symbol"])
+        self.assertIdentical(
+            prog.function("main"),
+            Object(
+                prog,
+                prog.function_type(prog.int_type("int", 4, True), (), False),
+                address=0x1000,
+            ),
+        )
+
+    def test_variable_without_datasec(self):
+        prog = btf_elf_program(
+            [btf_int("int", bits=32, signed=True), btf_var("counter", 1)],
+            [ElfSymbol("counter", 0x2000, 4, STT.OBJECT, STB.GLOBAL, 1)],
+        )
+        # The "btf" finder will not be able to find this, because there is no
+        # DATASEC containing the VAR, so there is no way to determine the
+        # address without a symbol.
+        prog.set_enabled_object_finders(["btf"])
+        msgre = "A BTF VAR is present.*no DATASEC containing.*"
+        with self.assertRaisesRegex(ObjectNotFoundError, msgre):
+            prog.variable("counter")
+        # The "btf_symbol" finder will be able to find this, because there is a
+        # VAR entry with the type, and a symbol of the same name providing the
+        # address.
+        prog.set_enabled_object_finders(["btf_symbol"])
+        self.assertIdentical(
+            prog.variable("counter"),
+            Object(prog, prog.int_type("int", 4, True), address=0x2000),
+        )
+
+    def test_variable_with_datasec(self):
+        prog = btf_elf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                btf_var("counter", 1),
+                btf_var("counter2", 1),
+                btf_datasec(
+                    ".data",
+                    8,
+                    (
+                        btf_var_secinfo(2, 0, 4),
+                        btf_var_secinfo(3, 4, 4),
+                    ),
+                ),
+            ],
+            [ElfSymbol("dummy", 0x2000, 8, STT.OBJECT, STB.GLOBAL, 1)],
+        )
+        # The "btf" finder will will be able to use the ".data" section address
+        # to determine the base address, and the offset from the var_secinfo to
+        # augment it.
+        prog.set_enabled_object_finders(["btf"])
+        self.assertIdentical(
+            prog.variable("counter"),
+            Object(prog, prog.int_type("int", 4, True), address=0x2000),
+        )
+        self.assertIdentical(
+            prog.variable("counter2"),
+            Object(prog, prog.int_type("int", 4, True), address=0x2004),
+        )
+        # Since there is no matching symbol, the "btf_symbol" finder cannot find
+        # the variable.
+        prog.set_enabled_object_finders(["btf_symbol"])
+        self.assertRaises(ObjectNotFoundError, prog.variable, "counter")
+        self.assertRaises(ObjectNotFoundError, prog.variable, "counter2")
+
+    def test_variable_with_datasec_unknown_section_address(self):
+        prog = btf_elf_program(
+            [
+                btf_int("int", bits=32, signed=True),
+                btf_var("counter", 1),
+                btf_datasec(".foobar", 4, (btf_var_secinfo(2, 0, 4),)),
+            ],
+            [ElfSymbol("dummy", 0x2000, 4, STT.OBJECT, STB.GLOBAL, 1)],
+        )
+        # Although a DATASEC is available, we cannot find the base address for
+        # the section. As a result, the btf finder will be unable to find the
+        # "counter" variable.
+        prog.set_enabled_object_finders(["btf"])
+        msgre = "A BTF VAR is present.*DATASEC base address was not found.*"
+        with self.assertRaisesRegex(ObjectNotFoundError, msgre):
+            prog.variable("counter")
+        # Since there is no matching symbol, the "btf_symbol" finder cannot find
+        # the variable.
+        prog.set_enabled_object_finders(["btf_symbol"])
+        self.assertRaises(ObjectNotFoundError, prog.variable, "counter")
+
+    def test_constant(self):
+        prog = btf_elf_program(
+            [
+                btf_enum(
+                    "color",
+                    4,
+                    [
+                        BtfEnum("RED", 0),
+                        BtfEnum("ALL", -1),
+                    ],
+                ),
+                btf_var("my_color", 1),
+            ],
+            [ElfSymbol("my_color", 0x2000, 4, STT.OBJECT, STB.GLOBAL, 1)],
+        )
+        type_ = prog.enum_type(
+            "color",
+            prog.int_type("u32", 4, False),
+            (TypeEnumerator("RED", 0), TypeEnumerator("ALL", 2**32 - 1)),
+        )
+        prog.set_enabled_object_finders(["btf"])
+        self.assertIdentical(
+            prog.constant("RED"),
+            Object(prog, type_, value=0),
+        )
+        prog.set_enabled_object_finders(["btf_symbol"])
+        self.assertIdentical(
+            prog.constant("RED"),
+            Object(prog, type_, value=0),
+        )

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -23,6 +23,7 @@ from drgn import (
     Qualifiers,
     TypeKind,
     TypeMember,
+    _with_libbpf,
     get_default_prog,
     host_platform,
     set_default_prog,
@@ -497,19 +498,26 @@ class TestTypeFinder(TestCase):
     def test_register(self):
         prog = Program(MOCK_PLATFORM)
 
+        if _with_libbpf:
+            expected_reg = {"dwarf", "btf"}
+            expected_enabled = ["dwarf", "btf"]
+        else:
+            expected_reg = {"dwarf"}
+            expected_enabled = ["dwarf"]
+
         # We don't test every corner case because the symbol finder tests cover
         # the shared part.
-        self.assertEqual(prog.registered_type_finders(), {"dwarf"})
-        self.assertEqual(prog.enabled_type_finders(), ["dwarf"])
+        self.assertEqual(prog.registered_type_finders(), expected_reg)
+        self.assertEqual(prog.enabled_type_finders(), expected_enabled)
 
         prog.register_type_finder(
             "foo", lambda prog, kinds, name, filename: None, enable_index=-1
         )
-        self.assertEqual(prog.registered_type_finders(), {"dwarf", "foo"})
-        self.assertEqual(prog.enabled_type_finders(), ["dwarf", "foo"])
+        self.assertEqual(prog.registered_type_finders(), expected_reg | {"foo"})
+        self.assertEqual(prog.enabled_type_finders(), expected_enabled + ["foo"])
 
         prog.set_enabled_type_finders(["foo"])
-        self.assertEqual(prog.registered_type_finders(), {"dwarf", "foo"})
+        self.assertEqual(prog.registered_type_finders(), expected_reg | {"foo"})
         self.assertEqual(prog.enabled_type_finders(), ["foo"])
 
     def test_add_type_finder(self):
@@ -605,19 +613,26 @@ class TestObjectFinder(TestCase):
     def test_register(self):
         prog = Program(MOCK_PLATFORM)
 
+        if _with_libbpf:
+            expected_reg = {"dwarf", "btf", "btf_symbol"}
+            expected_enabled = ["dwarf", "btf"]
+        else:
+            expected_reg = {"dwarf"}
+            expected_enabled = ["dwarf"]
+
         # We don't test every corner case because the symbol finder tests cover
         # the shared part.
-        self.assertEqual(prog.registered_object_finders(), {"dwarf"})
-        self.assertEqual(prog.enabled_object_finders(), ["dwarf"])
+        self.assertEqual(prog.registered_object_finders(), expected_reg)
+        self.assertEqual(prog.enabled_object_finders(), expected_enabled)
 
         prog.register_object_finder(
             "foo", lambda prog, name, flags, filename: None, enable_index=-1
         )
-        self.assertEqual(prog.registered_object_finders(), {"dwarf", "foo"})
-        self.assertEqual(prog.enabled_object_finders(), ["dwarf", "foo"])
+        self.assertEqual(prog.registered_object_finders(), expected_reg | {"foo"})
+        self.assertEqual(prog.enabled_object_finders(), expected_enabled + ["foo"])
 
         prog.set_enabled_object_finders(["foo"])
-        self.assertEqual(prog.registered_object_finders(), {"dwarf", "foo"})
+        self.assertEqual(prog.registered_object_finders(), expected_reg | {"foo"})
         self.assertEqual(prog.enabled_object_finders(), ["foo"])
 
     def test_add_object_finder(self):

--- a/vmtest/rootfsbuild.py
+++ b/vmtest/rootfsbuild.py
@@ -25,6 +25,7 @@ _ROOTFS_PACKAGES = (
     "gcc",
     "git",
     "libdw-dev",
+    "libbpf-dev",
     "libelf-dev",
     "libjson-c-dev",
     "libkdumpfile-dev",


### PR DESCRIPTION
I think the BTF code is getting close to ready, so I was hoping to request an API review if possible, to ensure that it's going in a direction you're happy with.

The API I have here is surprisingly small: I just add a `Module.load_btf()` method. This method can optionally take a buffer, but if the buffer is not provided, it will search for a `.BTF` section in the loaded or debug file and use that. It will read and index the types, so that the already-registered BTF type/object finder can use them.

For the DWARFless case, the current status of BTF in the kernel is still missing all global variables (except percpu). So I've included some helpers that allow you to provide a list of variable declarations to help drgn bootstrap its module API and find the BTF associated with each module. This is definitely not ideal, but it's a starting place. It's actually surprising how much you can do with just a few hard-coded global variable declarations. Ideally, I'll get global variables into the kernel BTF somehow upstream, and then this will be usable without any of the variable declaration shenanigans.

Since the API allows finding `.BTF` sections from an ELF file, one interesting result is that you can actually use this with userspace programs that were compiled with `gcc -gbtf`. The variable lookup works a bit differently than the Linux kernel due to a quirk in the BTF DATASEC generation. But type lookup is identical. I figured this would be a good way to help test the BTF support.

What I'd love a sanity check on is:
- The API on the Module class
- Whether the helpers are worthwhile to include
- Should the object finder be separated out into another PR?

I know there's still a lot of work needed in certain areas:
- I'll need to create a unit test suite similar to the DWARF suite. I hadn't started since I didn't want to build on a shifting API.
- Same difference on testing the kernel BTF support in the vm tests: i'll need to add a test suite once the API is set.
- I definitely need to do a second pass on code organization and structure for `btf_info.c`.

If you wanted to try it out, I've been doing this on my Fedora development machine:
1. DWARFless: test out loading types or percpu variables
```
$ python -m drgn -qk --no-default-symbols
drgn 0.2.0+19.g1d09fd07.dirty (using Python 3.14.5, elfutils 0.195, with debuginfod (dlopen), with json-c, with libkdumpfile, with lzma, with pcre2, with libbpf)
For help, type help(drgn).
>>> import drgn
>>> from drgn import FaultError, NULL, Object, alignof, cast, container_of, execscript, implicit_convert, offsetof, reinterpret, sizeof, search_memory, search_memory_regex, search_memory_u16, search_memory_u32, search_memory_u64, search_memory_word, source_location, stack_trace
>>> from drgn.helpers.common import *
>>> from drgn.helpers.linux import *
>>> load_builtin_btf(prog)
>>> %py prog.type("struct task_struct") |head
struct task_struct {
	struct thread_info thread_info;
	unsigned int __state;
	unsigned int saved_state;
	void *stack;
	refcount_t usage;
	unsigned int flags;
	unsigned int ptrace;
	int on_cpu;
	struct __call_single_node wake_entry;
```
2. Userspace test (note that rodata is not included in the core dump, similar results happen with DWARF).
```
$ cat test.c
#include <stdio.h>
#include <stdlib.h>
struct my_struct { int foo; char *bar; };
struct my_struct value = {12, "blah"};
int foobar = 42;
const char ch = 'c';
const char *string = "string data";
int main(int argc, char **argv)
{
	abort();
	return 0;
}
$ gcc -gbtf -o test test.c
$ ./test
Aborted                    (core dumped) ./test
$ coredumpctl dump > test.core
$ python -m drgn -c test.core -s test
drgn 0.2.0+19.g1d09fd07.dirty (using Python 3.14.5, elfutils 0.195, with debuginfod (dlopen), with json-c, with libkdumpfile, with lzma, with pcre2, with libbpf)
warning: missing debugging symbols for /home/stephen/repos/drgn/test
critical: missing some debugging symbols; see https://drgn.readthedocs.io/en/latest/getting_debugging_symbols.html
For help, type help(drgn).
>>> import drgn
>>> from drgn import FaultError, NULL, Object, alignof, cast, container_of, execscript, implicit_convert, offsetof, reinterpret, sizeof, search_memory, search_memory_regex, search_memory_u16, search_memory_u32, search_memory_u64, search_memory_word, source_location, stack_trace
>>> from drgn.helpers.common import *
>>> prog.main_module().load_btf()
>>> prog["value"]
(struct my_struct){
	.foo = (int)12,
	.bar = (char *)__dso_handle+0x8 = 0x401180,
}
>>> prog["ch"]
warning: can't print value: memory not saved in core dump: 0x401185
Object(prog, 'const char', address=0x401185)
>>> prog["foobar"]
(int)42
```