### PR TITLE
Support setting aarch64_insn_pac_mask at Program initialization

### DIFF
--- a/_drgn.pyi
+++ b/_drgn.pyi
@@ -84,6 +84,7 @@ class Program:
         platform: Optional[Platform] = None,
         *,
         vmcoreinfo: Union[bytes, str, None] = None,
+        aarch64_insn_pac_mask: Optional[int] = None,
     ) -> Self:
         """
         Create a ``Program`` with no target program. It is usually more
@@ -95,6 +96,8 @@ class Program:
         :param vmcoreinfo: Optionally provide the ``VMCOREINFO`` note data for
             Linux kernel core dumps, which will override any detected data. When
             not provided or ``None``, automatically detect the info.
+        :param aarch64_insn_pac_mask: Optionally, provide the pointer
+            authentication bit mask used for aarch64 stack unwinding.
         """
         ...
     flags: ProgramFlags

--- a/libdrgn/drgn.h
+++ b/libdrgn/drgn.h
@@ -959,6 +959,11 @@ const struct drgn_language *drgn_program_language(struct drgn_program *prog);
 void drgn_program_set_language(struct drgn_program *prog,
 			       const struct drgn_language *lang);
 
+/** Set the aarch64 pointer authentication mask of a @ref drgn_program. */
+struct drgn_error *
+drgn_program_set_aarch64_insn_pac_mask(struct drgn_program *prog,
+					uint64_t pac_mask);
+
 /**
  * Read from a program's memory.
  *

--- a/libdrgn/program.c
+++ b/libdrgn/program.c
@@ -970,6 +970,16 @@ struct drgn_error *drgn_program_cache_auxv(struct drgn_program *prog)
 	return NULL;
 }
 
+LIBDRGN_PUBLIC struct drgn_error *
+drgn_program_set_aarch64_insn_pac_mask(struct drgn_program *prog, uint64_t mask)
+{
+	if (prog->aarch64_insn_pac_mask)
+		return drgn_error_create(DRGN_ERROR_INVALID_ARGUMENT,
+					 "pac_mask is already set");
+	prog->aarch64_insn_pac_mask = mask;
+	return NULL;
+}
+
 static struct drgn_error *get_prstatus_pid(struct drgn_program *prog, const char *data,
 					   size_t size, uint32_t *ret)
 {

--- a/libdrgn/python/drgnpy.h
+++ b/libdrgn/python/drgnpy.h
@@ -517,6 +517,7 @@ struct index_arg {
 int index_converter(PyObject *o, void *p);
 
 int u64_converter(PyObject *o, void *p);
+int optional_u64_converter(PyObject *o, void *p);
 
 struct path_arg {
 	bool allow_fd;

--- a/libdrgn/python/program.c
+++ b/libdrgn/python/program.c
@@ -355,13 +355,17 @@ static Program *Program_new_impl(const struct drgn_platform *platform)
 static Program *Program_new(PyTypeObject *subtype, PyObject *args,
 			    PyObject *kwds)
 {
-	static char *keywords[] = { "platform", "vmcoreinfo", NULL };
+	static char *keywords[] = {
+		"platform", "vmcoreinfo", "aarch64_insn_pac_mask", NULL
+	};
 	PyObject *platform_obj = NULL;
 	const char *vmcoreinfo = NULL;
 	Py_ssize_t vmcoreinfo_size;
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O$z#:Program", keywords,
+	uint64_t pac_mask = 0;
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O$z#O&:Program", keywords,
 					 &platform_obj, &vmcoreinfo,
-					 &vmcoreinfo_size))
+					 &vmcoreinfo_size, optional_u64_converter,
+					 &pac_mask))
 		return NULL;
 
 	struct drgn_platform *platform;
@@ -380,6 +384,13 @@ static Program *Program_new(PyTypeObject *subtype, PyObject *args,
 	if (vmcoreinfo) {
 		struct drgn_error *err = drgn_program_parse_vmcoreinfo(
 			&prog->prog, vmcoreinfo, vmcoreinfo_size);
+		if (err)
+			return set_drgn_error(err);
+	}
+	if (pac_mask) {
+		struct drgn_error *err =
+			drgn_program_set_aarch64_insn_pac_mask(
+				&prog->prog, pac_mask);
 		if (err)
 			return set_drgn_error(err);
 	}

--- a/libdrgn/python/util.c
+++ b/libdrgn/python/util.c
@@ -117,6 +117,11 @@ int u64_converter(PyObject *o, void *p)
 	return PyLong_AsUInt64(o, p) == 0;
 }
 
+int optional_u64_converter(PyObject *o, void *p)
+{
+	return o == Py_None || PyLong_AsUInt64(o, p) == 0;
+}
+
 int path_converter(PyObject *o, void *p)
 {
 	if (o == NULL) {


### PR DESCRIPTION
So here's a first pass to allow specifying `aarch64_insn_pac_mask` (#647). It's basically the same as what we did for setting vmcoreinfo, though a bit more straightforward. I tested it with pstack on OL10 aarch64 with PAC, and it works as advertised. I'm putting together an update to contrib/pstack.py which I'll send separately.

Since this was so cheap and easy to write I figured I'd share it to get a conversation started. I acknowledge the API is ugly but it's serviceable, follows an existing pattern, and does what we need. Unless we want to look at some more elaborate way to provide fallback parameter values to the program, I think this would suffice.