### PR TITLE
drgn: crash: bpf: add verbose output for all programs and maps

### DIFF
--- a/drgn/commands/_crash/_bpf.py
+++ b/drgn/commands/_crash/_bpf.py
@@ -5,9 +5,9 @@
 
 import argparse
 from datetime import datetime
-from typing import Any, List, Sequence
+from typing import Any, List, Optional, Sequence
 
-from drgn import Program
+from drgn import Object, Program
 from drgn.commands import argument, drgn_argument
 from drgn.commands._crash.common import (
     CrashDrgnCodeBuilder,
@@ -34,6 +34,163 @@ from drgn.helpers.linux.timekeeping import (
 from drgn.helpers.linux.user import kuid_val
 
 
+def _get_map_flags(bpf_map: Object) -> str:
+    # The 'map_flags' field was added in Linux kernel commit 6c9059817432
+    # ("bpf: pre-allocate hash map elements") in version 4.6. Older kernels
+    # may not have this field, so we catch AttributeError and default to 0.
+    try:
+        return f"{bpf_map.map_flags.value_():08x}"
+    except AttributeError:
+        return "00000000"
+
+
+def _get_map_name(bpf_map: Object) -> str:
+    # The 'name' field was added in Linux kernel commit ad5b177bd73f ("bpf:
+    # Add map_name to bpf_map_info") (in v4.15).
+    try:
+        name_member = bpf_map.name
+    except AttributeError:
+        return "(unknown)"
+    raw_name = name_member.string_()
+    if raw_name:
+        return double_quote_ascii_string(raw_name)
+    return "(unused)"
+
+
+def _get_map_uid(bpf_map: Object) -> str:
+    user_ptr: Optional[Object] = None
+
+    # Linux 5.3 to 5.10: bpf_map.memory.user
+    # Commit 3539b96e041c ("bpf: group memory related fields in struct
+    # bpf_map_memory") (in v5.3) moved the user field into struct bpf_map_memory.
+    # This was removed in v5.11 by commit 80ee81e0403c ("bpf: Eliminate
+    # rlimit-based memory accounting infra for bpf maps").
+    try:
+        user_ptr = bpf_map.memory.user
+    except AttributeError:
+        # Linux 4.10 to 5.2: bpf_map.user
+        # Commit aaac3ba95e4c ("bpf: charge user for creation of BPF maps and
+        # programs") (in v4.10) added the user field directly to struct bpf_map.
+        # This was moved into struct bpf_map_memory in v5.3.
+        try:
+            user_ptr = bpf_map.user
+        except AttributeError:
+            pass
+
+    if user_ptr is not None:
+        try:
+            return str(kuid_val(user_ptr.uid))
+        except AttributeError:
+            return "(unknown)"
+    return "(unused)"
+
+
+def _print_prog_verbose(prog: Program, bpf_prog: Object) -> None:
+    """Print the verbose detail lines for a single BPF program."""
+    aux = bpf_prog.aux
+    prog_id = aux.id.value_()
+    prog_type_name = bpf_prog.type.format_(type_name=False).split("BPF_PROG_TYPE_")[-1]
+    INSN_SIZE = prog.type("struct bpf_insn").size
+
+    tag = bpf_prog.tag
+    prog_tag = "".join(f"{b.value_():02x}" for b in tag)
+
+    used_maps = [map.id.value_() for map in bpf_prog_used_maps(bpf_prog)]
+    used_maps_str = ",".join(str(m) for m in used_maps)
+
+    prog_rows: List[Sequence[Any]] = [
+        (
+            CellFormat("ID", "^"),
+            CellFormat("BPF_PROG", "^"),
+            CellFormat("BPF_PROG_AUX", "^"),
+            CellFormat("BPF_PROG_TYPE", "^"),
+            CellFormat("TAG", "^"),
+            CellFormat("USED_MAPS", "^"),
+        ),
+        (
+            prog_id,
+            CellFormat(bpf_prog.value_(), "^x"),
+            CellFormat(aux.value_(), "^x"),
+            CellFormat(prog_type_name, "^"),
+            CellFormat(prog_tag, "^"),
+            CellFormat(used_maps_str, "^"),
+        ),
+    ]
+    print_table(prog_rows)
+
+    page_size = prog["PAGE_SIZE"].value_()
+    memlock = bpf_prog.pages.value_() * page_size
+
+    print(
+        f"     XLATED: {bpf_prog.len.value_() * INSN_SIZE}  JITED: {bpf_prog.jited_len.value_()}  MEMLOCK: {memlock}"
+    )
+
+    # load_time and name were added in Linux kernel commit cb4d2b3f03d8 ("bpf:
+    # Add name, load_time, uid and map_ids to bpf_prog_info") (in v4.15).
+    # Before that, default to "(unknown)".
+    try:
+        load_time_ns = aux.load_time.value_()
+    except AttributeError:
+        load_time_str = "(unknown)"
+    else:
+        current_boottime_ns = ktime_get_coarse_boottime_ns(prog).value_()
+        current_realtime_ns = ktime_get_coarse_real_ns(prog).value_()
+
+        elapsed_ns = current_boottime_ns - load_time_ns
+        actual_load_time_ns = current_realtime_ns - elapsed_ns
+        actual_load_time = datetime.fromtimestamp(actual_load_time_ns / 1e9)
+        load_time_str = actual_load_time.strftime("%a %b %d %H:%M:%S %Y")
+
+    print(f"     LOAD_TIME: {load_time_str}")
+
+    gpl_compat = "yes" if bpf_prog.gpl_compatible else "no"
+    uid = kuid_val(aux.user.uid)
+    try:
+        prog_name = escape_ascii_string(aux.name.string_(), escape_backslash=True)
+        if not prog_name:
+            prog_name = "(unused)"
+    except AttributeError:
+        prog_name = "(unknown)"
+
+    print(f"     GPL_COMPATIBLE: {gpl_compat}  NAME: {prog_name}  UID: {uid}")
+
+
+def _print_map_verbose(bpf_map: Object) -> None:
+    """Print the verbose detail lines for a single BPF map."""
+    map_id = bpf_map.id.value_()
+    map_type_name = bpf_map.map_type.format_(type_name=False).split("BPF_MAP_TYPE_")[-1]
+    map_flags = _get_map_flags(bpf_map)
+
+    map_rows: List[Sequence[Any]] = [
+        (
+            CellFormat("ID", "^"),
+            CellFormat("BPF_MAP", "^"),
+            CellFormat("BPF_MAP_TYPE", "^"),
+            CellFormat("MAP_FLAGS", "^"),
+        ),
+        (
+            map_id,
+            CellFormat(bpf_map.value_(), "^x"),
+            CellFormat(map_type_name, "^"),
+            CellFormat(map_flags, "^"),
+        ),
+    ]
+    print_table(map_rows)
+
+    key_size = bpf_map.key_size.value_()
+    value_size = bpf_map.value_size.value_()
+    max_entries = bpf_map.max_entries.value_()
+
+    print(
+        f"     KEY_SIZE: {key_size}  VALUE_SIZE: {value_size}  MAX_ENTRIES: {max_entries}",
+        end="",
+    )
+
+    map_name = _get_map_name(bpf_map)
+    uid_str = _get_map_uid(bpf_map)
+    print(f"     NAME: {map_name}  UID: {uid_str}")
+
+
 @crash_command(
     description="display loaded eBPF programs and maps",
     arguments=(
@@ -44,10 +201,24 @@ from drgn.helpers.linux.user import kuid_val
             help="display additional information for the specified BPF program ID",
         ),
         argument(
+            "-P",
+            dest="all_progs_verbose",
+            action="store_true",
+            default=False,
+            help="display additional information for all BPF programs",
+        ),
+        argument(
             "-m",
             dest="map_id",
             type=int,
             help="display additional information for the specified BPF map ID",
+        ),
+        argument(
+            "-M",
+            dest="all_maps_verbose",
+            action="store_true",
+            default=False,
+            help="display additional information for all BPF maps",
         ),
         argument(
             "-s",
@@ -110,6 +281,65 @@ for bpf_map in bpf_map_for_each(prog):
         )
         code.print()
         return
+
+    if args.prog_id is not None:
+        bpf_prog = bpf_prog_by_id(prog, args.prog_id)
+        if not bpf_prog:
+            print(f"invalid BPF program ID: {args.prog_id}")
+            return
+
+        _print_prog_verbose(prog, bpf_prog)
+
+        if args.show_struct:
+            aux = bpf_prog.aux
+            print()
+            format_options = _object_format_options(prog, args.integer_base)
+            print(bpf_prog[0].format_(**format_options))
+            print()
+            print(aux[0].format_(**format_options))
+
+        return
+
+    if args.map_id is not None:
+        bpf_map = bpf_map_by_id(prog, args.map_id)
+        if not bpf_map:
+            print(f"invalid BPF map ID: {args.map_id}")
+            return
+
+        _print_map_verbose(bpf_map)
+
+        if args.show_struct:
+            print()
+            format_options = _object_format_options(prog, args.integer_base)
+            print(bpf_map[0].format_(**format_options))
+
+        return
+
+    if args.all_progs_verbose:
+        first = True
+        for bpf_prog in bpf_prog_for_each(prog):
+            if first:
+                first = False
+            else:
+                print()
+            _print_prog_verbose(prog, bpf_prog)
+
+        if not args.all_maps_verbose:
+            return
+
+    if args.all_maps_verbose:
+        if args.all_progs_verbose:
+            print()
+        first = True
+        for bpf_map in bpf_map_for_each(prog):
+            if first:
+                first = False
+            else:
+                print()
+            _print_map_verbose(bpf_map)
+
+        return
+
     prog_rows: List[Sequence[Any]] = [
         (
             CellFormat("ID", "^"),
@@ -121,187 +351,6 @@ for bpf_map in bpf_map_for_each(prog):
         )
     ]
 
-    if args.prog_id is not None:
-
-        bpf_prog = bpf_prog_by_id(prog, args.prog_id)
-        if not bpf_prog:
-            print(f"invalid BPF program ID: {args.prog_id}")
-            return
-
-        aux = bpf_prog.aux
-        prog_id = aux.id.value_()
-        prog_type_name = bpf_prog.type.format_(type_name=False).split("BPF_PROG_TYPE_")[
-            -1
-        ]
-        INSN_SIZE = prog.type("struct bpf_insn").size
-
-        tag = bpf_prog.tag
-        prog_tag = "".join(f"{b.value_():02x}" for b in tag)
-
-        used_maps = []
-        for map in bpf_prog_used_maps(bpf_prog):
-            used_maps.append(map.id.value_())
-        used_maps_str = ",".join(str(m) for m in used_maps)
-
-        prog_rows.append(
-            (
-                prog_id,
-                CellFormat(bpf_prog.value_(), "^x"),
-                CellFormat(aux.value_(), "^x"),
-                CellFormat(prog_type_name, "^"),
-                CellFormat(prog_tag, "^"),
-                CellFormat(used_maps_str, "^"),
-            )
-        )
-        print_table(prog_rows)
-
-        page_size = prog["PAGE_SIZE"].value_()
-        memlock = bpf_prog.pages.value_() * page_size
-
-        print(
-            f"     XLATED: {bpf_prog.len.value_() * INSN_SIZE}  JITED: {bpf_prog.jited_len.value_()}  MEMLOCK: {memlock}"
-        )
-
-        # load_time and name were added in Linux kernel commit cb4d2b3f03d8 ("bpf:
-        # Add name, load_time, uid and map_ids to bpf_prog_info") (in v4.15).
-        # Before that, default to "(unknown)".
-        try:
-            load_time_ns = aux.load_time.value_()
-        except AttributeError:
-            load_time_str = "(unknown)"
-        else:
-            current_boottime_ns = ktime_get_coarse_boottime_ns(prog).value_()
-            current_realtime_ns = ktime_get_coarse_real_ns(prog).value_()
-
-            elapsed_ns = current_boottime_ns - load_time_ns
-            actual_load_time_ns = current_realtime_ns - elapsed_ns
-            actual_load_time = datetime.fromtimestamp(actual_load_time_ns / 1e9)
-            load_time_str = actual_load_time.strftime("%a %b %d %H:%M:%S %Y")
-
-        print(f"     LOAD_TIME: {load_time_str}")
-
-        gpl_compat = "yes" if bpf_prog.gpl_compatible else "no"
-        uid = kuid_val(aux.user.uid)
-        try:
-            prog_name = escape_ascii_string(aux.name.string_(), escape_backslash=True)
-            if not prog_name:
-                prog_name = "(unused)"
-        except AttributeError:
-            prog_name = "(unknown)"
-
-        print(f"     GPL_COMPATIBLE: {gpl_compat}  NAME: {prog_name}  UID: {uid}")
-
-        if args.show_struct:
-            print()
-            format_options = _object_format_options(prog, args.integer_base)
-            print(bpf_prog[0].format_(**format_options))
-
-            print()
-
-            print(aux[0].format_(**format_options))
-
-        return
-
-    if args.map_id is not None:
-
-        bpf_map = bpf_map_by_id(prog, args.map_id)
-        if not bpf_map:
-            print(f"invalid BPF map ID: {args.map_id}")
-            return
-
-        map_id = bpf_map.id.value_()
-
-        map_type_name = bpf_map.map_type.format_(type_name=False).split(
-            "BPF_MAP_TYPE_"
-        )[-1]
-
-        # The 'map_flags' field was added in Linux kernel commit 6c9059817432
-        # ("bpf: pre-allocate hash map elements") in version 4.6. Older kernels
-        # may not have this field, so we catch LookupError and default to 0.
-        try:
-            map_flags = f"{bpf_map.map_flags.value_():08x}"
-        except AttributeError:
-            map_flags = "00000000"
-
-        map_rows: List[Sequence[Any]] = [
-            (
-                CellFormat("ID", "^"),
-                CellFormat("BPF_MAP", "^"),
-                CellFormat("BPF_MAP_TYPE", "^"),
-                CellFormat("MAP_FLAGS", "^"),
-            )
-        ]
-
-        map_rows.append(
-            (
-                map_id,
-                CellFormat(bpf_map.value_(), "^x"),
-                CellFormat(map_type_name, "^"),
-                CellFormat(map_flags, "^"),
-            )
-        )
-
-        print_table(map_rows)
-
-        key_size = bpf_map.key_size.value_()
-        value_size = bpf_map.value_size.value_()
-        max_entries = bpf_map.max_entries.value_()
-
-        print(
-            f"     KEY_SIZE: {key_size}  VALUE_SIZE: {value_size}  MAX_ENTRIES: {max_entries}",
-            end="",
-        )
-
-        # The 'name' field was added in Linux kernel commit ad5b177bd73f ("bpf:
-        # Add map_name to bpf_map_info") (in v4.15).
-        map_name = "(unknown)"
-        try:
-            name_member = bpf_map.name
-        except AttributeError:
-            map_name = "(unknown)"
-        else:
-            raw_name = name_member.string_()
-            if raw_name:
-                map_name = double_quote_ascii_string(raw_name)
-            else:
-                map_name = "(unused)"
-
-        uid_str = "(unused)"
-        user_ptr = None
-
-        # Linux 5.3 to 5.10: bpf_map.memory.user
-        # Commit 3539b96e041c ("bpf: group memory related fields in struct
-        # bpf_map_memory") (in v5.3) moved the user field into struct bpf_map_memory.
-        # This was removed in v5.11 by commit 80ee81e0403c ("bpf: Eliminate
-        # rlimit-based memory accounting infra for bpf maps").
-        try:
-            user_ptr = bpf_map.memory.user
-        except AttributeError:
-            # Linux 4.10 to 5.2: bpf_map.user
-            # Commit aaac3ba95e4c ("bpf: charge user for creation of BPF maps and
-            # programs") (in v4.10) added the user field directly to struct bpf_map.
-            # This was moved into struct bpf_map_memory in v5.3.
-            try:
-                user_ptr = bpf_map.user
-            except AttributeError:
-                pass
-
-        if user_ptr is not None:
-            try:
-                uid_val = kuid_val(user_ptr.uid)
-                uid_str = str(uid_val)
-            except AttributeError:
-                uid_str = "(unknown)"
-
-        print(f"     NAME: {map_name}  UID: {uid_str}")
-
-        if args.show_struct:
-            print()
-            format_options = _object_format_options(prog, args.integer_base)
-            print(bpf_map[0].format_(**format_options))
-
-        return
-
     for bpf_prog in bpf_prog_for_each(prog):
         prog_id = bpf_prog.aux.id.value_()
         prog_type_name = bpf_prog.type.format_(type_name=False).split("BPF_PROG_TYPE_")[
@@ -311,9 +360,7 @@ for bpf_map in bpf_map_for_each(prog):
         tag = bpf_prog.tag
         prog_tag = "".join(f"{b.value_():02x}" for b in tag)
 
-        used_maps = []
-        for map in bpf_prog_used_maps(bpf_prog):
-            used_maps.append(map.id.value_())
+        used_maps = [map.id.value_() for map in bpf_prog_used_maps(bpf_prog)]
         used_maps_str = ",".join(str(m) for m in used_maps)
 
         prog_rows.append(
@@ -341,18 +388,10 @@ for bpf_map in bpf_map_for_each(prog):
 
     for bpf_map in bpf_map_for_each(prog):
         map_id = bpf_map.id.value_()
-
         map_type_name = bpf_map.map_type.format_(type_name=False).split(
             "BPF_MAP_TYPE_"
         )[-1]
-
-        # The 'map_flags' field was added in Linux kernel commit 6c9059817432
-        # ("bpf: pre-allocate hash map elements") in version 4.6. Older kernels
-        # may not have this field, so we catch LookupError and default to 0.
-        try:
-            map_flags = f"{bpf_map.map_flags.value_():08x}"
-        except AttributeError:
-            map_flags = "00000000"
+        map_flags = _get_map_flags(bpf_map)
 
         all_map_rows.append(
             (

--- a/tests/linux_kernel/crash_commands/test_bpf.py
+++ b/tests/linux_kernel/crash_commands/test_bpf.py
@@ -225,3 +225,87 @@ class TestBpf(CrashCommandTestCase, BpfTestCase):
         cmd = self.check_crash_command("bpf -m 99999999999999999 -s")
         self.assertIn("invalid BPF map ID", cmd.stdout)
         self.assertNotIn("struct bpf_map", cmd.stdout)
+
+    def test_bpf_all_programs_verbose(self):
+        with contextlib.ExitStack() as exit_stack:
+            prog1_fd = bpf_prog_load(BPF_PROG_TYPE_KPROBE, self.INSNS, b"GPL")
+            exit_stack.callback(os.close, prog1_fd)
+            prog2_fd = bpf_prog_load(BPF_PROG_TYPE_SOCKET_FILTER, self.INSNS, b"GPL")
+            exit_stack.callback(os.close, prog2_fd)
+
+            prog1_id = bpf_prog_get_info_by_fd(prog1_fd).id
+            prog2_id = bpf_prog_get_info_by_fd(prog2_fd).id
+
+            cmd = self.check_crash_command("bpf -P")
+
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)ID\s+.*BPF_PROG_TYPE.*^\s*{prog1_id}\s+.*KPROBE",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)ID\s+.*BPF_PROG_TYPE.*^\s*{prog2_id}\s+.*SOCKET_FILTER",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\s*XLATED:\s*\d+\s+JITED:\s*\d+\s+MEMLOCK:\s*\d+",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\s*LOAD_TIME:\s*((\w+\s+){3}\d{2}:\d{2}:\d{2}\s+\d{4}|\(unknown\))",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\s*GPL_COMPATIBLE:\s*(yes|no)\s+NAME:\s*(\(unused\)|\(unknown\)|\S+)\s+UID:\s*\d+",
+            )
+
+    def test_bpf_all_maps_verbose(self):
+        with contextlib.ExitStack() as exit_stack:
+            map1_fd = bpf_map_create(BPF_MAP_TYPE_HASH, 4, 8, 256)
+            exit_stack.callback(os.close, map1_fd)
+            map2_fd = bpf_map_create(BPF_MAP_TYPE_HASH, 8, 16, 64)
+            exit_stack.callback(os.close, map2_fd)
+
+            map1_id = bpf_map_get_info_by_fd(map1_fd).id
+            map2_id = bpf_map_get_info_by_fd(map2_fd).id
+
+            cmd = self.check_crash_command("bpf -M")
+
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)ID\s+.*BPF_MAP.*^\s*{map1_id}\s+.*HASH\s+",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                rf"(?sm)ID\s+.*BPF_MAP.*^\s*{map2_id}\s+.*HASH\s+",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\s*KEY_SIZE:\s*4\s+VALUE_SIZE:\s*8\s+MAX_ENTRIES:\s*256",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)^\s*KEY_SIZE:\s*8\s+VALUE_SIZE:\s*16\s+MAX_ENTRIES:\s*64",
+            )
+            self.assertRegex(
+                cmd.stdout,
+                r"(?sm)NAME:\s*(\(unused\)|\(unknown\)|\"[^\"]*\")\s+UID:\s*(\d+|\(unknown\)|\(unused\))",
+            )
+
+    def test_bpf_all_progs_and_maps_verbose(self):
+        with contextlib.ExitStack() as exit_stack:
+            map_fd = bpf_map_create(BPF_MAP_TYPE_HASH, 8, 8, 8)
+            exit_stack.callback(os.close, map_fd)
+            prog_fd = bpf_prog_load(BPF_PROG_TYPE_KPROBE, self.INSNS, b"GPL")
+            exit_stack.callback(os.close, prog_fd)
+
+            map_id = bpf_map_get_info_by_fd(map_fd).id
+            prog_id = bpf_prog_get_info_by_fd(prog_fd).id
+
+            cmd = self.check_crash_command("bpf -P -M")
+            self.assertIn("BPF_PROG_TYPE", cmd.stdout)
+            self.assertIn("BPF_MAP_TYPE", cmd.stdout)
+            self.assertIn(f"{prog_id}", cmd.stdout)
+            self.assertIn(f"{map_id}", cmd.stdout)
+            self.assertIn("XLATED:", cmd.stdout)
+            self.assertIn("KEY_SIZE:", cmd.stdout)


### PR DESCRIPTION
Add `-P` and `-M` options to the crash `bpf` command to display verbose information for all loaded BPF programs and maps.

Refactor the existing verbose output into helper functions and add kernel-version compatibility handling for fields which may not exist on older kernels.

Add crash command tests covering verbose program output, verbose map output, and displaying both programs and maps together.