### PR TITLE
crash: add vm command options  for mm/vma inspection

### DIFF
--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -582,6 +582,13 @@ for si in for_each_swap_info():
             help="translate each virtual page to its physical address",
         ),
         argument(
+            "-P",
+            dest="P",
+            metavar="vma",
+            type="hexadecimal",
+            help="translate pages belonging to the specified VM area",
+        ),
+        argument(
             "-x",
             dest="integer_base",
             action="store_const",
@@ -652,6 +659,35 @@ if mm:
                 phys_addr = follow_phys(mm, page_addr)
             except FaultError:
                 phys_addr = None
+"""
+                )
+            elif args.P is not None:
+                code.add_from_import("drgn", "FaultError", "Object")
+                code.add_from_import(
+                    "drgn.helpers.linux.mm",
+                    "follow_phys",
+                    "task_rss",
+                    "vma_name",
+                )
+                code.append(
+                    f"""\
+page_size = prog["PAGE_SIZE"].value_()
+mm = task.mm.read_()
+if mm:
+    pgd = mm.pgd
+    rss = task_rss(task)
+    total_vm = mm.total_vm
+    vma = Object(prog, "struct vm_area_struct *", {hex(args.P)})
+    start = vma.vm_start
+    end = vma.vm_end
+    flags = vma.vm_flags
+    file = vma_name(vma)
+    vm_file = vma.vm_file.read_()
+    for page_addr in range(start, end, page_size):
+        try:
+            phys_addr = follow_phys(mm, page_addr)
+        except FaultError:
+            phys_addr = None
 """
                 )
             elif args.reference:
@@ -810,6 +846,66 @@ if mm:
                                 )
             continue
 
+        if args.P is not None:
+            if mm:
+                page_size = prog["PAGE_SIZE"].value_()
+                vma = Object(prog, "struct vm_area_struct *", args.P)
+                try:
+                    vma_start = vma.vm_start.value_()
+                except FaultError:
+                    print(f"(invalid VMA: {args.P:#x})")
+                    continue
+                vma_end = vma.vm_end.value_()
+                vm_file = vma.vm_file.read_()
+                vm_pgoff = vma.vm_pgoff.value_() if vm_file else 0
+                vma_name_str = vma_name(vma)
+                print_table(
+                    (
+                        (
+                            CellFormat("VMA", "^"),
+                            CellFormat("START", "^"),
+                            CellFormat("END", "^"),
+                            CellFormat("FLAGS", "<"),
+                            CellFormat("FILE", "<"),
+                        ),
+                        (
+                            CellFormat(vma.value_(), "^x"),
+                            CellFormat(vma_start, "^x"),
+                            CellFormat(vma_end, "^x"),
+                            CellFormat(vma.vm_flags.value_(), "<x"),
+                            escape_ascii_string(vma_name_str, escape_backslash=True),
+                        ),
+                    )
+                )
+                vma_translation_rows: List[Sequence[Any]] = [("VIRTUAL", "PHYSICAL")]
+                for page_addr in range(vma_start, vma_end, page_size):
+                    try:
+                        phys_addr = follow_phys(mm, page_addr).value_()
+                        vma_translation_rows.append(
+                            (
+                                CellFormat(page_addr, "^x"),
+                                CellFormat(phys_addr, "^x"),
+                            )
+                        )
+                    except FaultError:
+                        if vm_file:
+                            offset = (page_addr - vma_start) + vm_pgoff * page_size
+                            vma_translation_rows.append(
+                                (
+                                    CellFormat(page_addr, "^x"),
+                                    f"FILE: {vma_name_str.decode(errors='replace')}  OFFSET: {offset:x}",
+                                )
+                            )
+                        else:
+                            vma_translation_rows.append(
+                                (
+                                    CellFormat(page_addr, "^x"),
+                                    "SWAP: (unavailable)",
+                                )
+                            )
+                print_table(vma_translation_rows)
+            continue
+
         if mm:
             pgd_value = mm.pgd.value_()
             rss_total = task_rss(task).total
@@ -906,6 +1002,13 @@ arguments are entered, the current context is used.
             dest="p",
             action="store_true",
             help="translate each virtual page to its physical address",
+        ),
+        argument(
+            "-P",
+            dest="P",
+            metavar="vma",
+            type="hexadecimal",
+            help="translate pages belonging to the specified VM area",
         ),
         argument(
             "-x",

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -6,9 +6,16 @@
 
 import argparse
 import sys
-from typing import Any, List, Sequence
+from typing import Any, List, Sequence, Tuple
 
-from drgn import Architecture, FaultError, Object, Platform, Program
+from drgn import (
+    Architecture,
+    FaultError,
+    Object,
+    ObjectNotFoundError,
+    Platform,
+    Program,
+)
 from drgn.commands import (
     DrgnCodeBlockContext,
     argument,
@@ -25,7 +32,12 @@ from drgn.commands._crash.common import (
     parse_cpuspec,
     print_task_header,
 )
-from drgn.helpers.common.format import CellFormat, escape_ascii_string, print_table
+from drgn.helpers.common.format import (
+    CellFormat,
+    decode_flags,
+    escape_ascii_string,
+    print_table,
+)
 from drgn.helpers.linux.mm import (
     follow_phys,
     for_each_vma,
@@ -40,6 +52,70 @@ from drgn.helpers.linux.swap import (
     swap_is_file,
     swap_usage_in_pages,
 )
+
+# Since Linux kernel commit 2b6a3f061f11 ("mm: declare VMA flags by bit") (in
+# v6.19), VMA flag bit numbers are defined in an anonymous enum. Before that,
+# we have to hard-code them.
+_VM_FLAGS: Sequence[Tuple[str, int]] = [
+    ("READ", 0x00000001),
+    ("WRITE", 0x00000002),
+    ("EXEC", 0x00000004),
+    ("SHARED", 0x00000008),
+    ("MAYREAD", 0x00000010),
+    ("MAYWRITE", 0x00000020),
+    ("MAYEXEC", 0x00000040),
+    ("MAYSHARE", 0x00000080),
+    ("GROWSDOWN", 0x00000100),
+    ("UFFD_MISSING", 0x00000200),
+    ("PFNMAP", 0x00000400),
+    ("DENYWRITE", 0x00000800),
+    ("EXECUTABLE", 0x00001000),
+    ("LOCKED", 0x00002000),
+    ("IO", 0x00004000),
+    ("SEQ_READ", 0x00008000),
+    ("RAND_READ", 0x00010000),
+    ("DONTCOPY", 0x00020000),
+    ("DONTEXPAND", 0x00040000),
+    ("LOCKONFAULT", 0x00080000),
+    ("ACCOUNT", 0x00100000),
+    ("NORESERVE", 0x00200000),
+    ("HUGETLB", 0x00400000),
+    ("SYNC", 0x00800000),
+    ("ARCH_1", 0x01000000),
+    ("WIPEONFORK", 0x02000000),
+    ("DONTDUMP", 0x04000000),
+    ("SOFTDIRTY", 0x08000000),
+    ("MIXEDMAP", 0x10000000),
+    ("HUGEPAGE", 0x20000000),
+    ("NOHUGEPAGE", 0x40000000),
+    ("MERGEABLE", 0x80000000),
+]
+
+
+def _get_vm_flag_values(prog: Program) -> Sequence[Tuple[str, int]]:
+    try:
+        enumerators = prog["VMA_READ_BIT"].type_.enumerators
+    except ObjectNotFoundError:
+        return _VM_FLAGS
+    if enumerators is None:
+        return _VM_FLAGS
+    flags = []
+    for name, bit_num in enumerators:
+        flags.append(
+            (
+                (
+                    name[4:-4]
+                    if name.startswith("VMA_") and name.endswith("_BIT")
+                    else (
+                        name[4:]
+                        if name.startswith("VMA_")
+                        else name[:-4] if name.endswith("_BIT") else name
+                    )
+                ),
+                1 << bit_num,
+            )
+        )
+    return flags
 
 
 @crash_command(
@@ -671,6 +747,13 @@ arguments are entered, the current context is used.
             help="output integers in decimal format regardless of the default",
         ),
         argument(
+            "-f",
+            dest="f",
+            metavar="vm_flags",
+            type="hexadecimal",
+            help="translate the bits of a FLAGS (vm_flags) value",
+        ),
+        argument(
             "tasks",
             metavar="pid|task",
             nargs="*",
@@ -683,6 +766,22 @@ arguments are entered, the current context is used.
 def _crash_cmd_vm(
     prog: Program, name: str, args: argparse.Namespace, **kwargs: Any
 ) -> None:
+    if args.f is not None:
+        if args.drgn:
+            code = CrashDrgnCodeBuilder(prog)
+            code.add_from_import("drgn.commands._crash._mm", "_get_vm_flag_values")
+            code.add_from_import("drgn.helpers.common.format", "decode_flags")
+            code.append(f"vm_flags = {hex(args.f)}\n")
+            code.append(
+                "decoded = decode_flags("
+                "vm_flags, _get_vm_flag_values(prog), bit_numbers=False)\n"
+            )
+            return code.print()
+        print(
+            f"{args.f:x}: ("
+            f"{decode_flags(args.f, _get_vm_flag_values(prog), bit_numbers=False)})"
+        )
+        return
     if not args.tasks:
         args.tasks.append(None)
     return _crash_foreach_vm(_TaskSelector(prog, args.tasks), args)

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -589,6 +589,13 @@ for si in for_each_swap_info():
             help="translate pages belonging to the specified VM area",
         ),
         argument(
+            "-M",
+            dest="M",
+            metavar="mm",
+            type="hexadecimal",
+            help="use a manually specified mm_struct address",
+        ),
+        argument(
             "-x",
             dest="integer_base",
             action="store_const",
@@ -618,13 +625,17 @@ def _crash_foreach_vm(task_selector: _TaskSelector, args: argparse.Namespace) ->
         code = CrashDrgnCodeBuilder(prog)
         with task_selector.begin_task_loop(code):
             code.append_task_header()
-            if args.m:
+            if args.M is not None:
+                code.add_from_import("drgn", "Object")
+                code.append(f'mm = Object(prog, "struct mm_struct *", {hex(args.M)})\n')
+            else:
                 code.append("mm = task.mm.read_()\n")
+            if args.m:
+                pass
             elif args.v:
                 code.add_from_import("drgn.helpers.linux.mm", "for_each_vma")
                 code.append(
                     """\
-mm = task.mm.read_()
 if mm:
     for vma in for_each_vma(mm):
         pass
@@ -642,7 +653,6 @@ if mm:
                 code.append(
                     """\
 page_size = prog["PAGE_SIZE"].value_()
-mm = task.mm.read_()
 if mm:
     pgd = mm.pgd
     rss = task_rss(task)
@@ -672,7 +682,6 @@ if mm:
                 code.append(
                     f"""\
 page_size = prog["PAGE_SIZE"].value_()
-mm = task.mm.read_()
 if mm:
     pgd = mm.pgd
     rss = task_rss(task)
@@ -704,7 +713,6 @@ try:
     ref_num = int(ref, 16)
 except ValueError:
     ref_num = None
-mm = task.mm.read_()
 if mm:
     pgd = mm.pgd
     rss = task_rss(task)
@@ -738,7 +746,6 @@ if mm:
                 code.append(
                     """\
 
-mm = task.mm.read_()
 if mm:
     pgd = mm.pgd
     rss = task_rss(task)
@@ -764,6 +771,8 @@ if mm:
         print_task_header(task)
 
         mm = task.mm.read_()
+        if args.M is not None:
+            mm = Object(prog, "struct mm_struct *", args.M)
 
         if args.m:
             if mm:
@@ -1009,6 +1018,13 @@ arguments are entered, the current context is used.
             metavar="vma",
             type="hexadecimal",
             help="translate pages belonging to the specified VM area",
+        ),
+        argument(
+            "-M",
+            dest="M",
+            metavar="mm",
+            type="hexadecimal",
+            help="use a manually specified mm_struct address",
         ),
         argument(
             "-x",

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -589,6 +589,12 @@ for si in for_each_swap_info():
             const=10,
             help="output integers in decimal format regardless of the default",
         ),
+        argument(
+            "-R",
+            dest="reference",
+            metavar="reference",
+            help="search for references to this number or filename",
+        ),
         drgn_argument,
     ),
 )
@@ -609,6 +615,44 @@ mm = task.mm.read_()
 if mm:
     for vma in for_each_vma(mm):
         pass
+"""
+                )
+            elif args.reference:
+                code.add_from_import(
+                    "drgn.helpers.linux.mm",
+                    "for_each_vma",
+                    "task_rss",
+                    "vma_name",
+                )
+                code.append(
+                    f"""\
+ref = {repr(args.reference)}
+try:
+    ref_num = int(ref, 16)
+except ValueError:
+    ref_num = None
+mm = task.mm.read_()
+if mm:
+    pgd = mm.pgd
+    rss = task_rss(task)
+    total_vm = mm.total_vm
+
+    for vma in for_each_vma(mm):
+        matches = True
+        if ref_num is not None:
+            start = vma.vm_start
+            end = vma.vm_end
+            flags = vma.vm_flags
+            matches = (
+                flags == ref_num
+                or start == ref_num
+                or start <= ref_num < end
+            )
+        else:
+            file = vma_name(vma)
+            matches = ref in file.decode(errors="replace")
+        if matches:
+            pass
 """
                 )
             else:
@@ -698,7 +742,29 @@ if mm:
                 CellFormat("FILE", "<"),
             )
         ]
+        reference = args.reference
+        ref_num = None
+        if reference is not None:
+            try:
+                ref_num = int(reference, 16)
+            except ValueError:
+                pass
         for vma in for_each_vma(mm):
+            if reference is not None:
+                vma_start = vma.vm_start.value_()
+                vma_end = vma.vm_end.value_()
+                vma_flags = vma.vm_flags.value_()
+                vma_file = vma_name(vma)
+                if ref_num is not None:
+                    if not (
+                        vma_flags == ref_num
+                        or vma_start == ref_num
+                        or vma_start <= ref_num < vma_end
+                    ):
+                        continue
+                else:
+                    if reference not in vma_file.decode(errors="replace"):
+                        continue
             rows.append(
                 (
                     CellFormat(vma.value_(), "^x"),
@@ -752,6 +818,12 @@ arguments are entered, the current context is used.
             metavar="vm_flags",
             type="hexadecimal",
             help="translate the bits of a FLAGS (vm_flags) value",
+        ),
+        argument(
+            "-R",
+            dest="reference",
+            metavar="reference",
+            help="search for references to this number or filename",
         ),
         argument(
             "tasks",

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -499,6 +499,20 @@ for si in for_each_swap_info():
             action="store_true",
             help="dump all vm_area_structs associated with the task",
         ),
+        argument(
+            "-x",
+            dest="integer_base",
+            action="store_const",
+            const=16,
+            help="output integers in hexadecimal format regardless of the default",
+        ),
+        argument(
+            "-d",
+            dest="integer_base",
+            action="store_const",
+            const=10,
+            help="output integers in decimal format regardless of the default",
+        ),
         drgn_argument,
     ),
 )
@@ -641,6 +655,20 @@ arguments are entered, the current context is used.
             dest="v",
             action="store_true",
             help="dump all vm_area_structs associated with the task",
+        ),
+        argument(
+            "-x",
+            dest="integer_base",
+            action="store_const",
+            const=16,
+            help="output integers in hexadecimal format regardless of the default",
+        ),
+        argument(
+            "-d",
+            dest="integer_base",
+            action="store_const",
+            const=10,
+            help="output integers in decimal format regardless of the default",
         ),
         argument(
             "tasks",

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -576,6 +576,12 @@ for si in for_each_swap_info():
             help="dump all vm_area_structs associated with the task",
         ),
         argument(
+            "-p",
+            dest="p",
+            action="store_true",
+            help="translate each virtual page to its physical address",
+        ),
+        argument(
             "-x",
             dest="integer_base",
             action="store_const",
@@ -615,6 +621,37 @@ mm = task.mm.read_()
 if mm:
     for vma in for_each_vma(mm):
         pass
+"""
+                )
+            elif args.p:
+                code.add_from_import("drgn", "FaultError")
+                code.add_from_import(
+                    "drgn.helpers.linux.mm",
+                    "follow_phys",
+                    "for_each_vma",
+                    "task_rss",
+                    "vma_name",
+                )
+                code.append(
+                    """\
+page_size = prog["PAGE_SIZE"].value_()
+mm = task.mm.read_()
+if mm:
+    pgd = mm.pgd
+    rss = task_rss(task)
+    total_vm = mm.total_vm
+
+    for vma in for_each_vma(mm):
+        start = vma.vm_start
+        end = vma.vm_end
+        flags = vma.vm_flags
+        file = vma_name(vma)
+        vm_file = vma.vm_file.read_()
+        for page_addr in range(start, end, page_size):
+            try:
+                phys_addr = follow_phys(mm, page_addr)
+            except FaultError:
+                phys_addr = None
 """
                 )
             elif args.reference:
@@ -707,6 +744,72 @@ if mm:
                 print("(no mm_struct)")
             continue
 
+        if args.p:
+            if mm:
+                page_size = prog["PAGE_SIZE"].value_()
+                for vma in for_each_vma(mm):
+                    try:
+                        vma_start = vma.vm_start.value_()
+                    except FaultError:
+                        continue
+                    vma_end = vma.vm_end.value_()
+                    vm_file = vma.vm_file.read_()
+                    vm_pgoff = vma.vm_pgoff.value_() if vm_file else 0
+                    vma_name_str = vma_name(vma)
+                    print_table(
+                        (
+                            (
+                                CellFormat("VMA", "^"),
+                                CellFormat("START", "^"),
+                                CellFormat("END", "^"),
+                                CellFormat("FLAGS", "<"),
+                                CellFormat("FILE", "<"),
+                            ),
+                            (
+                                CellFormat(vma.value_(), "^x"),
+                                CellFormat(vma_start, "^x"),
+                                CellFormat(vma_end, "^x"),
+                                CellFormat(vma.vm_flags.value_(), "<x"),
+                                escape_ascii_string(
+                                    vma_name_str, escape_backslash=True
+                                ),
+                            ),
+                        )
+                    )
+                    print_table([("VIRTUAL", "PHYSICAL")])
+                    for page_addr in range(vma_start, vma_end, page_size):
+                        try:
+                            phys_addr = follow_phys(mm, page_addr).value_()
+                            print_table(
+                                [
+                                    (
+                                        CellFormat(page_addr, "^x"),
+                                        CellFormat(phys_addr, "^x"),
+                                    )
+                                ]
+                            )
+                        except FaultError:
+                            if vm_file:
+                                offset = (page_addr - vma_start) + vm_pgoff * page_size
+                                print_table(
+                                    [
+                                        (
+                                            CellFormat(page_addr, "^x"),
+                                            f"FILE: {vma_name_str.decode(errors='replace')}  OFFSET: {offset:x}",
+                                        )
+                                    ]
+                                )
+                            else:
+                                print_table(
+                                    [
+                                        (
+                                            CellFormat(page_addr, "^x"),
+                                            "SWAP: (unavailable)",
+                                        )
+                                    ]
+                                )
+            continue
+
         if mm:
             pgd_value = mm.pgd.value_()
             rss_total = task_rss(task).total
@@ -797,6 +900,12 @@ arguments are entered, the current context is used.
             dest="v",
             action="store_true",
             help="dump all vm_area_structs associated with the task",
+        ),
+        argument(
+            "-p",
+            dest="p",
+            action="store_true",
+            help="translate each virtual page to its physical address",
         ),
         argument(
             "-x",

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -19,6 +19,7 @@ from drgn.commands import (
 from drgn.commands._crash.common import (
     CrashDrgnCodeBuilder,
     _crash_foreach_subcommand,
+    _object_format_options,
     _TaskSelector,
     crash_command,
     parse_cpuspec,
@@ -485,7 +486,15 @@ for si in for_each_swap_info():
 
 
 @_crash_foreach_subcommand(
-    arguments=(drgn_argument,),
+    arguments=(
+        argument(
+            "-m",
+            dest="m",
+            action="store_true",
+            help="dump the mm_struct associated with the task",
+        ),
+        drgn_argument,
+    ),
 )
 def _crash_foreach_vm(task_selector: _TaskSelector, args: argparse.Namespace) -> None:
     prog = task_selector.prog
@@ -494,11 +503,17 @@ def _crash_foreach_vm(task_selector: _TaskSelector, args: argparse.Namespace) ->
         code = CrashDrgnCodeBuilder(prog)
         with task_selector.begin_task_loop(code):
             code.append_task_header()
-            code.add_from_import(
-                "drgn.helpers.linux.mm", "for_each_vma", "task_rss", "vma_name"
-            )
-            code.append(
-                """\
+            if args.m:
+                code.append("mm = task.mm.read_()\n")
+            else:
+                code.add_from_import(
+                    "drgn.helpers.linux.mm",
+                    "for_each_vma",
+                    "task_rss",
+                    "vma_name",
+                )
+                code.append(
+                    """\
 
 mm = task.mm.read_()
 if mm:
@@ -512,8 +527,10 @@ if mm:
         flags = vma.vm_flags
         file = vma_name(vma)
 """
-            )
+                )
         return code.print()
+
+    format_options = _object_format_options(prog, getattr(args, "integer_base", None))
 
     first = True
     for task in task_selector.tasks():
@@ -524,6 +541,14 @@ if mm:
         print_task_header(task)
 
         mm = task.mm.read_()
+
+        if args.m:
+            if mm:
+                print(mm[0].format_(**format_options))
+            else:
+                print("(no mm_struct)")
+            continue
+
         if mm:
             pgd_value = mm.pgd.value_()
             rss_total = task_rss(task).total
@@ -581,6 +606,12 @@ its starting and ending address, vm_flags value, and file pathname. If no
 arguments are entered, the current context is used.
 """,
     arguments=(
+        argument(
+            "-m",
+            dest="m",
+            action="store_true",
+            help="dump the mm_struct associated with the task",
+        ),
         argument(
             "tasks",
             metavar="pid|task",

--- a/drgn/commands/_crash/_mm.py
+++ b/drgn/commands/_crash/_mm.py
@@ -493,6 +493,12 @@ for si in for_each_swap_info():
             action="store_true",
             help="dump the mm_struct associated with the task",
         ),
+        argument(
+            "-v",
+            dest="v",
+            action="store_true",
+            help="dump all vm_area_structs associated with the task",
+        ),
         drgn_argument,
     ),
 )
@@ -505,6 +511,16 @@ def _crash_foreach_vm(task_selector: _TaskSelector, args: argparse.Namespace) ->
             code.append_task_header()
             if args.m:
                 code.append("mm = task.mm.read_()\n")
+            elif args.v:
+                code.add_from_import("drgn.helpers.linux.mm", "for_each_vma")
+                code.append(
+                    """\
+mm = task.mm.read_()
+if mm:
+    for vma in for_each_vma(mm):
+        pass
+"""
+                )
             else:
                 code.add_from_import(
                     "drgn.helpers.linux.mm",
@@ -545,6 +561,14 @@ if mm:
         if args.m:
             if mm:
                 print(mm[0].format_(**format_options))
+            else:
+                print("(no mm_struct)")
+            continue
+
+        if args.v:
+            if mm:
+                for vma in for_each_vma(mm):
+                    print(vma[0].format_(**format_options))
             else:
                 print("(no mm_struct)")
             continue
@@ -611,6 +635,12 @@ arguments are entered, the current context is used.
             dest="m",
             action="store_true",
             help="dump the mm_struct associated with the task",
+        ),
+        argument(
+            "-v",
+            dest="v",
+            action="store_true",
+            help="dump all vm_area_structs associated with the task",
         ),
         argument(
             "tasks",

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -5,6 +5,8 @@
 import mmap
 import os
 import re
+import subprocess
+import time
 
 from drgn import Object
 from drgn.helpers.linux.cpumask import for_each_online_cpu
@@ -359,3 +361,19 @@ class TestVm(CrashCommandTestCase):
         self.assertIn("PID: 2", cmd.stdout)
         self.assertRegex(cmd.stdout, r"\bMM\s+PGD\s+RSS\s+TOTAL_VM\s+0\s+0\s+0k\s+0k\b")
         self.assertNotIn("VMA", cmd.stdout)
+
+    @skip_unless_have_full_mm_support
+    def test_p_page_translation(self):
+        self.run_crash_command("set -p")
+
+        proc = subprocess.Popen(["sleep", "60"])
+        try:
+            time.sleep(0.1)
+            cmd = self.check_crash_command(f"vm -p {proc.pid}", mode="capture")
+            self.assertIn(f"PID: {proc.pid}", cmd.stdout)
+            self.assertIn("VIRTUAL", cmd.stdout)
+            self.assertIn("PHYSICAL", cmd.stdout)
+            self.assertIn("VMA", cmd.stdout)
+        finally:
+            proc.kill()
+            proc.wait()

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -390,3 +390,25 @@ class TestVm(CrashCommandTestCase):
         )
         self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
         self.assertIn("VIRTUAL", cmd.stdout)
+
+    def test_M_manual_mm(self):
+        self.run_crash_command("set -p")
+
+        task = find_task(self.prog, os.getpid())
+        mm = task.mm.read_()
+        mm_addr = mm.value_()
+        cmd = self.check_crash_command(
+            f"vm -M {mm_addr:x} {os.getpid()}", mode="capture"
+        )
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("MM", cmd.stdout)
+        self.assertIn(f"{mm_addr:x}", cmd.stdout)
+
+    def test_M_manual_mm_drgn(self):
+        self.run_crash_command("set -p")
+
+        task = find_task(self.prog, os.getpid())
+        mm = task.mm.read_()
+        mm_addr = mm.value_()
+        cmd = self.check_crash_command(f"vm -M {mm_addr:x} {os.getpid()}")
+        self.assertIsInstance(cmd.drgn_option.globals["mm"], Object)

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -341,3 +341,21 @@ class TestVm(CrashCommandTestCase):
     def test_f_decode_zero(self):
         cmd = self.check_crash_command("vm -f 0")
         self.assertIn("0: (0)", cmd.stdout)
+
+    def test_r_reference(self):
+        self.run_crash_command("set -p")
+
+        cmd = self.check_crash_command("vm -R libc")
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("VMA", cmd.stdout)
+        self.assertIn("libc", cmd.stdout)
+
+        self.assertIn("ref", cmd.drgn_option.globals)
+        self.assertIsInstance(cmd.drgn_option.globals["ref"], str)
+        self.assertEqual(cmd.drgn_option.globals["ref"], "libc")
+
+    def test_r_reference_kernel_thread(self):
+        cmd = self.check_crash_command("vm -R 75 2")
+        self.assertIn("PID: 2", cmd.stdout)
+        self.assertRegex(cmd.stdout, r"\bMM\s+PGD\s+RSS\s+TOTAL_VM\s+0\s+0\s+0k\s+0k\b")
+        self.assertNotIn("VMA", cmd.stdout)

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -283,3 +283,19 @@ class TestVm(CrashCommandTestCase):
         self.assertNotIn("VMA", cmd.stdout)
 
         self.assertFalse(cmd.drgn_option.globals["mm"])
+
+    def test_m_dump_mm_struct(self):
+        self.run_crash_command("set -p")
+
+        cmd = self.check_crash_command("vm -m")
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("struct mm_struct", cmd.stdout)
+        self.assertIn("mmap", cmd.stdout)
+        self.assertIn("pgd", cmd.stdout)
+
+        self.assertIsInstance(cmd.drgn_option.globals["mm"], Object)
+
+    def test_m_kernel_thread(self):
+        cmd = self.check_crash_command("vm -m 2")
+        self.assertIn("(no mm_struct)", cmd.stdout)
+        self.assertFalse(cmd.drgn_option.globals["mm"])

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -330,3 +330,14 @@ class TestVm(CrashCommandTestCase):
         cmd = self.check_crash_command("vm -m -d")
         self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
         self.assertIn("struct mm_struct", cmd.stdout)
+
+    def test_f_decode_flags(self):
+        cmd = self.check_crash_command("vm -f 75")
+        self.assertIn("75: (READ|EXEC|MAYREAD|MAYWRITE|MAYEXEC)", cmd.stdout)
+
+        self.assertEqual(cmd.drgn_option.globals["vm_flags"], 0x75)
+        self.assertIsInstance(cmd.drgn_option.globals["decoded"], str)
+
+    def test_f_decode_zero(self):
+        cmd = self.check_crash_command("vm -f 0")
+        self.assertIn("0: (0)", cmd.stdout)

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -299,3 +299,20 @@ class TestVm(CrashCommandTestCase):
         cmd = self.check_crash_command("vm -m 2")
         self.assertIn("(no mm_struct)", cmd.stdout)
         self.assertFalse(cmd.drgn_option.globals["mm"])
+
+    def test_v_dump_vma_structs(self):
+        self.run_crash_command("set -p")
+
+        cmd = self.check_crash_command("vm -v")
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("struct vm_area_struct", cmd.stdout)
+        self.assertIn("vm_start", cmd.stdout)
+        self.assertIn("vm_end", cmd.stdout)
+        self.assertIn("vm_flags", cmd.stdout)
+
+        self.assertIsInstance(cmd.drgn_option.globals["vma"], Object)
+
+    def test_v_kernel_thread(self):
+        cmd = self.check_crash_command("vm -v 2")
+        self.assertIn("(no mm_struct)", cmd.stdout)
+        self.assertNotIn("vm_area_struct", cmd.stdout)

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -10,8 +10,9 @@ import time
 
 from drgn import Object
 from drgn.helpers.linux.cpumask import for_each_online_cpu
-from drgn.helpers.linux.mm import PFN_PHYS, TaskRss, phys_to_virt
+from drgn.helpers.linux.mm import PFN_PHYS, TaskRss, for_each_vma, phys_to_virt
 from drgn.helpers.linux.percpu import per_cpu_ptr
+from drgn.helpers.linux.pid import find_task
 from tests.linux_kernel import (
     skip_if_highmem,
     skip_unless_have_full_mm_support,
@@ -377,3 +378,15 @@ class TestVm(CrashCommandTestCase):
         finally:
             proc.kill()
             proc.wait()
+
+    @skip_unless_have_full_mm_support
+    def test_P_specific_vma(self):
+        self.run_crash_command("set -p")
+
+        task = find_task(self.prog, os.getpid())
+        vma_addr = next(for_each_vma(task.mm)).value_()
+        cmd = self.check_crash_command(
+            f"vm -P {vma_addr:x} {os.getpid()}", mode="capture"
+        )
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("VIRTUAL", cmd.stdout)

--- a/tests/linux_kernel/crash_commands/test_mm.py
+++ b/tests/linux_kernel/crash_commands/test_mm.py
@@ -316,3 +316,17 @@ class TestVm(CrashCommandTestCase):
         cmd = self.check_crash_command("vm -v 2")
         self.assertIn("(no mm_struct)", cmd.stdout)
         self.assertNotIn("vm_area_struct", cmd.stdout)
+
+    def test_x_mm_struct_hex(self):
+        self.run_crash_command("set -p")
+
+        cmd = self.check_crash_command("vm -m -x")
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("struct mm_struct", cmd.stdout)
+
+    def test_d_mm_struct_dec(self):
+        self.run_crash_command("set -p")
+
+        cmd = self.check_crash_command("vm -m -d")
+        self.assertIn(f"PID: {os.getpid()}", cmd.stdout)
+        self.assertIn("struct mm_struct", cmd.stdout)


### PR DESCRIPTION
This PR extends the `crash` command's `vm` subcommand with some new options to facilitate inspection of memory management structures:

  options:
    -m            dump the mm_struct associated with the task
    -v            dump all vm_area_structs associated with the task
    -p            translate each virtual page to its physical address
    -P vma        translate pages belonging to the specified VM area
    -M mm         use a manually specified mm_struct address
    -x            output integers in hexadecimal format regardless of the default
    -d            output integers in decimal format regardless of the default
    -f vm_flags   translate the bits of a FLAGS (vm_flags) value
    -R reference  search for references to this number or filename
    --drgn        print how to do the equivalent operation using drgn APIs
