### PR TITLE
ci: update to Noble / 24.04 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ${{ (github.event_name == 'push' || inputs.test_all_python_versions)

--- a/.github/workflows/vmtest-build.yml
+++ b/.github/workflows/vmtest-build.yml
@@ -13,7 +13,7 @@ jobs:
         arch: [x86_64, aarch64, ppc64, s390x, arm, riscv64]
       fail-fast: false
       max-parallel: 6
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     env:


### PR DESCRIPTION
Just wanted to start a discussion. The motivation here (see commit message) is to get a more recent libbpf in the CI. There are multiple breaking changes in libbpf 1.0, and versions prior to 1.0 don't support BTF_ENUM64.

The issue with supporting older versions of libbpf is that we use it to parse any kernel's data. So running tests against a bleeding-edge kernel with libbpf 0.5.0 is not going to work. Nor will an old version of libbpf understand an ENUM64 type that I included in my synthetic debug data.

So there are three possibilities right here, and I've taken the laziest route first:
1. Use a newer CI image and hope that new kernels don't have any backwards-incompatible BTF features for a while.
2. Download and build a suitably recent libbpf in a CI step (or maybe put it into another dummy git tag).
3. Drop the libbpf dependency altogether, bundle the latest `btf.h` header from the kernel, and parse the BTF format ourselves.

Honestly, number 3 isn't terrible -- that's what my original BTF branch did a long time ago. I migrated to use libbpf because it seemed like the "correct" option. But given how tightly coupled it is to the target kernel, number 3 could be preferred. If not, then number 1, i.e. this PR, would be the best step for right now.