### PR TITLE
libdrgn: kallsyms: fix inconsistent name length

### DIFF
--- a/libdrgn/kallsyms.c
+++ b/libdrgn/kallsyms.c
@@ -251,7 +251,12 @@ kallsyms_expand_symbol(struct kallsyms_reader *kr,
 		       struct string_builder *sb, char *kind_ret)
 {
 	uint64_t len;
-	struct drgn_error *err = binary_buffer_next_uleb128(names_bb, &len);
+	struct drgn_error *err;
+
+	if (kr->long_names)
+		err = binary_buffer_next_uleb128(names_bb, &len);
+	else
+		err = binary_buffer_next_u8_into_u64(names_bb, &len);
 	if (err)
 		return err;
 


### PR DESCRIPTION
In kallsyms_copy_tables(), we scan through kallsyms_names to determine the buffer's length, and as part of this scan we must determine the length of each symbol. Later, in kallsyms_expand_symbol(), we again determine the length of a symbol. However, these two implementations are inconsistent with each other.

In kallsyms_copy_tables(), we use guess_long_names() to determine whether to use a second byte to encode the symbol length, as introduced in Linux kernel commit 73bbb94466fd3 ("kallsyms: support "big" kernel symbols") in v6.1. However, in kallsyms_expand_symbol(), we unconditionally treat the data as ULEB128, without consulting the long_names guess.

When parsing kallsyms from a pre-6.1 kernel, if a symbol's length is in the range [0x80, 0xFF], kallsyms_expand_symbol() would incorrectly consume an additional byte as part of the length, and would compute an incorrect length. This would result in a large, garbled symbol name. Further, every following symbol name would be offset. Thankfully, due to the use of the binary buffer, we will not read out of bounds data: just corrupted values.

Since we haven't seen any BAD_DATA errors or garbled kallsyms in tests, it's likely that our pre-6.1 vmtest kernels don't have long enough symbol names to trigger the behavior. Regardless, let's fix the inconsistency. While our guess_long_names() answer may or may not be correct, respect its decision and treat the length as a single byte if it returned false, just as kallsyms_copy_tables() does.