### PR TITLE
vmtest: roll vmtest-build back to Ubuntu 22.04

### DIFF
--- a/.github/workflows/vmtest-build.yml
+++ b/.github/workflows/vmtest-build.yml
@@ -13,7 +13,7 @@ jobs:
         arch: [x86_64, aarch64, ppc64, s390x, arm, riscv64]
       fail-fast: false
       max-parallel: 6
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     env:

--- a/vmtest/config.py
+++ b/vmtest/config.py
@@ -561,7 +561,7 @@ def kconfig_localversion(arch: Architecture, flavor: KernelFlavor, version: str)
     vmtest_kernel_version = [
         # Increment the major version to rebuild every
         # architecture/flavor/version combination.
-        41,
+        42,
         # The minor version makes the default flavor the "latest" version.
         1 if flavor.name == "default" else 0,
     ]


### PR DESCRIPTION
Ubuntu 24.04 uses glibc 2.39, so it produces kernel build tools (e.g., objtool) that are too new for my development machines on CentOS Stream 9, which has glibc 2.34. Roll back to Ubuntu 22.04.

@brenns10 will this cause any issues for the BTF work? I hope not since the CI will still be on Ubuntu 24.04.