### PR TITLE
testsuite: Skip tests for unavailable kernel modules

### DIFF
--- a/tests/linux_kernel/__init__.py
+++ b/tests/linux_kernel/__init__.py
@@ -73,6 +73,11 @@ except ImportError:
 class LinuxKernelTestCase(TestCase):
     prog = None
     skip_reason = None
+    loaded_modules = set()
+
+    def require_module(self, module):
+        if module not in LinuxKernelTestCase.loaded_modules:
+            self.skipTest(f"module {module} is not available")
 
     @staticmethod
     def _load_debug_info(prog):
@@ -119,9 +124,10 @@ class LinuxKernelTestCase(TestCase):
                     )
                 else:
                     # Load modules that are used by test cases.
-                    subprocess.check_call(
-                        ["modprobe", "-a", "btrfs", "configs", "loop"]
-                    )
+                    for module in ["btrfs", "configs", "loop"]:
+                        result = subprocess.run(["modprobe", module])
+                        if result.returncode == 0:
+                            LinuxKernelTestCase.loaded_modules.add(module)
                     try:
                         cls._load_debug_info(prog)
                         LinuxKernelTestCase.prog = prog

--- a/tests/linux_kernel/tools/test_fsrefs.py
+++ b/tests/linux_kernel/tools/test_fsrefs.py
@@ -210,6 +210,7 @@ class TestFsRefs(LinuxKernelTestCase):
 
     @skip_unless_have_test_disk
     def test_super_block_on_block_device(self):
+        self.require_module("btrfs")
         disk = os.environ["DRGN_TEST_DISK"]
         for fstype, mkfs in (
             ("ext2", ("mke2fs", "-qF")),
@@ -235,6 +236,7 @@ class TestFsRefs(LinuxKernelTestCase):
 
     @skip_unless_have_test_disk
     def test_btrfs_subvolume(self):
+        self.require_module("btrfs")
         disk = os.environ["DRGN_TEST_DISK"]
         with contextlib.ExitStack() as exit_stack:
             subprocess.check_call(["mkfs.btrfs", "-qf", "-s", str(mmap.PAGESIZE), disk])
@@ -355,6 +357,7 @@ class TestFsRefs(LinuxKernelTestCase):
             )
 
     def test_loop_device(self):
+        self.require_module("loop")
         path = self._tmp / "file"
         with open(path, "wb") as f:
             os.ftruncate(f.fileno(), 1024 * 1024)


### PR DESCRIPTION
When a module is not supported and not loaded, the test suite fails on all the tests as it unconditionally tries to load the module.

Replace the single modprobe -a call with a per-module loop using subprocess.run, so one missing module doesn't blow up the whole suite. Tracks which modules loaded successfully in loaded_modules. Add require_module method to
LinuxKernelTestCase so any test can cleanly skip itself if a needed module isn't available. Add self.require_module("loop") to test_loop_device, and self.require_module("btrfs") to test_btrfs_subvolume and test_super_block_on_block_device.