### PR TITLE
contrib: Synchronize pstack.py with drgn-tools

### DIFF
--- a/contrib/pstack.py
+++ b/contrib/pstack.py
@@ -1,57 +1,55 @@
-# Copyright (c) 2025, Oracle and/or its affiliates.
+# Copyright (c) 2025, 2026, Oracle and/or its affiliates.
 """
 Tools for creating stack traces of userspace tasks, from the kernel
 
 This script contains tools that enable creating stack traces for userspace
 tasks, when debugging a kernel program. This requires having access to the
-userspace pages, which is not common for core dumps (see makedumpfile's -d
-option), however it is available for /proc/kcore and /proc/vmcore. The script
-contains two approaches:
+userspace pages, which is not common for core dumps, however they are normally
+available for /proc/kcore and /proc/vmcore. If you would like to use this script
+with a core dump file, you must either ensure that makedumpfile's dump-level
+does not exclude userspace pages, or you could make use of the in-development
+"userstack" makedumpfile extensions.
 
-1. By directly creating a Program to represent a process, which reads memory via
-   the kernel Program. This allows directly printing stack traces. This approach
-   works well with /proc/kcore, but in the kexec/kdump environment it may
-   require too much memory, as well as access to the full root filesystem.
-2. By dumping userspace stack memory and some metadata. Later, a second call can
-   read this information and actually create the stack trace. This approach
-   works better in a kexec environment, because the root filesystem is not
-   required, and userspace debuginfo is not consulted.
+It works by creating a second drgn Program to represent a userspace process,
+with a memory reader that just uses the underlying kernel Program to read memory
+from the process address space in the vmcore. It assumes that the root
+filesystem in which it is running is the same one as the vmcore, and so it
+consults the binaries on the filesystem for unwind info.
 
 This script is tested on x86_64 and aarch64, and it's especially suited for
 Fedora and its derivatives, due to their inclusion of ".eh_frame" on runtime
 binaries, as well as ".gnu_debugdata" sections for address to symbol resolution.
 """
 import argparse
-import base64
 import ctypes.util
 import fnmatch
-import gzip
-import json
+import functools
 import logging
 import os
 import struct
 import sys
 import warnings
-from bisect import bisect_left
+from collections import defaultdict
 from functools import lru_cache
-from pathlib import Path
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
 from typing import Union
 
-import drgn
 from drgn import Architecture
 from drgn import FaultError
+from drgn import host_platform
 from drgn import Object
 from drgn import Program
 from drgn import ProgramFlags
 from drgn import sizeof
 from drgn import StackTrace
+from drgn.helpers.common.format import escape_ascii_string
 from drgn.helpers.linux import access_remote_vm
 from drgn.helpers.linux import cpu_curr
 from drgn.helpers.linux import d_path
@@ -61,9 +59,7 @@ from drgn.helpers.linux import for_each_task
 from drgn.helpers.linux import for_each_task_in_group
 from drgn.helpers.linux import for_each_vma
 from drgn.helpers.linux import task_cpu
-from drgn.helpers.linux import task_on_cpu
 from drgn.helpers.linux import task_state_to_char
-from drgn.helpers.linux import vma_find
 
 
 log = logging.getLogger("drgn.pstack")
@@ -91,6 +87,84 @@ class CommaList(argparse.Action):
         for element in value.split(","):
             result.append(self.element_type(element))
         setattr(namespace, self.dest, result)
+
+
+def align(val: int, alignment: int) -> int:
+    align_mask = alignment - 1
+    return (val + align_mask) & ~align_mask
+
+
+def vmcoreinfo_data(prog: Program) -> Dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in prog["VMCOREINFO"]
+        .string_()
+        .decode("utf-8")
+        .strip()
+        .split("\n")
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def drgn_supports_pac_mask() -> bool:
+    try:
+        Program(platform=host_platform, aarch64_insn_pac_mask=1234)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
+def build_id_from_first_bytes(data: bytes) -> Optional[bytes]:
+    """
+    Return the build ID from the first bytes of an ELF file.
+
+    HACK: we only support x86_64 and aarch64, so we're only implementing support
+    for ELF64 little-endian.
+    """
+
+    # Basic sanity check: enough data for ELF header and have a header.
+    if len(data) < 64 or data[:4] != b"\x7fELF":
+        return None
+
+    # Rather than encode the whole struct, let's just get the fields we care
+    # about.
+    e_phoff = struct.unpack_from("=Q", data, 32)[0]
+    e_phentsize = struct.unpack_from("=H", data, 54)[0]
+    e_phnum = struct.unpack_from("=H", data, 56)[0]
+
+    if e_phentsize != 56:
+        return None
+
+    PT_NOTE = 0x4
+    for phoff in range(e_phoff, e_phoff + e_phentsize * e_phnum, e_phentsize):
+        # Hit the end of the data, we couldn't find it.
+        if phoff + e_phentsize > len(data):
+            break
+
+        # Only process PT_NOTE
+        p_type = struct.unpack_from("=I", data, phoff)[0]
+        if p_type != PT_NOTE:
+            continue
+
+        # Process all notes contained within data
+        p_offset = struct.unpack_from("=Q", data, phoff + 8)[0]
+        p_filesz = struct.unpack_from("=Q", data, phoff + 32)[0]
+        noff = p_offset
+        nend = min(len(data), p_offset + p_filesz)
+        while noff + 16 < nend:
+            namesz, descsz, tp = struct.unpack_from("=3I", data, noff)
+            if (
+                namesz == 4
+                and tp == 3
+                and noff + 16 + descsz <= nend
+                and data[noff + 12 : noff + 16] == b"GNU\0"
+            ):
+                # A GNU_BUILD_ID with its full desc present! Return it.
+                return data[noff + 16 : noff + 16 + descsz]
+
+            noff += 12 + align(namesz, 4) + align(descsz, 4)
+    return None
 
 
 def task_saved_pt_regs(task: Object) -> Object:
@@ -262,27 +336,27 @@ def add_task_args(group: argparse.ArgumentParser) -> None:
         "--online",
         "-o",
         action="store_true",
-        help="dump stacks for all on-cpu tasks (not supported for live kernels)",
+        help="print stacks for all on-cpu tasks (not supported for live kernels)",
     )
     group.add_argument(
         "--all",
         "-a",
         action="store_true",
-        help="dump stacks for all PIDs (not recommended)",
+        help="print stacks for all PIDs (not recommended)",
     )
     group.add_argument(
         "--state",
         "-s",
         action=CommaList,
         default=[],
-        help="dump stacks for all tasks in given state (ps(1) 1-letter code)",
+        help="print stacks for all tasks in given state (ps(1) 1-letter code)",
     )
     group.add_argument(
         "--comm",
         "-c",
         action=CommaList,
         default=[],
-        help="dump stacks for all tasks whose command matches this pattern (glob)",
+        help="print stacks for all tasks whose command matches this pattern (glob)",
     )
     group.add_argument(
         "--pid",
@@ -290,299 +364,70 @@ def add_task_args(group: argparse.ArgumentParser) -> None:
         action=CommaList,
         default=[],
         element_type=int,
-        help="dump stack for specific PIDs (may be specified multiple times)",
+        help="print stack for specific PIDs (may be specified multiple times)",
+    )
+    group.add_argument(
+        "--dump-mappings",
+        action="store_true",
+        help="(advanced) dump the file mappings for each user process",
     )
 
 
-def task_dsos(mm: Object) -> List[Tuple[str, int, int, int]]:
+class Dso(NamedTuple):
+    path: str
+    base_addr: int
+    ino: int
+    build_id: Optional[bytes]
+    ranges: List[Tuple[int, int]]
+
+
+def task_dsos(mm: Object) -> List[Dso]:
     """
     Return the mapped DSOs for a task's ``mm_struct``. The return value is a
-    tuple: (path, start, end, ino)
+    tuple: (path, start, ino, build_id, address_ranges)
     """
-    # For the first pass, find any mapping which starts at offset 0 within the
-    # file, and record the full range of the file (even if it's not actually
-    # mapped for its full size). Also, record which file mappings have an
-    # executable VMA, since we'll only care about those.
-    file_range: Dict[str, Tuple[int, int, int]] = {}
-    file_exec = set()
+    # For the first pass, we're getting:
+    # - All mapped ranges for all mapped files.
+    # - The vaddr of the *first* mapping with pgoff == 0 for each file.
+    #   This would be the "base" address of the ELF file.
+    # - The path of each mapped file.
+    file_to_ranges: Dict[int, List[Tuple[int, int]]] = defaultdict(list)
+    file_to_base: Dict[int, int] = {}
+    file_to_path: Dict[int, Tuple[str, int]] = {}
     VM_EXEC = 0x4
     for vma in for_each_vma(mm):
         if not vma.vm_file:
             continue
-        path = os.fsdecode(d_path(vma.vm_file.f_path))
-        if vma.vm_pgoff == 0:
-            file_range[path] = (
-                vma.vm_start.value_(),
-                (vma.vm_start + vma.vm_file.f_inode.i_size).value_(),
-                vma.vm_file.f_inode.i_ino.value_(),
-            )
+        fileaddr = vma.vm_file.value_()
+        file_to_ranges[fileaddr].append((int(vma.vm_start), int(vma.vm_end)))
+        if vma.vm_pgoff == 0 and fileaddr not in file_to_base:
+            file_to_base[fileaddr] = int(vma.vm_start)
         if vma.vm_flags & VM_EXEC:
-            file_exec.add(path)
+            path = os.fsdecode(d_path(vma.vm_file.f_path))
+            ino = int(vma.vm_file.f_inode.i_ino)
+            file_to_path[fileaddr] = (path, ino)
 
-    # For the second pass, ensure there is no overlap between the ranges we
-    # created previously. Since the whole file is not necessarily mapped, we
-    # want to avoid creating overlapping ranges that drgn is not expecting (see
-    # https://github.com/osandov/drgn/issues/574). Once we've ensured there are
-    # no overlaps, and the file had an executable mapping, we can emit it.
-    ranges = sorted(file_range.items(), key=lambda t: t[1][0])
+    # Now synthesize all of that: any file which has an executable mapping, for
+    # which we can identify an ELF base address, should become a DSO.
+    page_size = int(mm.prog_["PAGE_SIZE"])
     result = []
-    for i, (path, (start, end, ino)) in enumerate(ranges):
-        if i + 1 < len(ranges):
-            end = min(end, ranges[i + 1][1][1])
-        if path in file_exec:
-            result.append((path, start, end, ino))
+    for fileaddr, (path, ino) in file_to_path.items():
+        # No mapping with pgoff == 0, continue
+        if fileaddr not in file_to_base:
+            continue
+        # Try to get a build ID. For live systems this is unlikely to fail, but
+        # for vmcores it is. However, vmcores produced with the elfheader
+        # makedumpfile extension will retain the first page of memory of each
+        # mapped ELF file, meaning we still have a shot at this.
+        base = file_to_base[fileaddr]
+        try:
+            build_id = build_id_from_first_bytes(
+                access_remote_vm(mm, base, page_size)
+            )
+        except FaultError:
+            build_id = None
+        result.append(Dso(path, base, ino, build_id, file_to_ranges[fileaddr]))
     return result
-
-
-def task_metadata(prog: Program, task: Object) -> Dict[str, Any]:
-    """Return JSON metadata about a task, for later use."""
-    load_addrs = {}
-    if task.mm:
-        for path, start, end, inode in task_dsos(task.mm):
-            load_addrs[path] = [start, end, inode]
-    return {
-        "pid": task.pid.value_(),
-        "comm": task.comm.string_().decode("utf-8", errors="replace"),
-        "mm": load_addrs,
-        "kernel": not bool(task.mm),
-        "threads": [],
-    }
-
-
-def dump_task(
-    task: Object, outfile: gzip.GzipFile, max_stack_bytes: int = 1048576
-) -> Tuple[int, int, int]:
-    prog = task.prog_
-    metadata = task_metadata(prog, task)
-    page_mask = ~(prog["PAGE_SIZE"] - 1)
-    page_ranges = []
-    threads = 0
-    for thread in for_each_task_in_group(task, include_self=True):
-        tid = thread.pid.value_()
-        tcomm = thread.comm.string_().decode("utf-8", errors="replace")
-        try:
-            kstack = prog.stack_trace(thread)
-        except ValueError:
-            log.warning("skipped running TID %d ('%s')", tid, tcomm)
-            continue
-        kstack_str = str(kstack)
-        cpu = task_cpu(thread)
-        thread_meta = {
-            "tid": tid,
-            "comm": tcomm,
-            "kstack": kstack_str,
-            "cpu": cpu,
-            "on_cpu": cpu_curr(prog, cpu) == thread,
-            "state": task_state_to_char(thread),
-        }
-
-        # Kernel threads can still be included even though the value of this
-        # tool is getting userspace stacks. Just skip the user registers and
-        # stack.
-        if not task.mm:
-            metadata["threads"].append(thread_meta)
-            continue
-
-        # Add user registers to metadata.
-        if len(kstack) > 0 and (kstack[0].pc & (1 << 63)):
-            # CPU was running in kernel mode, get the saved registers
-            regs = task_saved_pt_regs(thread)
-        else:
-            # CPU was in user mode. Drgn won't make be able to unwind
-            # it, but we can take the top frame and get the original
-            # registers for unwinding.
-            regs = task_running_pt_regs(kstack)
-            kstack_str = "<running in user mode>"
-        thread_meta["regs"] = base64.b64encode(regs.to_bytes_()).decode()
-        metadata["threads"].append(thread_meta)
-
-        # Now get the stack memory range to dump.  Three big assumptions here:
-        # (1) the stack grows down, (2) there is no stack switching going on,
-        # and (3) the stack is in its own VMA.  These are usually true, but not
-        # always.
-        vma = vma_find(task.mm, regs.sp)
-        if not vma:
-            log.warning(
-                "could not find VMA for SP (%x) in TID %d ('%s')",
-                regs.sp.value_(),
-                tid,
-                tcomm,
-            )
-            continue
-        start = (regs.sp & page_mask).value_()
-        end = vma.vm_end.value_()
-        page_ranges.append((start, end))
-        threads += 1
-
-    write_json_object(metadata, outfile)
-
-    page_ranges.sort()
-    prev_end = 0
-    pgsize = prog["PAGE_SIZE"].value_()
-    max_stack_bytes = max_stack_bytes & page_mask
-    pages_written = pages_faulted = 0
-    for start, end in page_ranges:
-        # There's no guarantee that we have a reasonable stack size. Apply a
-        # limit here to avoid dumping excess data.
-        end = min(end, start + max_stack_bytes)
-
-        # It's possible (though unlikely) that the ranges overlap. Avoid
-        # re-writing the same pages multiple times.
-        start = max(prev_end, start)
-        prev_end = end
-        for pgaddr in range(start, end, pgsize):
-            try:
-                data = access_remote_vm(task.mm, pgaddr, pgsize)
-            except FaultError:
-                pages_faulted += 1
-                continue
-            outfile.write(struct.pack("=Q", pgaddr))
-            outfile.write(data)
-            pages_written += 1
-    log.info(
-        "PID %d: wrote %d pages (%.1f MiB), faulted on %d pages",
-        task.pid.value_(),
-        pages_written,
-        pages_written * pgsize / (1024 * 1024),
-        pages_faulted,
-    )
-
-    outfile.write(b"\xff" * 8)
-    return threads, pages_written, pages_faulted
-
-
-def write_json_object(obj: Dict[str, Any], outfile: gzip.GzipFile) -> None:
-    encoded_data = json.dumps(obj).encode("utf-8")
-    outfile.write(struct.pack("=Q", len(encoded_data)))
-    outfile.write(encoded_data)
-
-
-def dump_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "output",
-        help="store stack dumps in the given file",
-    )
-    parser.add_argument(
-        "--max-stack-bytes",
-        type=int,
-        default=(1024 * 1024),
-        help="max stack bytes to dump for any thread (default 1MiB)",
-    )
-    add_task_args(parser)
-
-
-def dump(prog: Program, args: argparse.Namespace) -> None:
-    """
-    Write stack information to a compressed binary file.
-
-    The binary format is based on simple blocks of data which are prefixed by an
-    8-byte little-endian field which contains either a length, or an address.
-    The following blocks are defined and must occur in order.
-
-      - magic header: "pstack" followed by a NUL byte, and a one byte version
-      - global metadata: 8-byte length followed by JSON object. The object
-        contains "page_size" field, and maybe others. The next block MUST be a
-        task metadata.
-      - task metadata: 8-byte length followed by JSON object. The object
-        represents all tasks sharing the same mm, or for kthreads, a single task
-        struct. The object contains an array of threads. The task metadata is
-        immediately followed by zero or more stack memory blocks, and then an
-        "end of memory" marker.
-      - stack memory block: 8-byte field containing a page-aligned address, and
-        then one page of data.
-      - end of memory block: an 8-byte field containing the signal value
-        0xFFFFFFFFFFFFFFFF. The end-of-memory block may be followed by an
-        additional task metadata, or the end of file.
-    """
-    magic = b"pstack\x00\x01"
-    file = Path(args.output)
-    tasks = threads_written = 0
-    pages_written = pages_faulted = 0
-    with gzip.open(file, "wb") as f:
-        f.write(magic)
-
-        metadata = {
-            "page_size": prog["PAGE_SIZE"].value_(),
-        }
-        write_json_object(metadata, f)
-
-        for task in get_tasks(prog, args):
-            threads, written, faulted = dump_task(
-                task, f, max_stack_bytes=args.max_stack_bytes
-            )
-            threads_written += threads
-            pages_written += written
-            pages_faulted += faulted
-            tasks += 1
-
-    print(
-        "Dumped {} tasks ({} threads) with {} pages of stack ({:.1f} MiB) -- that's {:.1f} KiB per thread. Skipped {} faulted pages.".format(
-            tasks,
-            threads_written,
-            pages_written,
-            (pages_written * prog["PAGE_SIZE"].value_()) / (1024 * 1024),
-            (pages_written * prog["PAGE_SIZE"].value_())
-            / (1024)
-            / threads_written,
-            pages_faulted,
-        )
-    )
-
-
-def build_prog_from_dump(
-    data: List[Tuple[int, bytes]], metadata: Dict[str, Any], page_size: int
-) -> Program:
-    prog = Program(drgn.host_platform)
-    data.sort()
-
-    def read_fn(_, count, offset, __):
-        # This may be a bit overkill given that the average single-threaded task
-        # only has a few stack pages to speak of. But I can't justify using a
-        # linear search when binary search will do better.
-        page = offset & ~(page_size - 1)
-        # bisect_left gained a "key" kwarg, but in Python 3.10, oh well...
-        index = bisect_left(data, (page, b""))
-        output = bytearray()
-        while len(output) < count:
-            if index >= len(data) or data[index][0] != page:
-                raise FaultError("memory not present", page)
-            pgoff = (offset + len(output)) & (page_size - 1)
-            pgend = min(page_size, pgoff + count - len(output))
-            output += data[index][1][pgoff:pgend]
-
-            # Move to the next page, which is hopefully present if we have more
-            # to read.
-            page += page_size
-            index += 1
-        return output
-
-    prog.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, read_fn, False)
-
-    pid = metadata["pid"]
-    for name, (start, end, ino) in metadata["mm"].items():
-        path = Path(name)
-        inode = None
-        try:
-            if path.exists():
-                inode = path.stat().st_ino
-            else:
-                log.warning("For PID %d, could not find file %s", pid, name)
-                continue
-        except OSError as e:
-            log.warning(
-                "For PID %d, could not access file %s (%r)", pid, name, e
-            )
-            continue
-        if inode is not None and inode != ino:
-            log.warning(
-                "For PID %d, file %s inode does not match, file may be updated",
-                pid,
-                name,
-            )
-        mod = prog.extra_module(name=name, create=True)
-        mod.address_range = (start, end)
-        mod.try_file(name, force=True)
-    return prog
 
 
 @lru_cache(maxsize=1)
@@ -641,13 +486,26 @@ def demangle(mangled: str) -> str:
         return mangled
 
 
-def print_user_stack_trace(regs: Object) -> None:
+def print_user_stack_trace(
+    regs: Object, pac_mask: Optional[int] = None
+) -> None:
     """
     Prints the userspace stack trace for regs, with the module name included
     for each frame. Including the module name is pretty important for userspace.
     """
     prog = regs.prog_
     trace = prog.stack_trace(regs)
+    if pac_mask and not drgn_supports_pac_mask():
+        # Fallback for when setting pac_mask is not supported:
+        pcs = []
+        for frame in trace:
+            try:
+                pcs.append(frame.pc & ~pac_mask)
+            except LookupError:
+                # Sometimes stack frames have unknown PCs. These are usually at
+                # the end or beginning of the trace. Skip them.
+                continue
+        trace = prog.stack_trace_from_pcs(pcs)
     print("    ------ userspace ---------")
     for i, frame in enumerate(trace):
         name = demangle(frame.name)
@@ -662,7 +520,7 @@ def print_user_stack_trace(regs: Object) -> None:
         mod_text = ""
         try:
             mod = prog.module(frame.pc)
-            off = frame.pc - mod.address_range[0]
+            off = frame.pc - mod.id
             mod_text = f" (from {mod.name} +0x{off:x})"
         except LookupError:
             pass
@@ -677,120 +535,108 @@ def print_user_stack_trace(regs: Object) -> None:
         print(f"    #{i:<2d} {name}{offset}{source_text}{mod_text}")
 
 
-def dump_print_process(
-    fp: gzip.GzipFile, meta: Dict[str, Any], page_size: int
-) -> None:
-    """Print traces for a dumped process"""
-    pid = meta["pid"]
-    data = []
-    end = b"\xff" * 8
-    while True:
-        header = fp.read(8)
-        if header == end:
-            break
-        addr = struct.unpack("=Q", header)[0]
-        data.append((addr, fp.read(page_size)))
-
-    comm = meta["comm"]
-    print(f"[PID: {pid} COMM: {comm}]")
-
-    # Special-case for kernel threads, so we don't build a fake program
-    if meta["kernel"]:
-        for thread in meta["threads"]:
-            print("  " + thread["kstack"].replace("\n", "\n  "))
-        return
-    prog = build_prog_from_dump(data, meta, page_size)
-    for i, t in enumerate(meta["threads"]):
-        tid = t["tid"]
-        tcomm = t["comm"]
-        st = t["state"]
-        cpu = t["cpu"]
-        cpunote = "RUNNING ON " if t["on_cpu"] else ""
-        print(f"  Thread {i} TID={tid} [{st}] {cpunote}CPU={cpu} ('{tcomm}')")
-        print("    " + t["kstack"].replace("\n", "\n    "))
-        regs = make_fake_pt_regs(prog, base64.b64decode(t["regs"]))
-        print_user_stack_trace(regs)
-
-
-def read_json_object(fp: gzip.GzipFile) -> Dict[str, Any]:
-    header = fp.read(8)
-    if len(header) != 8:
-        raise EOFError("end of file")
-    length = struct.unpack("=Q", header)[0]
-    return json.loads(fp.read(length))
-
-
-def dump_print(d: str):
-    with gzip.open(d, "rb") as f:
-        try:
-            magic = f.read(8)
-        except OSError:
-            sys.exit(f"error: {args.file} doesn't exist or is not a gzip file")
-        if magic != b"pstack\x00\x01":
-            sys.exit("error: unrecognized file format")
-
-        metadata = read_json_object(f)
-        pgsize = metadata["page_size"]
-
-        while True:
-            try:
-                task_meta = read_json_object(f)
-            except EOFError:
-                break
-            dump_print_process(f, task_meta, pgsize)
-            print()
-
-
-def build_prog_from_mm(mm: Object) -> Program:
+def build_prog_from_mm(mm: Object, pac_mask: Optional[int]) -> Program:
     """
     Create a Program representing a userspace task in the kernel Program
 
     :param mm: the ``struct mm_struct`` for the process
+    :param mm: the aarch64 PAC mask, if present
     :returns: a Program which can be debugged like a userspace process
     """
     prog = mm.prog_
-    up = Program(prog.platform)
+    if pac_mask and drgn_supports_pac_mask():
+        up = Program(prog.platform, aarch64_insn_pac_mask=pac_mask)
+    else:
+        up = Program(prog.platform)
 
     def read_fn(_, count, offset, __):
         return access_remote_vm(mm, offset, count)
 
     up.add_memory_segment(0, 0xFFFFFFFFFFFFFFFF, read_fn, False)
 
-    for path, start, end, ino in task_dsos(mm):
-        try:
-            statbuf = os.stat(path)
-            if statbuf.st_ino != ino:
-                log.warning(
-                    "file %s doesn't match the inode on-disk, it may"
-                    " have been updated",
-                    path,
-                )
-        except OSError:
-            pass
-        mod = up.extra_module(path, create=True)
-        mod.address_range = (start, end)
-        mod.try_file(path)
+    page_size = int(mm.prog_["PAGE_SIZE"])
+    for dso in task_dsos(mm):
+        # Create the file with id=start, so that later on we can use the ID for
+        # the base address of the module.
+        mod = up.extra_module(dso.path, id=dso.base_addr, create=True)
+
+        # If the first page of the ELF file is available, either due to use of
+        # elfheader makedumpfile extension or because it's paged-in on a live
+        # machine, we can usually get the build ID and use that to validate that
+        # we have the correct ELF file! Drgn will transparently reject files
+        # that don't match.
+        if dso.build_id:
+            mod.build_id = dso.build_id
+        else:
+            # If we don't have the build ID, a fallback approach is to use the
+            # inode number. The inode number frequently changes when a file is
+            # updated, but it's not a guarantee or a 100% accurate signal, so
+            # just warn based on it.
+            try:
+                statbuf = os.stat(dso.path)
+                if statbuf.st_ino != dso.ino:
+                    log.warning(
+                        "file %s doesn't match the inode on-disk, it may"
+                        " have been updated",
+                        dso.path,
+                    )
+            except OSError:
+                # Assume it's okay and soldier on
+                pass
+
+        # First, set a single address range. Use the true base address, and make
+        # it just one page so we can guarantee it won't overlap anything. The
+        # purpose here is to communicate to drgn the ELF file bias which it will
+        # determine in try_file().
+        mod.address_range = (dso.base_addr, dso.base_addr + page_size)
+        mod.try_file(dso.path)
+
+        # Now that we have set the file, provide the true ranges to drgn, so
+        # that it can map memory addresses to the correct DSO.
+        mod.address_ranges = dso.ranges
 
     return up
 
 
-def pstack_print_process(task: Object) -> None:
-    comm = task.comm.string_().decode("utf-8", errors="replace")
+def debug_dump_mappings(prog: Program) -> None:
+    for mod in prog.modules():
+        if mod.build_id:
+            build_id = mod.build_id.hex()
+        else:
+            build_id = "?" * 40
+        print(f"{build_id} {mod.name}")
+        id_ = getattr(mod, "id", 0)
+
+        for s, e in sorted(mod.address_ranges):
+            base_mark = "  (file base)" if s == id_ else ""
+            print(f"  {s:16x}--{e:16x}{base_mark}")
+    print()
+
+
+def pstack_print_process(
+    task: Object,
+    dump_mappings: bool = False,
+    pac_mask: Optional[int] = None,
+) -> None:
+    comm = escape_ascii_string(task.comm.string_())
     print(f"[PID: {task.pid.value_()} COMM: {comm}]")
     prog = task.prog_
     if not task.mm:
         print("  " + str(prog.stack_trace(task)).replace("\n", "\n  "))
         return
 
-    user_prog = build_prog_from_mm(task.mm)
+    user_prog = build_prog_from_mm(task.mm, pac_mask=pac_mask)
+    if dump_mappings:
+        debug_dump_mappings(user_prog)
+
     for i, thread in enumerate(
         for_each_task_in_group(task, include_self=True)
     ):
         tid = thread.pid.value_()
-        tcomm = thread.comm.string_().decode("utf-8", errors="replace")
+        tcomm = escape_ascii_string(thread.comm.string_())
         st = task_state_to_char(thread)
         cpu = task_cpu(thread)
-        on_cpu = task_on_cpu(thread)
+        on_cpu = cpu_curr(prog, cpu) == thread
         cpunote = "RUNNING ON " if on_cpu else ""
         print(f"  Thread {i} TID={tid} [{st}] {cpunote}CPU={cpu} ('{tcomm}')")
         try:
@@ -812,37 +658,57 @@ def pstack_print_process(task: Object) -> None:
             print("    <running in user mode>")
             regs = task_running_pt_regs(kstack)
         fake_regs = make_fake_pt_regs(user_prog, regs.to_bytes_())
-        print_user_stack_trace(fake_regs)
+        print_user_stack_trace(fake_regs, pac_mask)
+
+
+def aarch64_user_pac_mask(prog: Program) -> Optional[int]:
+    """
+    Return the pointer mask to remove pointer authentication bits from userspace
+    return addresses, so that that drgn can recognize the memory addresses. When
+    PAC is present, our approach is to have drgn unwind the stack, then mask the
+    bits for each PC, and then create a new stack trace from those masked PCs.
+
+    This is a bit of a hack: it only works if frame pointers are used, because
+    drgn needs to unwind the stack with PAC unmasked, which means that it cannot
+    refer to any .eh_frame data. In practice, this is not really a problem on
+    aarch64 in Oracle Linux but to be more general, it would be best to
+    generalize drgn's PAC support so custom programs can specify the mask.
+    """
+    if prog.platform.arch != Architecture.AARCH64:
+        return None
+    vmci = vmcoreinfo_data(prog)
+    kernel_pac_mask = int(vmci.get("NUMBER(KERNELPACMASK)", "0"), 16)
+    if kernel_pac_mask != 0:
+        vabits_actual = 64 - int(vmci["NUMBER(TCR_EL1_T1SZ)"], 16)
+        # GENMASK(54, vabits_actual)
+        return (1 << 55) - (1 << vabits_actual)
+    return None
 
 
 def pstack(prog: Program) -> None:
     parser = argparse.ArgumentParser(description="print stack traces")
     add_task_args(parser)
-    args = parser.parse_args(sys.argv[2:])
+    args = parser.parse_args()
     if args.online and prog.flags & ProgramFlags.IS_LIVE:
         sys.exit("error: --online: cannot unwind running tasks on live system")
+    errs = 0
+    pac_mask = aarch64_user_pac_mask(prog)
     for task in get_tasks(prog, args):
-        pstack_print_process(task)
+        try:
+            pstack_print_process(
+                task,
+                dump_mappings=args.dump_mappings,
+                pac_mask=pac_mask,
+            )
+        except Exception as e:
+            errs += 1
+            print(f"error: {str(e)}")
         print()
+    if errs > 0:
+        print(f"NOTE: encountered {errs} error{'s' if errs > 1 else ''}")
 
 
 if __name__ == "__main__":
     logging.basicConfig()
     prog: Program
-    if len(sys.argv) <= 1 or sys.argv[1] not in ("dump", "print", "pstack"):
-        sys.exit(
-            f"usage: drgn [args...] {sys.argv} [dump | print | pstack] ..."
-        )
-    elif sys.argv[1] == "dump":
-        parser = argparse.ArgumentParser(description="dump stacks")
-        dump_args(parser)
-        dump(prog, parser.parse_args(sys.argv[2:]))  # noqa
-    elif sys.argv[1] == "print":
-        parser = argparse.ArgumentParser(
-            description="print traces for dumped stacks"
-        )
-        parser.add_argument("file", type=Path, help="compressed")
-        args = parser.parse_args(sys.argv[2:])
-        dump_print(args.file)
-    elif sys.argv[1] == "pstack":
-        pstack(prog)  # noqa
+    pstack(prog)  # noqa


### PR DESCRIPTION
The pstack script in drgn-tools has seen some development, and I don't want to let the contrib version in drgn get out of date. This pulls those changes in all in one commit (sorry). To summarize the changes:

(1) The "dump" and "dump-print" modes are removed. These were intended
    to run within the dump capture kernel. However, thanks to the
    progress on the makedumpfile userstack & elfheader extensions,
    makedumpfile will be able to include the necessary data into vmcores
    directly, without trying to run drgn there.

(2) Since I now expect/hope that this will be used with both the
    userstack *and* elfheader extensions, I've added build-id detection
    using the first page of each executable. For now, this is just used
    to take advantage of drgn's build ID validation when trying files.
    But in the future I plan to use it to automatically grab
    debuginfo (or just runtime files) from RPMs so that stack traces can
    be done using a vmcore on a totally different system.

(3) Similar to the issue described in #645, the pstack.py script created
    address ranges based on the minimum and maximum file mapping,
    resulting in the same overlap error on aarch64, so this contains a
    similar fix for that issue.

(4) As mentioned in #647, aarch64's PAC breaks stack unwinding, and
    there's no way to set the mask for custom programs. This commit
    includes a fallback to manually strip PAC, as well as an
    implementation that will work with #649.

(5) Add a diagnostic flag to dump the address ranges of the userspace
    programs as we print their stack traces.