### PR TITLE
libdrgn: use ELF symbol size to complete incomplete array types

### DIFF
--- a/libdrgn/dwarf_info.c
+++ b/libdrgn/dwarf_info.c
@@ -5067,6 +5067,39 @@ absent:
 		drgn_object_set_absent_internal(ret, &type, absence_reason);
 		err = NULL;
 	} else if (bit_offset >= 0) {
+		/*
+		 * If the type is an incomplete array and we have an address,
+		 * try to use the ELF symbol size to create a complete array type.
+		 * This works around compilers that emit incomplete array types
+		 * in DWARF even when the array has a known size in the symbol table.
+		 */
+		if (qualified_type.type &&
+		    drgn_type_kind(qualified_type.type) == DRGN_TYPE_ARRAY &&
+		    !drgn_type_is_complete(qualified_type.type)) {
+			struct drgn_symbol *sym = NULL;
+			err = drgn_program_find_symbol_by_address_internal(prog, address, &sym);
+			if (!err && sym && sym->size > 0) {
+				struct drgn_qualified_type element_type =
+					drgn_type_type(qualified_type.type);
+				uint64_t element_size;
+				err = drgn_type_sizeof(element_type.type, &element_size);
+				if (!err && element_size > 0) {
+					uint64_t length = sym->size / element_size;
+					struct drgn_type *complete_array_type;
+					err = drgn_array_type_create(prog, element_type,
+								     length,
+								     drgn_type_language(qualified_type.type),
+								     &complete_array_type);
+					if (!err) {
+						qualified_type.type = complete_array_type;
+						err = drgn_object_type(qualified_type, 0, &type);
+					}
+				}
+			}
+			drgn_symbol_destroy(sym);
+			if (err)
+				goto out;
+		}
 		err = drgn_object_set_reference_internal(ret, &type, address,
 							 bit_offset);
 	} else if (type.encoding == DRGN_OBJECT_ENCODING_BUFFER) {

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -4849,6 +4849,52 @@ class TestObjects(TestCase):
             ),
         )
 
+    def test_incomplete_array_with_symbol_size(self):
+        prog = dwarf_program(
+            wrap_test_type_dies(
+                *labeled_int_die,
+                DwarfLabel("array_die"),
+                DwarfDie(
+                    DW_TAG.array_type,
+                    (DwarfAttrib(DW_AT.type, DW_FORM.ref4, "int_die"),),
+                ),
+                DwarfDie(
+                    DW_TAG.variable,
+                    (
+                        DwarfAttrib(DW_AT.name, DW_FORM.string, "my_array"),
+                        DwarfAttrib(DW_AT.type, DW_FORM.ref4, "array_die"),
+                        DwarfAttrib(
+                            DW_AT.location,
+                            DW_FORM.exprloc,
+                            b"\x03\x00\x10\x00\x00\xff\xff\xff\xff",
+                        ),
+                    ),
+                ),
+            ),
+            symbols=(
+                ElfSymbol(
+                    name="my_array",
+                    value=0xFFFFFFFF00001000,
+                    size=16,
+                    type=STT.OBJECT,
+                    binding=STB.GLOBAL,
+                    shindex=1,
+                ),
+            ),
+            segments=[
+                MockMemorySegment(b"\x01\x02\x03\x04" * 4, virt_addr=0xFFFFFFFF00001000)
+            ],
+        )
+        self.assertIdentical(
+            prog["my_array"],
+            Object(
+                prog,
+                prog.array_type(prog.int_type("int", 4, True), 4),
+                address=0xFFFFFFFF00001000,
+            ),
+        )
+        self.assertEqual(prog["my_array"].to_bytes_(), b"\x01\x02\x03\x04" * 4)
+
     def test_variable_no_address(self):
         prog = dwarf_program(
             wrap_test_type_dies(


### PR DESCRIPTION
**Problem**:
When using GCC 14 with DWARF 5 (common on RHEL 10 and recent Fedora), variables like linux_banner that are declared as const char array[] show up in the debug information as incomplete arrays, even though the symbol table has the correct size.

This breaks when you try to read the data:
 >>> prog['linux_banner'].to_bytes_()
TypeError: cannot read object with incomplete array type

But the size information is there in the symbol table:
>>> prog.symbol('linux_banner')
Symbol(name='linux_banner', address=0x..., size=0xd3, ...)

**Solution**:
When we create an object from DWARF and find an incomplete array with a known address, we now check the symbol table at that address. If we find a symbol with a size, we calculate how many elements fit (symbol size divided by element size) and create a properly sized array type instead of leaving it incomplete.
The fix only kicks in when all the pieces are there (incomplete array, valid address, matching symbol with size), so it does not affect normal cases.

**Testing**:
Added `test_incomplete_array_with_symbol_size()` which verifies that incomplete arrays are completed using symbol size information.