### PR TITLE
libdrgn: arm: add fallbacks for resolving swapper_pg_dir

### DIFF
--- a/libdrgn/arch_arm.c
+++ b/libdrgn/arch_arm.c
@@ -8,9 +8,12 @@
 #include "cfi.h"
 #include "error.h"
 #include "helpers.h"
+#include "linux_kernel.h"
+#include "memory_reader.h"
 #include "platform.h" // IWYU pragma: associated
 #include "program.h"
 #include "register_state.h"
+#include "symbol.h"
 
 /*
  * The ABI specification can be found at:
@@ -167,7 +170,43 @@ apply_elf_reloc_arm(const struct drgn_relocating_section *relocating,
 	}
 }
 
+// Resolve swapper_pg_dir to a physical address so reading it does not recurse
+// back into the page table iterator. Use the same heuristic fallbacks as the
+// crash utility. Derive PAGE_OFFSET by rounding _stext's address down to a 32
+// MB boundary. This heuristic works for all standard Arm VMSPLIT
+// configurations. PHYS_OFFSET is normally the lowest physical address among
+// file-backed ELF core PT_LOAD segments, so estimate it as such.
+static struct drgn_error *
+linux_kernel_resolve_swapper_pg_dir_arm(struct drgn_program *prog,
+					uint64_t swapper_pg_dir,
+					uint64_t *ret)
+{
+	struct drgn_error *err;
+
+	_cleanup_symbol_ struct drgn_symbol *stext = NULL;
+	err = drgn_program_find_symbol_by_name(prog, "_stext", &stext);
+	if (drgn_error_catch(&err, DRGN_ERROR_LOOKUP)) {
+		return drgn_error_create(DRGN_ERROR_LOOKUP,
+					 "could not find _stext to determine PAGE_OFFSET");
+	} else if (err) {
+		return err;
+	}
+	uint32_t page_offset = stext->address & ~UINT32_C(0x01ffffff);
+
+	uint64_t phys_offset;
+	if (!drgn_memory_reader_min_file_segment_physical_address(
+		    &prog->reader, &phys_offset)) {
+		return drgn_error_create(DRGN_ERROR_LOOKUP,
+					 "could not determine PHYS_OFFSET from core file segments");
+	}
+
+	*ret = swapper_pg_dir - page_offset + phys_offset;
+	return NULL;
+}
+
 struct pgtable_iterator_arm {
+	uint64_t swapper_pg_dir_phys;
+	bool swapper_pg_dir_resolved;
 	union {
 		// For LPAE.
 		struct {
@@ -189,6 +228,9 @@ linux_kernel_pgtable_iterator_arch_create_arm(struct drgn_program *prog,
 	struct pgtable_iterator_arm *it_arch = malloc(sizeof(*it_arch));
 	if (!it_arch)
 		return &drgn_enomem;
+
+	it_arch->swapper_pg_dir_phys = 0;
+	it_arch->swapper_pg_dir_resolved = false;
 	*ret = it_arch;
 	return NULL;
 }
@@ -199,6 +241,42 @@ static void linux_kernel_pgtable_iterator_init_arm(struct drgn_program *prog,
 	struct pgtable_iterator_arm *it_arch = it->arch;
 	memset(it_arch->cached_entries, 0, sizeof(it_arch->cached_entries));
 	it_arch->cached_virt_addr = 0;
+}
+
+static struct drgn_error *
+linux_kernel_pgtable_iterator_root_arm(struct drgn_program *prog,
+				       struct pgtable_iterator *it,
+				       uint64_t *pgtable_ret,
+				       bool *physical_ret)
+{
+	struct drgn_error *err;
+
+	*pgtable_ret = it->pgtable;
+	*physical_ret = false;
+	if (it->pgtable != prog->vmcoreinfo.swapper_pg_dir)
+		return NULL;
+
+	struct pgtable_iterator_arm *it_arch = it->arch;
+	if (it_arch->swapper_pg_dir_resolved) {
+		*pgtable_ret = it_arch->swapper_pg_dir_phys;
+		*physical_ret = true;
+		return NULL;
+	}
+
+	drgn_memory_read_fn read_fn =
+		drgn_memory_reader_segment_read_fn(&prog->reader, it->pgtable,
+						   false);
+	if (read_fn && read_fn != read_memory_via_pgtable)
+		return NULL;
+
+	err = linux_kernel_resolve_swapper_pg_dir_arm(
+		prog, it->pgtable, &it_arch->swapper_pg_dir_phys);
+	if (err)
+		return err;
+	it_arch->swapper_pg_dir_resolved = true;
+	*pgtable_ret = it_arch->swapper_pg_dir_phys;
+	*physical_ret = true;
+	return NULL;
 }
 
 static struct drgn_error *
@@ -213,8 +291,13 @@ linux_kernel_pgtable_iterator_next_arm_lpae(struct drgn_program *prog,
 
 	const uint64_t phys_addr_mask = 0xfffffff000;
 	uint32_t index_mask = 0x3;
-	uint64_t table = it->pgtable;
-	bool table_physical = false;
+	uint64_t table;
+	bool table_physical;
+	err = linux_kernel_pgtable_iterator_root_arm(prog, it, &table,
+						     &table_physical);
+	if (err)
+		return err;
+
 	for (int level = 2;; level--) {
 		int level_shift = 12 + 9 * level;
 		uint32_t index = (virt_addr >> level_shift) & index_mask;
@@ -265,11 +348,17 @@ linux_kernel_pgtable_iterator_next_arm(struct drgn_program *prog,
 	}
 
 	const uint32_t virt_addr = it->virt_addr;
+	uint64_t table;
+	bool table_physical;
+	err = linux_kernel_pgtable_iterator_root_arm(prog, it, &table,
+						     &table_physical);
+	if (err)
+		return err;
 
 	uint32_t index = virt_addr >> 20;
 	if (it_arch->cached_index != index || !it_arch->cached_entry) {
-		err = drgn_program_read_u32(prog, it->pgtable + index * 4,
-					    false, &it_arch->cached_entry);
+		err = drgn_program_read_u32(prog, table + index * 4,
+					    table_physical, &it_arch->cached_entry);
 		if (err)
 			return err;
 		it_arch->cached_index = index;
@@ -295,7 +384,7 @@ linux_kernel_pgtable_iterator_next_arm(struct drgn_program *prog,
 		return NULL;
 	}
 
-	uint32_t table = entry & ~((UINT32_C(1) << 10) - 1);
+	table = entry & ~((UINT32_C(1) << 10) - 1);
 	index = (virt_addr >> 12) & 0xff;
 	err = drgn_program_read_u32(prog, table + index * 4, true, &entry);
 	if (err)

--- a/libdrgn/memory_reader.c
+++ b/libdrgn/memory_reader.c
@@ -180,6 +180,38 @@ bool drgn_memory_reader_empty_virtual(struct drgn_memory_reader *reader)
 	return drgn_memory_segment_tree_empty(&reader->virtual_segments);
 }
 
+drgn_memory_read_fn
+drgn_memory_reader_segment_read_fn(struct drgn_memory_reader *reader,
+				   uint64_t address, bool physical)
+{
+	struct drgn_memory_segment_tree *tree = (physical ?
+						 &reader->physical_segments :
+						 &reader->virtual_segments);
+	struct drgn_memory_segment *segment =
+		drgn_memory_segment_tree_search_le(tree, &address).entry;
+	if (!segment || address > segment->max_address)
+		return NULL;
+	return segment->read_fn;
+}
+
+bool drgn_memory_reader_min_file_segment_physical_address(
+	struct drgn_memory_reader *reader, uint64_t *ret)
+{
+	// ELF core PT_LOAD ranges use drgn_read_memory_file for their physical
+	// segments. Other backends may instead expose physical memory through a
+	// catch-all segment whose start is not the lowest saved physical address.
+	// Therefore, only consider segments read by drgn_read_memory_file.
+	for (struct drgn_memory_segment_tree_iterator it =
+		     drgn_memory_segment_tree_first(&reader->physical_segments);
+	     it.entry; it = drgn_memory_segment_tree_next(it)) {
+		if (it.entry->read_fn == drgn_read_memory_file) {
+			*ret = it.entry->min_address;
+			return true;
+		}
+	}
+	return false;
+}
+
 struct drgn_error *
 drgn_memory_reader_add_segment(struct drgn_memory_reader *reader,
 			       uint64_t min_address, uint64_t max_address,

--- a/libdrgn/memory_reader.h
+++ b/libdrgn/memory_reader.h
@@ -70,6 +70,40 @@ bool drgn_memory_reader_empty(struct drgn_memory_reader *reader);
 bool drgn_memory_reader_empty_virtual(struct drgn_memory_reader *reader);
 
 /**
+ * Get the callback that a @ref drgn_memory_reader would use to read an address.
+ *
+ * This can be used to determine how an address would be read before actually
+ * reading it, for example to detect that a read would recurse.
+ *
+ * @param[in] reader Memory reader.
+ * @param[in] address Address to look up.
+ * @param[in] physical Whether @p address is physical.
+ * @return Callback registered for the segment containing @p address, or @c NULL
+ * if no segment contains it.
+ */
+drgn_memory_read_fn
+drgn_memory_reader_segment_read_fn(struct drgn_memory_reader *reader,
+				   uint64_t address, bool physical);
+
+/**
+ * Get the lowest physical address of any core file segment in a
+ * @ref drgn_memory_reader.
+ *
+ * Only physical segments read by @ref drgn_read_memory_file() are considered.
+ * These represent individual ELF core PT_LOAD ranges. Some backends (e.g.
+ * libkdumpfile) instead register a physical catch-all segment spanning the
+ * whole address space, whose start is not the lowest saved physical address.
+ * Such segments are ignored.
+ *
+ * @param[in] reader Memory reader.
+ * @param[out] ret Returned lowest physical address.
+ * @return @c true if there is at least one physical core file segment (in which
+ * case @p ret is set), @c false otherwise.
+ */
+bool drgn_memory_reader_min_file_segment_physical_address(
+	struct drgn_memory_reader *reader, uint64_t *ret);
+
+/**
  * Add a segment to a @ref drgn_memory_reader.
  *
  * @param[in] reader Memory reader.

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -21,6 +21,9 @@ from drgn import (
     Program,
     ProgramFlags,
     Qualifiers,
+    Symbol,
+    SymbolBinding,
+    SymbolKind,
     TypeKind,
     TypeMember,
     get_default_prog,
@@ -1176,6 +1179,64 @@ class TestCoreDump(TestCase):
         with self.assertRaisesRegex(FaultError, "memory not saved in core dump") as cm:
             prog.read(0xFFFF0000, len(data) + 4)
         self.assertEqual(cm.exception.address, 0xFFFF000C)
+
+    def test_arm_missing_virtual_address_segment(self):
+        expected = b"hello, world"
+        data = bytearray(0x8000)
+        data[: len(expected)] = expected
+
+        page_offset = 0xC0000000
+        phys_offset = 0x80000000
+        swapper_pg_dir = page_offset + 0x4000
+        pgd_phys = swapper_pg_dir - page_offset + phys_offset
+
+        # Map the 1 MB section at PAGE_OFFSET to the section at PHYS_OFFSET.
+        pgd_entry_offset = pgd_phys - phys_offset + (page_offset >> 20) * 4
+        data[pgd_entry_offset : pgd_entry_offset + 4] = (phys_offset | 0x2).to_bytes(
+            4, "little"
+        )
+
+        prog = Program(
+            Platform(Architecture.ARM, PlatformFlags.IS_LITTLE_ENDIAN),
+            vmcoreinfo=make_vmcoreinfo(swapper_pg_dir=swapper_pg_dir),
+        )
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(
+                create_elf_file(
+                    ET.CORE,
+                    [
+                        ElfSection(
+                            p_type=PT.LOAD,
+                            vaddr=0,
+                            paddr=phys_offset,
+                            data=data,
+                        ),
+                    ],
+                    bits=32,
+                    e_machine=40,  # EM_ARM
+                )
+            )
+            f.flush()
+            prog.set_core_dump(f.name)
+
+        prog.register_symbol_finder(
+            "test",
+            lambda prog, name, address, one: (
+                [
+                    Symbol(
+                        "_stext",
+                        page_offset + 0x100000,
+                        0,
+                        SymbolBinding.GLOBAL,
+                        SymbolKind.UNKNOWN,
+                    )
+                ]
+                if name == "_stext"
+                else []
+            ),
+        )
+        prog.set_enabled_symbol_finders(["test"])
+        self.assertEqual(prog.read(page_offset, len(expected), False), expected)
 
 
 def make_vmcoreinfo(


### PR DESCRIPTION
This is an implementation of the fallback discussed in https://github.com/osandov/drgn/issues/633.

It fixes recursive address translation for arm32 cores when `swapper_pg_dir` is not covered by a directly readable virtual segment.

In that case, resolve `swapper_pg_dir` to a physical address using the same PAGE_OFFSET and PHYS_OFFSET heuristics as crash, and cache the result in the page table iterator.

I changed my approach slightly from the one I drafted in the issue, and no longer use the direct mapping offset helper in order to move most logic to the actual arch specific file.

I could not find an obvious location for the test, but ended up putting it in `test_program.py`, let me know if there is a better place for it.