### PR TITLE
drgn.helpers.linux.printk: fix text offset for wrapped records

### DIFF
--- a/drgn/helpers/linux/printk.py
+++ b/drgn/helpers/linux/printk.py
@@ -136,7 +136,7 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
             return
         if lpos_begin > lpos_next:
             # Data wrapped.
-            lpos_begin = 0
+            lpos_begin = ulong_size
         info = infos[idx].read_()
         text_len = info.text_len.value_()
         if lpos_next - lpos_begin < text_len:

--- a/drgn/helpers/linux/printk.py
+++ b/drgn/helpers/linux/printk.py
@@ -127,8 +127,8 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
         if not record_committed(current_id, desc.state_var.counter.value_()):
             return
 
-        lpos_begin = desc.text_blk_lpos.begin & text_data_ring_mask
-        lpos_next = desc.text_blk_lpos.next & text_data_ring_mask
+        lpos_begin = (desc.text_blk_lpos.begin & text_data_ring_mask).value_()
+        lpos_next = (desc.text_blk_lpos.next & text_data_ring_mask).value_()
         lpos_begin += ulong_size
 
         if lpos_begin == lpos_next:
@@ -136,9 +136,9 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
             return
         if lpos_begin > lpos_next:
             # Data wrapped.
-            lpos_begin -= lpos_begin
+            lpos_begin = 0
         info = infos[idx].read_()
-        text_len = info.text_len
+        text_len = info.text_len.value_()
         if lpos_next - lpos_begin < text_len:
             # Truncated record.
             text_len = lpos_next - lpos_begin

--- a/drgn/helpers/linux/printk.py
+++ b/drgn/helpers/linux/printk.py
@@ -103,6 +103,8 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
     LOG_CONT = prog["LOG_CONT"].value_()
     desc_committed = prog["desc_committed"].value_()
     desc_finalized = prog["desc_finalized"].value_()
+    LPOS_DATALESS = 0x1
+    EMPTY_LINE_LPOS = 0x3
 
     def record_committed(current_id: int, state_var: int) -> bool:
         state_desc_id = state_var & DESC_ID_MASK
@@ -130,23 +132,35 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
 
         lpos_begin = (desc.text_blk_lpos.begin & text_data_ring_mask).value_()
         lpos_next = (desc.text_blk_lpos.next & text_data_ring_mask).value_()
-        lpos_begin += ulong_size
 
-        if lpos_begin == lpos_next:
-            # Data-less record.
+        data_less = (lpos_begin & LPOS_DATALESS) and (lpos_next & LPOS_DATALESS)
+        if data_less and (
+            lpos_begin != EMPTY_LINE_LPOS or lpos_next != EMPTY_LINE_LPOS
+        ):
+            # Lost, invalid or otherwise unavailable data.
             return
-        if lpos_next == 0:
-            # The block ends exactly at the ring boundary. Represent offset 0 as
-            # the end of the ring so that the text length can be calculated.
-            lpos_next = text_data_ring_size
-        if lpos_begin > lpos_next:
-            # Data wrapped.
-            lpos_begin = ulong_size
+
         info = infos[idx].read_()
-        text_len = info.text_len.value_()
-        if lpos_next - lpos_begin < text_len:
-            # Truncated record.
-            text_len = lpos_next - lpos_begin
+        if data_less:
+            # Empty-line record.
+            text = b""
+        else:
+            if lpos_next == 0:
+                # The block ends exactly at the ring boundary. Represent offset 0
+                # as the end of the ring so that the text length can be calculated.
+                lpos_next = text_data_ring_size
+            if lpos_begin > lpos_next:
+                # Data wrapped.
+                lpos_begin = 0
+
+            # Skip the block id.
+            lpos_begin += ulong_size
+
+            text_len = info.text_len.value_()
+            if lpos_next - lpos_begin < text_len:
+                # Truncated record.
+                text_len = lpos_next - lpos_begin
+            text = prog.read(text_data_ring_data + lpos_begin, text_len)
 
         caller_tid, caller_cpu = _caller_id(info.caller_id.value_())
 
@@ -160,7 +174,7 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
 
         result.append(
             PrintkRecord(
-                text=prog.read(text_data_ring_data + lpos_begin, text_len),
+                text=text,
                 facility=info.facility.value_(),
                 level=info.level.value_(),
                 seq=info.seq.value_(),

--- a/drgn/helpers/linux/printk.py
+++ b/drgn/helpers/linux/printk.py
@@ -117,7 +117,8 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
     desc_ring_mask = (1 << desc_ring.count_bits.value_()) - 1
     text_data_ring = prb.text_data_ring
     text_data_ring_data = text_data_ring.data.read_()
-    text_data_ring_mask = (1 << text_data_ring.size_bits) - 1
+    text_data_ring_size = 1 << text_data_ring.size_bits
+    text_data_ring_mask = text_data_ring_size - 1
 
     result = []
 
@@ -134,9 +135,13 @@ def _get_printk_records_lockless(prog: Program, prb: Object) -> List[PrintkRecor
         if lpos_begin == lpos_next:
             # Data-less record.
             return
+        if lpos_next == 0:
+            # The block ends exactly at the ring boundary. Represent offset 0 as
+            # the end of the ring so that the text length can be calculated.
+            lpos_next = text_data_ring_size
         if lpos_begin > lpos_next:
             # Data wrapped.
-            lpos_begin = 0
+            lpos_begin = ulong_size
         info = infos[idx].read_()
         text_len = info.text_len.value_()
         if lpos_next - lpos_begin < text_len:

--- a/tests/linux_kernel/helpers/test_printk.py
+++ b/tests/linux_kernel/helpers/test_printk.py
@@ -5,7 +5,9 @@ import errno
 import os
 import re
 
+from drgn import Object, TypeMember
 from drgn.helpers.linux.printk import PrintkRecord, get_printk_records
+from tests import MockObject, MockProgramTestCase
 from tests.linux_kernel import LinuxKernelTestCase
 
 
@@ -51,6 +53,207 @@ def get_kmsg_records():
                 )
             )
     return result
+
+
+class TestPrintkLockless(MockProgramTestCase):
+    DATA_ADDRESS = 0x1000
+    DESC_ADDRESS = 0x2000
+    INFO_ADDRESS = 0x3000
+    DATA_RING_SIZE = 256
+    ULONG_SIZE = 8
+
+    def setUp(self):
+        super().setUp()
+
+        ulong_type = self.prog.int_type("unsigned long", self.ULONG_SIZE, False)
+        long_type = self.prog.int_type("long", self.ULONG_SIZE, True)
+        u64_type = self.prog.int_type("unsigned long long", 8, False)
+        u32_type = self.prog.int_type("unsigned int", 4, False)
+        u16_type = self.prog.int_type("unsigned short", 2, False)
+        u8_type = self.prog.int_type("unsigned char", 1, False)
+        char_type = self.prog.int_type("char", 1, True)
+        self.types.append(ulong_type)
+
+        atomic_long_type = self.prog.struct_type(
+            "atomic_long_t",
+            self.ULONG_SIZE,
+            (TypeMember(long_type, "counter", 0),),
+        )
+        lpos_type = self.prog.struct_type(
+            "prb_data_blk_lpos",
+            2 * self.ULONG_SIZE,
+            (
+                TypeMember(ulong_type, "begin", 0),
+                TypeMember(ulong_type, "next", 8 * self.ULONG_SIZE),
+            ),
+        )
+        self.desc_type = self.prog.struct_type(
+            "prb_desc",
+            3 * self.ULONG_SIZE,
+            (
+                TypeMember(atomic_long_type, "state_var", 0),
+                TypeMember(lpos_type, "text_blk_lpos", 8 * self.ULONG_SIZE),
+            ),
+        )
+        dev_info_type = self.prog.struct_type(
+            "dev_printk_info",
+            64,
+            (
+                TypeMember(self.prog.array_type(char_type, 16), "subsystem", 0),
+                TypeMember(self.prog.array_type(char_type, 48), "device", 128),
+            ),
+        )
+        self.info_type = self.prog.struct_type(
+            "printk_info",
+            88,
+            (
+                TypeMember(u64_type, "seq", 0),
+                TypeMember(u64_type, "ts_nsec", 64),
+                TypeMember(u16_type, "text_len", 128),
+                TypeMember(u8_type, "facility", 144),
+                TypeMember(Object(self.prog, u8_type, bit_field_size=5), "flags", 152),
+                TypeMember(Object(self.prog, u8_type, bit_field_size=3), "level", 157),
+                TypeMember(u32_type, "caller_id", 160),
+                TypeMember(dev_info_type, "dev_info", 192),
+            ),
+        )
+        desc_ring_type = self.prog.struct_type(
+            "prb_desc_ring",
+            6 * self.ULONG_SIZE,
+            (
+                TypeMember(u32_type, "count_bits", 0),
+                TypeMember(
+                    self.prog.pointer_type(self.desc_type),
+                    "descs",
+                    8 * self.ULONG_SIZE,
+                ),
+                TypeMember(
+                    self.prog.pointer_type(self.info_type),
+                    "infos",
+                    16 * self.ULONG_SIZE,
+                ),
+                TypeMember(atomic_long_type, "head_id", 24 * self.ULONG_SIZE),
+                TypeMember(atomic_long_type, "tail_id", 32 * self.ULONG_SIZE),
+                TypeMember(
+                    atomic_long_type, "last_finalized_seq", 40 * self.ULONG_SIZE
+                ),
+            ),
+        )
+        data_ring_type = self.prog.struct_type(
+            "prb_data_ring",
+            4 * self.ULONG_SIZE,
+            (
+                TypeMember(u32_type, "size_bits", 0),
+                TypeMember(
+                    self.prog.pointer_type(char_type), "data", 8 * self.ULONG_SIZE
+                ),
+                TypeMember(atomic_long_type, "head_lpos", 16 * self.ULONG_SIZE),
+                TypeMember(atomic_long_type, "tail_lpos", 24 * self.ULONG_SIZE),
+            ),
+        )
+        self.prb_type = self.prog.struct_type(
+            "printk_ringbuffer",
+            11 * self.ULONG_SIZE,
+            (
+                TypeMember(desc_ring_type, "desc_ring", 0),
+                TypeMember(data_ring_type, "text_data_ring", 48 * self.ULONG_SIZE),
+                TypeMember(atomic_long_type, "fail", 80 * self.ULONG_SIZE),
+            ),
+        )
+        self.objects.extend(
+            (
+                MockObject("LOG_CONT", u8_type, value=8),
+                MockObject("desc_committed", u8_type, value=1),
+                MockObject("desc_finalized", u8_type, value=2),
+            )
+        )
+
+    def _get_records(
+        self, lpos_begin, lpos_next, text=b"hello world", *, text_offset=None
+    ):
+        data = bytearray(self.DATA_RING_SIZE)
+        if text_offset is None:
+            text_offset = (lpos_begin & (self.DATA_RING_SIZE - 1)) + self.ULONG_SIZE
+        data[text_offset : text_offset + len(text)] = text
+        self.add_memory_segment(bytes(data), virt_addr=self.DATA_ADDRESS)
+        desc = Object(
+            self.prog,
+            self.desc_type,
+            value={
+                "state_var": {"counter": 1 << 62},  # desc_committed, id = 0
+                "text_blk_lpos": {"begin": lpos_begin, "next": lpos_next},
+            },
+        )
+        info = Object(
+            self.prog,
+            self.info_type,
+            value={
+                "seq": 0,
+                "ts_nsec": 456,
+                "text_len": len(text),
+                "facility": 1,  # LOG_USER
+                "flags": 0,
+                "level": 6,
+                "caller_id": 123,
+                "dev_info": {"subsystem": b"", "device": b""},
+            },
+        )
+        self.add_memory_segment(desc.to_bytes_(), virt_addr=self.DESC_ADDRESS)
+        self.add_memory_segment(info.to_bytes_(), virt_addr=self.INFO_ADDRESS)
+        self.objects.append(
+            MockObject(
+                "prb",
+                self.prb_type,
+                value={
+                    "desc_ring": {
+                        "head_id": {"counter": 0},
+                        "tail_id": {"counter": 0},
+                        "count_bits": 0,
+                        "descs": self.DESC_ADDRESS,
+                        "infos": self.INFO_ADDRESS,
+                    },
+                    "text_data_ring": {
+                        "size_bits": 8,
+                        "data": self.DATA_ADDRESS,
+                    },
+                },
+            )
+        )
+        return get_printk_records(self.prog)
+
+    def _record(self, text=b"hello world"):
+        return PrintkRecord(
+            text=text,
+            facility=1,  # LOG_USER
+            level=6,
+            seq=0,
+            timestamp=456,
+            caller_tid=123,
+            caller_cpu=None,
+            continuation=False,
+            context={},
+        )
+
+    def test_regular(self):
+        self.assertEqual(self._get_records(16, 40), [self._record()])
+
+    def test_ends_at_boundary(self):
+        self.assertEqual(self._get_records(232, 256), [self._record()])
+
+    def test_wrapped(self):
+        self.assertEqual(
+            self._get_records(248, 280, text_offset=self.ULONG_SIZE),
+            [self._record()],
+        )
+
+    def test_failed(self):
+        self.assertEqual(self._get_records(1, 1, b""), [])
+
+    def test_invalid_data_less(self):
+        self.assertEqual(self._get_records(1, 3, b""), [])
+
+    def test_empty(self):
+        self.assertEqual(self._get_records(3, 3, b""), [self._record(b"")])
 
 
 class TestPrintk(LinuxKernelTestCase):


### PR DESCRIPTION
When a printk record wraps around the end of the lockless ring buffer, the block is relocated to the start of the ring. Each block begins with the descriptor's id (ulong_size bytes) followed by the text. In `_get_printk_records_lockless()`, lpos_begin was set to 0 when wrapping, so the returned text included the id.

For example on an aarch64 vmcore with a wrapped printk record in the buffer, `get_dmesg()` includes the descriptor's id for that block in the returned string:
```
[  593.756214] p\xfd\xff\xff\x00\x00\x00\x00
```

Setting `lpos_begin` to `ulong_size` when wrapping around the end of the buffer in `helpers/linux/printk.py` fixes the issue.
```python
lpos_begin = ulong_size
```

The first commit unpacks `lpos_begin`, `lpos_next` and `text_len` to int so `lpos_begin` can be set directly, and the second commit contains the fix.